### PR TITLE
fix reverse_imu bug in trajectory

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,8 +208,8 @@ To visualize the eagleye output location /eagleye/fix, for example, use the foll
 
 | No. | Date | Place | Sensors | Link |
 |-----|------|-------|---------| ---- |
-|1|2020/01/27|Moriyama, Nagoya<br>[route](https://www.google.com/maps/d/edit?mid=1pK4BgrGtoo14nguArDf-rZDqIL5Cg-v5&usp=sharing)|GNSS: Ublox F9P<br>IMU: Tamagawa AU7684<br>LiDAR: Velodyne HDL-32E|[Download](https://www.dropbox.com/sh/ks5kg8033f5n3w8/AADv9plEjXnwlxex23Z91kR_a?dl=0)|
-|2|2020/07/15|Moriyama, Nagoya<br>[route](https://www.google.com/maps/d/edit?mid=1DnXfZBTSsHpWlzTAcENmFxo17r3PxGxM&usp=sharing)|GNSS: Ublox F9P with RTK<br>IMU: Tamagawa AU7684<br>LiDAR: Velodyne VLP-32C|[Download](https://www.dropbox.com/sh/mhdib1m1oivotiu/AAD0UnANDsuIsKqcSKHt9WAJa?dl=0)
+|1|2020/01/27|Moriyama, Nagoya<br>[route](https://www.google.com/maps/d/edit?mid=1pK4BgrGtoo14nguArDf-rZDqIL5Cg-v5&usp=sharing)|GNSS: Ublox F9P<br>IMU: Tamagawa AU7684<br>LiDAR: Velodyne HDL-32E|[Download](https://www.dropbox.com/s/pfs307qn7gfeou5/eagleye_sample_20200127.bag?dl=0)|
+|2|2020/07/15|Moriyama, Nagoya<br>[route](https://www.google.com/maps/d/edit?mid=1DnXfZBTSsHpWlzTAcENmFxo17r3PxGxM&usp=sharing)|GNSS: Ublox F9P with RTK<br>IMU: Tamagawa AU7684<br>LiDAR: Velodyne VLP-32C|[Download](https://www.dropbox.com/s/w9ag6gs17bi80st/eagleye_sample_20200715.bag?dl=0)
 
 ### Maps
 The 3D maps (point cloud and vector data) of the route is also available from [Autoware sample data](https://drive.google.com/file/d/1Uwp9vwvcZwaoZi4kdjJaY55-LEXIzSxf/view).

--- a/eagleye_core/navigation/src/trajectory.cpp
+++ b/eagleye_core/navigation/src/trajectory.cpp
@@ -49,11 +49,11 @@ void trajectory_estimate(const sensor_msgs::Imu imu, const eagleye_msgs::Velocit
   {
     if (std::abs(velocity_scale_factor.correction_velocity.linear.x) > trajectory_parameter.stop_judgment_velocity_threshold  && yawrate_offset_2nd.status.enabled_status == true)
     {
-      eagleye_twist->twist.angular.z = -1 * (-1 * (imu.angular_velocity.z + yawrate_offset_2nd.yawrate_offset)); //Inverted because the coordinate system is reversed
+      eagleye_twist->twist.angular.z = -1 * (-1 * imu.angular_velocity.z + yawrate_offset_2nd.yawrate_offset); //Inverted because the coordinate system is reversed
     }
     else
     {
-      eagleye_twist->twist.angular.z = -1 * (-1 * (imu.angular_velocity.z + yawrate_offset_stop.yawrate_offset)); //Inverted because the coordinate system is reversed
+      eagleye_twist->twist.angular.z = -1 * (-1 * imu.angular_velocity.z + yawrate_offset_stop.yawrate_offset); //Inverted because the coordinate system is reversed
     }
   }
   eagleye_twist->twist.linear.x = velocity_scale_factor.correction_velocity.linear.x;
@@ -120,11 +120,11 @@ void trajectory3d_estimate(const sensor_msgs::Imu imu, const eagleye_msgs::Veloc
   {
     if (std::abs(velocity_scale_factor.correction_velocity.linear.x) > trajectory_parameter.stop_judgment_velocity_threshold  && yawrate_offset_2nd.status.enabled_status == true)
     {
-      eagleye_twist->twist.angular.z = -1 * (-1 * (imu.angular_velocity.z + yawrate_offset_2nd.yawrate_offset)); //Inverted because the coordinate system is reversed
+      eagleye_twist->twist.angular.z = -1 * (-1 * imu.angular_velocity.z + yawrate_offset_2nd.yawrate_offset); //Inverted because the coordinate system is reversed
     }
     else
     {
-      eagleye_twist->twist.angular.z = -1 * (-1 * (imu.angular_velocity.z + yawrate_offset_stop.yawrate_offset)); //Inverted because the coordinate system is reversed
+      eagleye_twist->twist.angular.z = -1 * (-1 * imu.angular_velocity.z + yawrate_offset_stop.yawrate_offset); //Inverted because the coordinate system is reversed
     }
   }
   eagleye_twist->twist.linear.x = velocity_scale_factor.correction_velocity.linear.x;


### PR DESCRIPTION
Problem solved when `reverse_imu` is set to `true`.

Previously, the model would add IMU errors if set to `true`. 
The model has been modified to cancel out the error.