### PR TITLE
Eliminate inversion problems during estimation

### DIFF
--- a/eagleye_core/src/heading_interpolate.cpp
+++ b/eagleye_core/src/heading_interpolate.cpp
@@ -193,6 +193,7 @@ void imu_callback(const sensor_msgs::Imu::ConstPtr& msg)
     }
   }
 
+  /*
   // angle reversal processing (-3.14~3.14)
   if (provisional_heading_angle > M_PI)
   {
@@ -202,6 +203,7 @@ void imu_callback(const sensor_msgs::Imu::ConstPtr& msg)
   {
     provisional_heading_angle = provisional_heading_angle + 2.0 * M_PI;
   }
+  */
 
   if (heading_estimate_start_status == true)
   {

--- a/eagleye_core/src/yawrate_offset.cpp
+++ b/eagleye_core/src/yawrate_offset.cpp
@@ -205,11 +205,13 @@ void imu_callback(const sensor_msgs::Imu::ConstPtr& msg)
       std::vector<double> inversion_up_index;
       std::vector<double> inversion_down_index;
 
+      /*
       for (i = 0; i < estimated_number; i++)
       {
         base_heading_angle_buffer.push_back(heading_angle_buffer[index[index_length-1]] - provisional_heading_angle_buffer[index[index_length-1]] + provisional_heading_angle_buffer[i]);
       }
 
+　　　　
       for (i = 0; i < index_length; i++)
       {
         diff_buffer.push_back(base_heading_angle_buffer[index[i]] - heading_angle_buffer[index[i]]);
@@ -245,16 +247,17 @@ void imu_callback(const sensor_msgs::Imu::ConstPtr& msg)
           heading_angle_buffer[inversion_down_index[i]] = heading_angle_buffer[inversion_down_index[i]] - 2.0 * M_PI;
         }
       }
+      */
 
       index_length = std::distance(index.begin(), index.end());
 
-      base_heading_angle_buffer.clear();
+      //base_heading_angle_buffer.clear();
       for (i = 0; i < estimated_number; i++)
       {
         base_heading_angle_buffer.push_back(heading_angle_buffer[index[index_length-1]] - provisional_heading_angle_buffer[index[index_length-1]] + provisional_heading_angle_buffer[i]);
       }
 
-      diff_buffer.clear();
+      //diff_buffer.clear();
       for (i = 0; i < index_length; i++)
       {
         // diff_buffer.push_back(base_heading_angle_buffer[index[i]] - heading_angle_buffer[index[i]]);


### PR DESCRIPTION
Fixed bug when estimating yaw rate offset

By eliminating the inversion process when estimating the azimuth angle, the effect of the inversion was eliminated in the yaw rate offset estimation.

Note:  Definition of the final output domein is undefined