### PR TITLE
Feature/illegal value diag

### DIFF
--- a/eagleye_core/navigation/include/navigation/navigation.hpp
+++ b/eagleye_core/navigation/include/navigation/navigation.hpp
@@ -466,28 +466,55 @@ struct RollingStatus
   bool data_status;
 };
 
-extern void velocity_scale_factor_estimate(const rtklib_msgs::RtklibNav, const geometry_msgs::TwistStamped, const VelocityScaleFactorParameter, VelocityScaleFactorStatus*, eagleye_msgs::VelocityScaleFactor*);
-extern void velocity_scale_factor_estimate(const nmea_msgs::Gprmc, const geometry_msgs::TwistStamped, const VelocityScaleFactorParameter, VelocityScaleFactorStatus*, eagleye_msgs::VelocityScaleFactor*);
+extern void velocity_scale_factor_estimate(const rtklib_msgs::RtklibNav, const geometry_msgs::TwistStamped, const VelocityScaleFactorParameter,
+  VelocityScaleFactorStatus*, eagleye_msgs::VelocityScaleFactor*);
+extern void velocity_scale_factor_estimate(const nmea_msgs::Gprmc, const geometry_msgs::TwistStamped, const VelocityScaleFactorParameter,
+  VelocityScaleFactorStatus*, eagleye_msgs::VelocityScaleFactor*);
 extern void distance_estimate(const eagleye_msgs::VelocityScaleFactor, DistanceStatus*,eagleye_msgs::Distance*);
-extern void yawrate_offset_stop_estimate(const geometry_msgs::TwistStamped, const sensor_msgs::Imu, const YawrateOffsetStopParameter, YawrateOffsetStopStatus*, eagleye_msgs::YawrateOffset*);
-extern void yawrate_offset_estimate(const eagleye_msgs::VelocityScaleFactor, const eagleye_msgs::YawrateOffset,const eagleye_msgs::Heading,const sensor_msgs::Imu, const YawrateOffsetParameter, YawrateOffsetStatus*, eagleye_msgs::YawrateOffset*);
-extern void heading_estimate(const rtklib_msgs::RtklibNav, const sensor_msgs::Imu, const eagleye_msgs::VelocityScaleFactor, const eagleye_msgs::YawrateOffset, const eagleye_msgs::YawrateOffset,  const eagleye_msgs::SlipAngle, const eagleye_msgs::Heading, const HeadingParameter, HeadingStatus*,eagleye_msgs::Heading*);
-extern void heading_estimate(const nmea_msgs::Gprmc, const sensor_msgs::Imu, const eagleye_msgs::VelocityScaleFactor, const eagleye_msgs::YawrateOffset, const eagleye_msgs::YawrateOffset,  const eagleye_msgs::SlipAngle, const eagleye_msgs::Heading, const HeadingParameter, HeadingStatus*,eagleye_msgs::Heading*);
-extern void position_estimate(const rtklib_msgs::RtklibNav, const eagleye_msgs::VelocityScaleFactor, const eagleye_msgs::Distance, const eagleye_msgs::Heading, const geometry_msgs::Vector3Stamped, const PositionParameter, PositionStatus*, eagleye_msgs::Position*);
-extern void position_estimate(const nmea_msgs::Gpgga gga, const eagleye_msgs::VelocityScaleFactor, const eagleye_msgs::Distance, const eagleye_msgs::Heading, const geometry_msgs::Vector3Stamped, const PositionParameter, PositionStatus*, eagleye_msgs::Position*);
-extern void slip_angle_estimate(const sensor_msgs::Imu,const eagleye_msgs::VelocityScaleFactor,const eagleye_msgs::YawrateOffset,const eagleye_msgs::YawrateOffset,const SlipangleParameter,eagleye_msgs::SlipAngle*);
-extern void slip_coefficient_estimate(const sensor_msgs::Imu,const rtklib_msgs::RtklibNav,const eagleye_msgs::VelocityScaleFactor,const eagleye_msgs::YawrateOffset,const eagleye_msgs::YawrateOffset,const eagleye_msgs::Heading,const SlipCoefficientParameter,SlipCoefficientStatus*,double*);
-extern void smoothing_estimate(const rtklib_msgs::RtklibNav,const eagleye_msgs::VelocityScaleFactor,const SmoothingParameter,SmoothingStatus*,eagleye_msgs::Position*);
-extern void trajectory_estimate(const sensor_msgs::Imu,const eagleye_msgs::VelocityScaleFactor,const eagleye_msgs::Heading,const eagleye_msgs::YawrateOffset,const eagleye_msgs::YawrateOffset,const TrajectoryParameter,TrajectoryStatus*,geometry_msgs::Vector3Stamped*,eagleye_msgs::Position*,geometry_msgs::TwistStamped*);
-extern void heading_interpolate_estimate(const sensor_msgs::Imu,const eagleye_msgs::VelocityScaleFactor,const eagleye_msgs::YawrateOffset,const eagleye_msgs::YawrateOffset,const eagleye_msgs::Heading,const eagleye_msgs::SlipAngle,const HeadingInterpolateParameter,HeadingInterpolateStatus*,eagleye_msgs::Heading*);
-extern void position_interpolate_estimate(const eagleye_msgs::Position,const geometry_msgs::Vector3Stamped,const eagleye_msgs::Position,const eagleye_msgs::Height,const PositionInterpolateParameter,PositionInterpolateStatus*,eagleye_msgs::Position*,sensor_msgs::NavSatFix*);
-extern void pitching_estimate(const sensor_msgs::Imu,const nmea_msgs::Gpgga,const eagleye_msgs::VelocityScaleFactor,const eagleye_msgs::Distance,const HeightParameter,HeightStatus*,eagleye_msgs::Height*,eagleye_msgs::Pitching*,eagleye_msgs::AccXOffset*,eagleye_msgs::AccXScaleFactor*);
-extern void trajectory3d_estimate(const sensor_msgs::Imu,const eagleye_msgs::VelocityScaleFactor,const eagleye_msgs::Heading,const eagleye_msgs::YawrateOffset,const eagleye_msgs::YawrateOffset,const eagleye_msgs::Pitching,const TrajectoryParameter,TrajectoryStatus*,geometry_msgs::Vector3Stamped*,eagleye_msgs::Position*,geometry_msgs::TwistStamped*);
-extern void angular_velocity_offset_stop_estimate(const geometry_msgs::TwistStamped, const sensor_msgs::Imu, const AngularVelocityOffsetStopParameter, AngularVelocityOffsetStopStatus*, eagleye_msgs::AngularVelocityOffset*);
-extern void rtk_deadreckoning_estimate(const rtklib_msgs::RtklibNav,const geometry_msgs::Vector3Stamped,const nmea_msgs::Gpgga, const eagleye_msgs::Heading,const RtkDeadreckoningParameter,RtkDeadreckoningStatus*,eagleye_msgs::Position*,sensor_msgs::NavSatFix*);
-extern void rtk_deadreckoning_estimate(const geometry_msgs::Vector3Stamped,const nmea_msgs::Gpgga, const eagleye_msgs::Heading,const RtkDeadreckoningParameter,RtkDeadreckoningStatus*,eagleye_msgs::Position*,sensor_msgs::NavSatFix*);
-extern void rtk_heading_estimate(const nmea_msgs::Gpgga gga, const sensor_msgs::Imu, const eagleye_msgs::VelocityScaleFactor, const eagleye_msgs::Distance,const eagleye_msgs::YawrateOffset, const eagleye_msgs::YawrateOffset,  const eagleye_msgs::SlipAngle, const eagleye_msgs::Heading, const RtkHeadingParameter, RtkHeadingStatus*,eagleye_msgs::Heading*);
-extern void enable_additional_rolling_estimate(const eagleye_msgs::VelocityScaleFactor,const eagleye_msgs::YawrateOffset ,const eagleye_msgs::YawrateOffset,const eagleye_msgs::Distance,const sensor_msgs::Imu,const geometry_msgs::PoseStamped,const eagleye_msgs::AngularVelocityOffset,const EnableAdditionalRollingParameter,EnableAdditionalRollingStatus*,eagleye_msgs::Rolling*,eagleye_msgs::AccYOffset*);
-extern void rolling_estimate(const sensor_msgs::Imu,const eagleye_msgs::VelocityScaleFactor,const eagleye_msgs::YawrateOffset ,const eagleye_msgs::YawrateOffset,const RollingParameter,RollingStatus*,eagleye_msgs::Rolling*);
+extern void yawrate_offset_stop_estimate(const geometry_msgs::TwistStamped, const sensor_msgs::Imu, const YawrateOffsetStopParameter,
+  YawrateOffsetStopStatus*, eagleye_msgs::YawrateOffset*);
+extern void yawrate_offset_estimate(const eagleye_msgs::VelocityScaleFactor, const eagleye_msgs::YawrateOffset,const eagleye_msgs::Heading,
+  const sensor_msgs::Imu, const YawrateOffsetParameter, YawrateOffsetStatus*, eagleye_msgs::YawrateOffset*);
+extern void heading_estimate(const rtklib_msgs::RtklibNav, const sensor_msgs::Imu, const eagleye_msgs::VelocityScaleFactor,
+  const eagleye_msgs::YawrateOffset, const eagleye_msgs::YawrateOffset,  const eagleye_msgs::SlipAngle, const eagleye_msgs::Heading, const HeadingParameter,
+  HeadingStatus*,eagleye_msgs::Heading*);
+extern void heading_estimate(const nmea_msgs::Gprmc, const sensor_msgs::Imu, const eagleye_msgs::VelocityScaleFactor, const eagleye_msgs::YawrateOffset,
+  const eagleye_msgs::YawrateOffset,  const eagleye_msgs::SlipAngle, const eagleye_msgs::Heading, const HeadingParameter, HeadingStatus*,eagleye_msgs::Heading*);
+extern void position_estimate(const rtklib_msgs::RtklibNav, const eagleye_msgs::VelocityScaleFactor, const eagleye_msgs::Distance,
+  const eagleye_msgs::Heading, const geometry_msgs::Vector3Stamped, const PositionParameter, PositionStatus*, eagleye_msgs::Position*);
+extern void position_estimate(const nmea_msgs::Gpgga gga, const eagleye_msgs::VelocityScaleFactor, const eagleye_msgs::Distance, const eagleye_msgs::Heading,
+  const geometry_msgs::Vector3Stamped, const PositionParameter, PositionStatus*, eagleye_msgs::Position*);
+extern void slip_angle_estimate(const sensor_msgs::Imu,const eagleye_msgs::VelocityScaleFactor,const eagleye_msgs::YawrateOffset,
+  const eagleye_msgs::YawrateOffset,const SlipangleParameter,eagleye_msgs::SlipAngle*);
+extern void slip_coefficient_estimate(const sensor_msgs::Imu,const rtklib_msgs::RtklibNav,const eagleye_msgs::VelocityScaleFactor,
+  const eagleye_msgs::YawrateOffset,const eagleye_msgs::YawrateOffset,const eagleye_msgs::Heading,const SlipCoefficientParameter,SlipCoefficientStatus*,double*);
+extern void smoothing_estimate(const rtklib_msgs::RtklibNav,const eagleye_msgs::VelocityScaleFactor,const SmoothingParameter,SmoothingStatus*,
+  eagleye_msgs::Position*);
+extern void trajectory_estimate(const sensor_msgs::Imu,const eagleye_msgs::VelocityScaleFactor,const eagleye_msgs::Heading,const eagleye_msgs::YawrateOffset,
+  const eagleye_msgs::YawrateOffset,const TrajectoryParameter,TrajectoryStatus*,geometry_msgs::Vector3Stamped*,eagleye_msgs::Position*,
+  geometry_msgs::TwistStamped*);
+extern void heading_interpolate_estimate(const sensor_msgs::Imu,const eagleye_msgs::VelocityScaleFactor,const eagleye_msgs::YawrateOffset,
+  const eagleye_msgs::YawrateOffset,const eagleye_msgs::Heading,const eagleye_msgs::SlipAngle,const HeadingInterpolateParameter,HeadingInterpolateStatus*,
+  eagleye_msgs::Heading*);
+extern void position_interpolate_estimate(const eagleye_msgs::Position,const geometry_msgs::Vector3Stamped,const eagleye_msgs::Position,
+  const eagleye_msgs::Height,const PositionInterpolateParameter,PositionInterpolateStatus*,eagleye_msgs::Position*,sensor_msgs::NavSatFix*);
+extern void pitching_estimate(const sensor_msgs::Imu,const nmea_msgs::Gpgga,const eagleye_msgs::VelocityScaleFactor,const eagleye_msgs::Distance,
+  const HeightParameter,HeightStatus*,eagleye_msgs::Height*,eagleye_msgs::Pitching*,eagleye_msgs::AccXOffset*,eagleye_msgs::AccXScaleFactor*);
+extern void trajectory3d_estimate(const sensor_msgs::Imu,const eagleye_msgs::VelocityScaleFactor,const eagleye_msgs::Heading,
+  const eagleye_msgs::YawrateOffset,const eagleye_msgs::YawrateOffset,const eagleye_msgs::Pitching,const TrajectoryParameter,TrajectoryStatus*,geometry_msgs::Vector3Stamped*,eagleye_msgs::Position*,geometry_msgs::TwistStamped*);
+extern void angular_velocity_offset_stop_estimate(const geometry_msgs::TwistStamped, const sensor_msgs::Imu, const AngularVelocityOffsetStopParameter,
+  AngularVelocityOffsetStopStatus*, eagleye_msgs::AngularVelocityOffset*);
+extern void rtk_deadreckoning_estimate(const rtklib_msgs::RtklibNav,const geometry_msgs::Vector3Stamped,const nmea_msgs::Gpgga, const eagleye_msgs::Heading,
+  const RtkDeadreckoningParameter,RtkDeadreckoningStatus*,eagleye_msgs::Position*,sensor_msgs::NavSatFix*);
+extern void rtk_deadreckoning_estimate(const geometry_msgs::Vector3Stamped,const nmea_msgs::Gpgga, const eagleye_msgs::Heading,
+  const RtkDeadreckoningParameter,RtkDeadreckoningStatus*,eagleye_msgs::Position*,sensor_msgs::NavSatFix*);
+extern void rtk_heading_estimate(const nmea_msgs::Gpgga gga, const sensor_msgs::Imu, const eagleye_msgs::VelocityScaleFactor, const eagleye_msgs::Distance,
+  const eagleye_msgs::YawrateOffset, const eagleye_msgs::YawrateOffset,  const eagleye_msgs::SlipAngle, const eagleye_msgs::Heading, const RtkHeadingParameter,
+  RtkHeadingStatus*,eagleye_msgs::Heading*);
+extern void enable_additional_rolling_estimate(const eagleye_msgs::VelocityScaleFactor,const eagleye_msgs::YawrateOffset ,const eagleye_msgs::YawrateOffset,
+  const eagleye_msgs::Distance,const sensor_msgs::Imu,const geometry_msgs::PoseStamped,const eagleye_msgs::AngularVelocityOffset,
+  const EnableAdditionalRollingParameter,EnableAdditionalRollingStatus*,eagleye_msgs::Rolling*,eagleye_msgs::AccYOffset*);
+extern void rolling_estimate(const sensor_msgs::Imu,const eagleye_msgs::VelocityScaleFactor,const eagleye_msgs::YawrateOffset,
+  const eagleye_msgs::YawrateOffset,const RollingParameter,RollingStatus*,eagleye_msgs::Rolling*);
 
 #endif /*NAVIGATION_H */

--- a/eagleye_core/navigation/src/angular_velocity_offset_stop.cpp
+++ b/eagleye_core/navigation/src/angular_velocity_offset_stop.cpp
@@ -31,7 +31,9 @@
  #include "coordinate/coordinate.hpp"
  #include "navigation/navigation.hpp"
 
-void angular_velocity_offset_stop_estimate(const geometry_msgs::TwistStamped velocity, const sensor_msgs::Imu imu, const AngularVelocityOffsetStopParameter angular_velocity_stop_parameter, AngularVelocityOffsetStopStatus* angular_velocity_stop_status, eagleye_msgs::AngularVelocityOffset* angular_velocity_offset_stop)
+void angular_velocity_offset_stop_estimate(const geometry_msgs::TwistStamped velocity, const sensor_msgs::Imu imu,
+  const AngularVelocityOffsetStopParameter angular_velocity_stop_parameter, AngularVelocityOffsetStopStatus* angular_velocity_stop_status,
+  eagleye_msgs::AngularVelocityOffset* angular_velocity_offset_stop)
 {
 
   int i;
@@ -58,7 +60,8 @@ void angular_velocity_offset_stop_estimate(const geometry_msgs::TwistStamped vel
       angular_velocity_stop_status->yawrate_buffer.push_back(-1 * imu.angular_velocity.z);
     }
   }
-  else if ( std::fabs(std::fabs(angular_velocity_stop_status->yawrate_offset_stop_last) - std::fabs(imu.angular_velocity.z)) < angular_velocity_stop_parameter.outlier_threshold && angular_velocity_stop_status->estimate_start_status == true)
+  else if ( std::fabs(std::fabs(angular_velocity_stop_status->yawrate_offset_stop_last) - std::fabs(imu.angular_velocity.z)) <
+    angular_velocity_stop_parameter.outlier_threshold && angular_velocity_stop_status->estimate_start_status == true)
   {
     if (angular_velocity_stop_parameter.reverse_imu == false)
     {

--- a/eagleye_core/navigation/src/distance.cpp
+++ b/eagleye_core/navigation/src/distance.cpp
@@ -35,7 +35,8 @@ void distance_estimate(const eagleye_msgs::VelocityScaleFactor velocity_scale_fa
 {
   if(distance_status->time_last != 0)
   {
-    distance->distance = distance->distance + velocity_scale_factor.correction_velocity.linear.x * std::abs((velocity_scale_factor.header.stamp.toSec() - distance_status->time_last));
+    distance->distance = distance->distance + velocity_scale_factor.correction_velocity.linear.x * std::abs((velocity_scale_factor.header.stamp.toSec() -
+      distance_status->time_last));
     distance->status.enabled_status = distance->status.estimate_status = true;
     distance_status->time_last = velocity_scale_factor.header.stamp.toSec();
   }

--- a/eagleye_core/navigation/src/enable_additional_rolling.cpp
+++ b/eagleye_core/navigation/src/enable_additional_rolling.cpp
@@ -33,7 +33,11 @@
 
 #define g 9.80665
 
-void enable_additional_rolling_estimate(const eagleye_msgs::VelocityScaleFactor velocity_scale_factor,const eagleye_msgs::YawrateOffset yawrate_offset_2nd,const eagleye_msgs::YawrateOffset yawrate_offset_stop,const eagleye_msgs::Distance distance,const sensor_msgs::Imu imu,const geometry_msgs::PoseStamped localization_pose,const eagleye_msgs::AngularVelocityOffset angular_velocity_offset_stop,const EnableAdditionalRollingParameter rolling_parameter,EnableAdditionalRollingStatus* rolling_status,eagleye_msgs::Rolling* rolling_angle,eagleye_msgs::AccYOffset* acc_y_offset)
+void enable_additional_rolling_estimate(const eagleye_msgs::VelocityScaleFactor velocity_scale_factor,const eagleye_msgs::YawrateOffset yawrate_offset_2nd,
+  const eagleye_msgs::YawrateOffset yawrate_offset_stop,const eagleye_msgs::Distance distance,const sensor_msgs::Imu imu,
+  const geometry_msgs::PoseStamped localization_pose,const eagleye_msgs::AngularVelocityOffset angular_velocity_offset_stop,
+  const EnableAdditionalRollingParameter rolling_parameter,EnableAdditionalRollingStatus* rolling_status,eagleye_msgs::Rolling* rolling_angle,
+  eagleye_msgs::AccYOffset* acc_y_offset)
 {
   bool acc_offset_status = false;
   bool rolling_buffer_status = false;
@@ -130,7 +134,8 @@ void enable_additional_rolling_estimate(const eagleye_msgs::VelocityScaleFactor 
           quaternionMsgToTF(localization_pose.pose.orientation, localization_quat);
           tf::Matrix3x3(localization_quat).getRPY(additional_angle[0], additional_angle[1], additional_angle[2]);
 
-          acc_y_offset_tmp = -1*(rolling_status->velocity_buffer[i]*(rolling_status->yawrate_buffer[i]+rolling_status->yawrate_offset_buffer[i])-rolling_status->acceleration_y_buffer[i]-g*std::sin(additional_angle[0]));
+          acc_y_offset_tmp = -1*(rolling_status->velocity_buffer[i]*(rolling_status->yawrate_buffer[i]+rolling_status->yawrate_offset_buffer[i])-
+            rolling_status->acceleration_y_buffer[i]-g*std::sin(additional_angle[0]));
           rolling_status->acc_offset_sum = rolling_status->acc_offset_sum + acc_y_offset_tmp;
           rolling_status->acc_offset_data_count ++;
           acc_y_offset->acc_y_offset = rolling_status->acc_offset_sum/rolling_status->acc_offset_data_count;
@@ -156,11 +161,13 @@ void enable_additional_rolling_estimate(const eagleye_msgs::VelocityScaleFactor 
   {
     if (velocity_scale_factor.correction_velocity.linear.x > rolling_parameter.stop_judgment_velocity_threshold)
     {
-      rolling_estimated_tmp = std::asin((velocity_scale_factor.correction_velocity.linear.x*(rolling_status->yawrate+yawrate_offset_2nd.yawrate_offset)/g)-(rolling_status->imu_acceleration_y-acc_y_offset->acc_y_offset)/g);
+      rolling_estimated_tmp = std::asin((velocity_scale_factor.correction_velocity.linear.x*(rolling_status->yawrate+yawrate_offset_2nd.yawrate_offset)/g)-
+        (rolling_status->imu_acceleration_y-acc_y_offset->acc_y_offset)/g);
     }
     else
     {
-      rolling_estimated_tmp = std::asin((velocity_scale_factor.correction_velocity.linear.x*(rolling_status->yawrate+yawrate_offset_stop.yawrate_offset)/g)-(rolling_status->imu_acceleration_y-acc_y_offset->acc_y_offset)/g);
+      rolling_estimated_tmp = std::asin((velocity_scale_factor.correction_velocity.linear.x*(rolling_status->yawrate+yawrate_offset_stop.yawrate_offset)/g)-
+        (rolling_status->imu_acceleration_y-acc_y_offset->acc_y_offset)/g);
     }
   }
 

--- a/eagleye_core/navigation/src/heading.cpp
+++ b/eagleye_core/navigation/src/heading.cpp
@@ -31,7 +31,9 @@
 #include "coordinate/coordinate.hpp"
 #include "navigation/navigation.hpp"
 
-void heading_estimate_(sensor_msgs::Imu imu,eagleye_msgs::VelocityScaleFactor velocity_scale_factor,eagleye_msgs::YawrateOffset yawrate_offset_stop,eagleye_msgs::YawrateOffset yawrate_offset,eagleye_msgs::SlipAngle slip_angle,eagleye_msgs::Heading heading_interpolate,HeadingParameter heading_parameter, HeadingStatus* heading_status,eagleye_msgs::Heading* heading)
+void heading_estimate_(sensor_msgs::Imu imu,eagleye_msgs::VelocityScaleFactor velocity_scale_factor,eagleye_msgs::YawrateOffset yawrate_offset_stop,
+  eagleye_msgs::YawrateOffset yawrate_offset,eagleye_msgs::SlipAngle slip_angle,eagleye_msgs::Heading heading_interpolate,HeadingParameter heading_parameter,
+  HeadingStatus* heading_status,eagleye_msgs::Heading* heading)
 {
   int i,index_max;
   double yawrate = 0.0; 
@@ -87,7 +89,10 @@ void heading_estimate_(sensor_msgs::Imu imu,eagleye_msgs::VelocityScaleFactor ve
   std::vector<int> velocity_index;
   std::vector<int> index;
 
-  if (heading_status->estimated_number  > heading_parameter.estimated_number_min && heading_status->gnss_status_buffer [heading_status->estimated_number -1] == true && heading_status->correction_velocity_buffer [heading_status->estimated_number -1] > heading_parameter.estimated_velocity_threshold && fabsf(heading_status->yawrate_buffer [heading_status->estimated_number -1]) < heading_parameter.estimated_yawrate_threshold)
+  if (heading_status->estimated_number  > heading_parameter.estimated_number_min &&
+    heading_status->gnss_status_buffer [heading_status->estimated_number -1] == true &&
+    heading_status->correction_velocity_buffer [heading_status->estimated_number -1] > heading_parameter.estimated_velocity_threshold &&
+    fabsf(heading_status->yawrate_buffer [heading_status->estimated_number -1]) < heading_parameter.estimated_yawrate_threshold)
   {
     heading->status.enabled_status = true;
   }
@@ -125,11 +130,15 @@ void heading_estimate_(sensor_msgs::Imu imu,eagleye_msgs::VelocityScaleFactor ve
         {
           if (std::abs(heading_status->correction_velocity_buffer [heading_status->estimated_number -1]) > heading_parameter.stop_judgment_velocity_threshold)
           {
-            provisional_heading_angle_buffer[i] = provisional_heading_angle_buffer[i-1] + ((heading_status->yawrate_buffer [i] + heading_status->yawrate_offset_buffer [i]) * (heading_status->time_buffer [i] - heading_status->time_buffer [i-1]));
+            provisional_heading_angle_buffer[i] = provisional_heading_angle_buffer[i-1] +
+              ((heading_status->yawrate_buffer [i] + heading_status->yawrate_offset_buffer [i]) *
+              (heading_status->time_buffer [i] - heading_status->time_buffer [i-1]));
           }
           else
           {
-            provisional_heading_angle_buffer[i] = provisional_heading_angle_buffer[i-1] + ((heading_status->yawrate_buffer [i] + heading_status->yawrate_offset_stop_buffer [i]) * (heading_status->time_buffer [i] - heading_status->time_buffer [i-1]));
+            provisional_heading_angle_buffer[i] = provisional_heading_angle_buffer[i-1] +
+              ((heading_status->yawrate_buffer [i] + heading_status->yawrate_offset_stop_buffer [i]) *
+              (heading_status->time_buffer [i] - heading_status->time_buffer [i-1]));
           }
         }
       }
@@ -152,7 +161,8 @@ void heading_estimate_(sensor_msgs::Imu imu,eagleye_msgs::VelocityScaleFactor ve
 
       for (i = 0; i < heading_status->estimated_number ; i++)
       {
-        base_heading_angle_buffer.push_back(heading_interpolate.heading_angle - provisional_heading_angle_buffer[index[index_length-1]] + provisional_heading_angle_buffer[i]);
+        base_heading_angle_buffer.push_back(heading_interpolate.heading_angle - provisional_heading_angle_buffer[index[index_length-1]] +
+          provisional_heading_angle_buffer[i]);
       }
 
       for (i = 0; i < index_length; i++)
@@ -169,7 +179,8 @@ void heading_estimate_(sensor_msgs::Imu imu,eagleye_msgs::VelocityScaleFactor ve
         base_heading_angle_buffer.clear();
         for (i = 0; i < heading_status->estimated_number ; i++)
         {
-          base_heading_angle_buffer.push_back(heading_angle_buffer2[index[index_length-1]] - provisional_heading_angle_buffer[index[index_length-1]] + provisional_heading_angle_buffer[i]);
+          base_heading_angle_buffer.push_back(heading_angle_buffer2[index[index_length-1]] - provisional_heading_angle_buffer[index[index_length-1]] +
+            provisional_heading_angle_buffer[i]);
         }
 
         diff_buffer.clear();
@@ -184,7 +195,8 @@ void heading_estimate_(sensor_msgs::Imu imu,eagleye_msgs::VelocityScaleFactor ve
         base_heading_angle_buffer2.clear();
         for (i = 0; i < heading_status->estimated_number ; i++)
         {
-          base_heading_angle_buffer2.push_back(tmp_heading_angle - provisional_heading_angle_buffer[index[index_length-1]] + provisional_heading_angle_buffer[i]);
+          base_heading_angle_buffer2.push_back(tmp_heading_angle - provisional_heading_angle_buffer[index[index_length-1]] +
+            provisional_heading_angle_buffer[i]);
         }
 
         diff_buffer.clear();
@@ -221,7 +233,8 @@ void heading_estimate_(sensor_msgs::Imu imu,eagleye_msgs::VelocityScaleFactor ve
         }
         else
         {
-          heading->heading_angle = tmp_heading_angle + (provisional_heading_angle_buffer[heading_status->estimated_number -1] - provisional_heading_angle_buffer[index[index_length-1]]);
+          heading->heading_angle = tmp_heading_angle + (provisional_heading_angle_buffer[heading_status->estimated_number -1] -
+            provisional_heading_angle_buffer[index[index_length-1]]);
         }
         heading->status.estimate_status = true;
       }
@@ -229,7 +242,9 @@ void heading_estimate_(sensor_msgs::Imu imu,eagleye_msgs::VelocityScaleFactor ve
   }
 }
 
-void heading_estimate(rtklib_msgs::RtklibNav rtklib_nav,sensor_msgs::Imu imu,eagleye_msgs::VelocityScaleFactor velocity_scale_factor,eagleye_msgs::YawrateOffset yawrate_offset_stop,eagleye_msgs::YawrateOffset yawrate_offset,eagleye_msgs::SlipAngle slip_angle,eagleye_msgs::Heading heading_interpolate,HeadingParameter heading_parameter, HeadingStatus* heading_status,eagleye_msgs::Heading* heading)
+void heading_estimate(rtklib_msgs::RtklibNav rtklib_nav,sensor_msgs::Imu imu,eagleye_msgs::VelocityScaleFactor velocity_scale_factor,
+  eagleye_msgs::YawrateOffset yawrate_offset_stop,eagleye_msgs::YawrateOffset yawrate_offset,eagleye_msgs::SlipAngle slip_angle,
+  eagleye_msgs::Heading heading_interpolate,HeadingParameter heading_parameter, HeadingStatus* heading_status,eagleye_msgs::Heading* heading)
 {
   double ecef_vel[3];
   double ecef_pos[3];
@@ -283,7 +298,9 @@ void heading_estimate(rtklib_msgs::RtklibNav rtklib_nav,sensor_msgs::Imu imu,eag
   heading_estimate_(imu,velocity_scale_factor,yawrate_offset_stop,yawrate_offset,slip_angle,heading_interpolate,heading_parameter,heading_status,heading);
 }
 
-void heading_estimate(const nmea_msgs::Gprmc nmea_rmc,sensor_msgs::Imu imu,eagleye_msgs::VelocityScaleFactor velocity_scale_factor,eagleye_msgs::YawrateOffset yawrate_offset_stop,eagleye_msgs::YawrateOffset yawrate_offset,eagleye_msgs::SlipAngle slip_angle,eagleye_msgs::Heading heading_interpolate,HeadingParameter heading_parameter, HeadingStatus* heading_status,eagleye_msgs::Heading* heading)
+void heading_estimate(const nmea_msgs::Gprmc nmea_rmc,sensor_msgs::Imu imu,eagleye_msgs::VelocityScaleFactor velocity_scale_factor,
+  eagleye_msgs::YawrateOffset yawrate_offset_stop,eagleye_msgs::YawrateOffset yawrate_offset,eagleye_msgs::SlipAngle slip_angle,
+  eagleye_msgs::Heading heading_interpolate,HeadingParameter heading_parameter, HeadingStatus* heading_status,eagleye_msgs::Heading* heading)
 {
   bool gnss_status;
   double doppler_heading_angle = 0.0;

--- a/eagleye_core/navigation/src/heading_interpolate.cpp
+++ b/eagleye_core/navigation/src/heading_interpolate.cpp
@@ -31,7 +31,10 @@
 #include "coordinate/coordinate.hpp"
 #include "navigation/navigation.hpp"
 
-void heading_interpolate_estimate(const sensor_msgs::Imu imu, const eagleye_msgs::VelocityScaleFactor velocity_scale_factor, const eagleye_msgs::YawrateOffset yawrate_offset_stop,const eagleye_msgs::YawrateOffset yawrate_offset,const eagleye_msgs::Heading heading,const eagleye_msgs::SlipAngle slip_angle,const HeadingInterpolateParameter heading_interpolate_parameter, HeadingInterpolateStatus* heading_interpolate_status,eagleye_msgs::Heading* heading_interpolate)
+void heading_interpolate_estimate(const sensor_msgs::Imu imu, const eagleye_msgs::VelocityScaleFactor velocity_scale_factor,
+  const eagleye_msgs::YawrateOffset yawrate_offset_stop,const eagleye_msgs::YawrateOffset yawrate_offset,const eagleye_msgs::Heading heading,
+  const eagleye_msgs::SlipAngle slip_angle,const HeadingInterpolateParameter heading_interpolate_parameter, HeadingInterpolateStatus* heading_interpolate_status,
+  eagleye_msgs::Heading* heading_interpolate)
 {
   int i;
   int estimate_index = 0;
@@ -78,9 +81,11 @@ void heading_interpolate_estimate(const sensor_msgs::Imu imu, const eagleye_msgs
     heading_estimate_status = false;
   }
 
-  if(heading_interpolate_status->time_last != 0 && std::abs(velocity_scale_factor.correction_velocity.linear.x) > heading_interpolate_parameter.stop_judgment_velocity_threshold)
+  if(heading_interpolate_status->time_last != 0 && std::abs(velocity_scale_factor.correction_velocity.linear.x) >
+    heading_interpolate_parameter.stop_judgment_velocity_threshold)
   {
-    heading_interpolate_status->provisional_heading_angle = heading_interpolate_status->provisional_heading_angle + (yawrate * (imu.header.stamp.toSec() - heading_interpolate_status->time_last));
+    heading_interpolate_status->provisional_heading_angle = heading_interpolate_status->provisional_heading_angle +
+      (yawrate * (imu.header.stamp.toSec() - heading_interpolate_status->time_last));
   }
 
   // data buffer generate
@@ -107,14 +112,17 @@ void heading_interpolate_estimate(const sensor_msgs::Imu imu, const eagleye_msgs
       }
     }
 
-    if (heading_estimate_status == true && estimate_index > 0 && heading_interpolate_status->number_buffer >= estimate_index && heading_interpolate_status->heading_estimate_status_count > 1)
+    if (heading_estimate_status == true && estimate_index > 0 && heading_interpolate_status->number_buffer >= estimate_index &&
+      heading_interpolate_status->heading_estimate_status_count > 1)
     {
       diff_estimate_heading_angle = (heading_interpolate_status->provisional_heading_angle_buffer[estimate_index-1] - heading.heading_angle);
       for (i = estimate_index; i <= heading_interpolate_status->number_buffer; i++)
       {
-        heading_interpolate_status->provisional_heading_angle_buffer[i-1] = heading_interpolate_status->provisional_heading_angle_buffer[i-1] - diff_estimate_heading_angle;
+        heading_interpolate_status->provisional_heading_angle_buffer[i-1] = heading_interpolate_status->provisional_heading_angle_buffer[i-1] -
+          diff_estimate_heading_angle;
       }
-      heading_interpolate_status->provisional_heading_angle = heading_interpolate_status->provisional_heading_angle_buffer[heading_interpolate_status->number_buffer-1];
+      heading_interpolate_status->provisional_heading_angle =
+        heading_interpolate_status->provisional_heading_angle_buffer[heading_interpolate_status->number_buffer-1];
 
       heading_interpolate->status.enabled_status = true;
       heading_interpolate->status.estimate_status = true;

--- a/eagleye_core/navigation/src/height.cpp
+++ b/eagleye_core/navigation/src/height.cpp
@@ -87,8 +87,10 @@ void pitching_estimate(const sensor_msgs::Imu imu,const nmea_msgs::Gpgga gga,con
 ///  relative_height  ///
   if (velocity_scale_factor.correction_velocity.linear.x > 0 && height_status->time_last != 0)
   {
-    height_status->relative_height_G += imu.linear_acceleration.x * velocity_scale_factor.correction_velocity.linear.x*(imu.header.stamp.toSec()-height_status->time_last)/g;
-    height_status->relative_height_diffvel += - (velocity_scale_factor.correction_velocity.linear.x-height_status->correction_velocity_x_last) * velocity_scale_factor.correction_velocity.linear.x/g;
+    height_status->relative_height_G += imu.linear_acceleration.x * velocity_scale_factor.correction_velocity.linear.x*
+      (imu.header.stamp.toSec()-height_status->time_last)/g;
+    height_status->relative_height_diffvel += - (velocity_scale_factor.correction_velocity.linear.x-height_status->correction_velocity_x_last) *
+      velocity_scale_factor.correction_velocity.linear.x/g;
     height_status->relative_height_offset += velocity_scale_factor.correction_velocity.linear.x*(imu.header.stamp.toSec()-height_status->time_last)/g;
     correction_relative_height = height_status->relative_height_G + height_status->relative_height_offset + height_status->relative_height_diffvel;
   }
@@ -173,7 +175,8 @@ void pitching_estimate(const sensor_msgs::Imu imu,const nmea_msgs::Gpgga gga,con
       for (i = 0; i < height_status->data_number; i++)
       {
         diff_height = height_status->height_buffer[i] - height_status->height_buffer[0];
-        diff_relative_height = (height_status->relative_height_G_buffer[i] + height_status->relative_height_diffvel_buffer[i])- (height_status->relative_height_G_buffer[0] + height_status->relative_height_diffvel_buffer[0]);
+        diff_relative_height = (height_status->relative_height_G_buffer[i] + height_status->relative_height_diffvel_buffer[i])-
+          (height_status->relative_height_G_buffer[0] + height_status->relative_height_diffvel_buffer[0]);
         diff_relative_height_offset = height_status->relative_height_offset_buffer[i] - height_status->relative_height_offset_buffer[0];
         A += diff_relative_height_offset * diff_relative_height_offset;
         B += 2 * diff_relative_height_offset * (diff_height - diff_relative_height);
@@ -188,14 +191,16 @@ void pitching_estimate(const sensor_msgs::Imu imu,const nmea_msgs::Gpgga gga,con
 
     for (i = 0; i < height_status->data_number; i++)
     {
-      height_status->correction_relative_height_buffer[i] = height_status->acceleration_SF_linear_x_last * height_status->relative_height_G_buffer[i] + height_status->relative_height_diffvel_buffer[i] + height_status->acceleration_offset_linear_x_last * height_status->relative_height_offset_buffer[i];
+      height_status->correction_relative_height_buffer[i] = height_status->acceleration_SF_linear_x_last * height_status->relative_height_G_buffer[i] +
+        height_status->relative_height_diffvel_buffer[i] + height_status->acceleration_offset_linear_x_last * height_status->relative_height_offset_buffer[i];
     }
   }
 
 ///  height estimate  ///
   if (height_status->estimate_start_status == true)
   {
-    if (distance.distance > height_parameter.estimated_distance && gnss_status == true && gps_quality ==4 && data_status == true && velocity_scale_factor.correction_velocity.linear.x > height_parameter.estimated_velocity_threshold )
+    if (distance.distance > height_parameter.estimated_distance && gnss_status == true && gps_quality ==4 && data_status == true &&
+      velocity_scale_factor.correction_velocity.linear.x > height_parameter.estimated_velocity_threshold )
     {
       height_status->correction_relative_height_buffer2.clear();
       height_status->height_buffer2.clear();
@@ -367,7 +372,8 @@ void pitching_estimate(const sensor_msgs::Imu imu,const nmea_msgs::Gpgga gga,con
 
 ///  pitch  ///
   correction_acceleration_linear_x = imu.linear_acceleration.x * height_status->acceleration_SF_linear_x_last + height_status->acceleration_offset_linear_x_last;
-  height_status->acc_buffer.push_back((correction_acceleration_linear_x -(velocity_scale_factor.correction_velocity.linear.x-height_status->correction_velocity_x_last)/(imu.header.stamp.toSec()-height_status->time_last)));
+  height_status->acc_buffer.push_back((correction_acceleration_linear_x -
+    (velocity_scale_factor.correction_velocity.linear.x-height_status->correction_velocity_x_last)/(imu.header.stamp.toSec()-height_status->time_last)));
   data_num_acc = height_status->acc_buffer.size();
 
   if (data_num_acc > height_parameter.average_num)

--- a/eagleye_core/navigation/src/position.cpp
+++ b/eagleye_core/navigation/src/position.cpp
@@ -31,7 +31,9 @@
 #include "coordinate/coordinate.hpp"
 #include "navigation/navigation.hpp"
 
-void position_estimate_(eagleye_msgs::VelocityScaleFactor velocity_scale_factor,eagleye_msgs::Distance distance,eagleye_msgs::Heading heading_interpolate_3rd,geometry_msgs::Vector3Stamped enu_vel,PositionParameter position_parameter, PositionStatus* position_status, eagleye_msgs::Position* enu_absolute_pos)
+void position_estimate_(eagleye_msgs::VelocityScaleFactor velocity_scale_factor,eagleye_msgs::Distance distance,
+  eagleye_msgs::Heading heading_interpolate_3rd,geometry_msgs::Vector3Stamped enu_vel,PositionParameter position_parameter,
+  PositionStatus* position_status, eagleye_msgs::Position* enu_absolute_pos)
 {
   int i;
   int estimated_number_max = position_parameter.estimated_distance/position_parameter.separation_distance;
@@ -70,8 +72,10 @@ void position_estimate_(eagleye_msgs::VelocityScaleFactor velocity_scale_factor,
     transform.setRotation(q);
 
     tf::Transform transform2;
-    tf::Quaternion q2(position_parameter.tf_gnss_rotation_x,position_parameter.tf_gnss_rotation_y,position_parameter.tf_gnss_rotation_z,position_parameter.tf_gnss_rotation_w);
-    transform2.setOrigin(transform*tf::Vector3(-position_parameter.tf_gnss_translation_x, -position_parameter.tf_gnss_translation_y, -position_parameter.tf_gnss_translation_z));
+    tf::Quaternion q2(position_parameter.tf_gnss_rotation_x,position_parameter.tf_gnss_rotation_y,
+      position_parameter.tf_gnss_rotation_z,position_parameter.tf_gnss_rotation_w);
+    transform2.setOrigin(transform*tf::Vector3(-position_parameter.tf_gnss_translation_x, -position_parameter.tf_gnss_translation_y,
+      -position_parameter.tf_gnss_translation_z));
     transform2.setRotation(transform*q2);
 
     tf::Vector3 tmp_pos;
@@ -100,7 +104,8 @@ void position_estimate_(eagleye_msgs::VelocityScaleFactor velocity_scale_factor,
   }
 
 
-  if (distance.distance-position_status->distance_last >= position_parameter.separation_distance && gnss_status == true && position_status->heading_estimate_status_count > 0)
+  if (distance.distance-position_status->distance_last >= position_parameter.separation_distance && gnss_status == true &&
+    position_status->heading_estimate_status_count > 0)
   {
 
     if (position_status->estimated_number < estimated_number_max)
@@ -142,7 +147,8 @@ void position_estimate_(eagleye_msgs::VelocityScaleFactor velocity_scale_factor,
   if (data_status == true)
   {
 
-    if (distance.distance > position_parameter.estimated_distance && gnss_status == true && velocity_scale_factor.correction_velocity.linear.x > position_parameter.estimated_velocity_threshold && position_status->heading_estimate_status_count > 0)
+    if (distance.distance > position_parameter.estimated_distance && gnss_status == true &&
+      velocity_scale_factor.correction_velocity.linear.x > position_parameter.estimated_velocity_threshold && position_status->heading_estimate_status_count > 0)
     {
       std::vector<int> distance_index;
       std::vector<int> velocity_index;
@@ -181,12 +187,12 @@ void position_estimate_(eagleye_msgs::VelocityScaleFactor velocity_scale_factor,
 
           for (i = 0; i < position_status->estimated_number; i++)
           {
-            base_enu_pos_x_buffer.push_back(position_status->enu_pos_x_buffer[index[index_length-1]] - position_status->enu_relative_pos_x_buffer[index[index_length-1]] +
-                                position_status->enu_relative_pos_x_buffer[i]);
-            base_enu_pos_y_buffer.push_back(position_status->enu_pos_y_buffer[index[index_length-1]] - position_status->enu_relative_pos_y_buffer[index[index_length-1]] +
-                                position_status->enu_relative_pos_y_buffer[i]);
-            base_enu_pos_z_buffer.push_back(position_status->enu_pos_z_buffer[index[index_length-1]] - position_status->enu_relative_pos_z_buffer[index[index_length-1]] +
-                                position_status->enu_relative_pos_z_buffer[i]);
+            base_enu_pos_x_buffer.push_back(position_status->enu_pos_x_buffer[index[index_length-1]] -
+              position_status->enu_relative_pos_x_buffer[index[index_length-1]] + position_status->enu_relative_pos_x_buffer[i]);
+            base_enu_pos_y_buffer.push_back(position_status->enu_pos_y_buffer[index[index_length-1]] -
+              position_status->enu_relative_pos_y_buffer[index[index_length-1]] + position_status->enu_relative_pos_y_buffer[i]);
+            base_enu_pos_z_buffer.push_back(position_status->enu_pos_z_buffer[index[index_length-1]] - 
+              position_status->enu_relative_pos_z_buffer[index[index_length-1]] + position_status->enu_relative_pos_z_buffer[i]);
           }
 
           diff_x_buffer2.clear();
@@ -214,9 +220,12 @@ void position_estimate_(eagleye_msgs::VelocityScaleFactor velocity_scale_factor,
 
           for (i = 0; i < position_status->estimated_number; i++)
           {
-            base_enu_pos_x_buffer2.push_back(tmp_enu_pos_x - position_status->enu_relative_pos_x_buffer[index[index_length - 1]] + position_status->enu_relative_pos_x_buffer[i]);
-            base_enu_pos_y_buffer2.push_back(tmp_enu_pos_y - position_status->enu_relative_pos_y_buffer[index[index_length - 1]] + position_status->enu_relative_pos_y_buffer[i]);
-            base_enu_pos_z_buffer2.push_back(tmp_enu_pos_z - position_status->enu_relative_pos_z_buffer[index[index_length - 1]] + position_status->enu_relative_pos_z_buffer[i]);
+            base_enu_pos_x_buffer2.push_back(tmp_enu_pos_x - position_status->enu_relative_pos_x_buffer[index[index_length - 1]] +
+              position_status->enu_relative_pos_x_buffer[i]);
+            base_enu_pos_y_buffer2.push_back(tmp_enu_pos_y - position_status->enu_relative_pos_y_buffer[index[index_length - 1]] +
+              position_status->enu_relative_pos_y_buffer[i]);
+            base_enu_pos_z_buffer2.push_back(tmp_enu_pos_z - position_status->enu_relative_pos_z_buffer[index[index_length - 1]] +
+              position_status->enu_relative_pos_z_buffer[i]);
           }
 
           diff_x_buffer.clear();
@@ -290,7 +299,9 @@ void position_estimate_(eagleye_msgs::VelocityScaleFactor velocity_scale_factor,
   data_status = false;
 }
 
-void position_estimate(rtklib_msgs::RtklibNav rtklib_nav,eagleye_msgs::VelocityScaleFactor velocity_scale_factor,eagleye_msgs::Distance distance,eagleye_msgs::Heading heading_interpolate_3rd,geometry_msgs::Vector3Stamped enu_vel,PositionParameter position_parameter, PositionStatus* position_status, eagleye_msgs::Position* enu_absolute_pos)
+void position_estimate(rtklib_msgs::RtklibNav rtklib_nav,eagleye_msgs::VelocityScaleFactor velocity_scale_factor,
+  eagleye_msgs::Distance distance,eagleye_msgs::Heading heading_interpolate_3rd,geometry_msgs::Vector3Stamped enu_vel,
+  PositionParameter position_parameter, PositionStatus* position_status, eagleye_msgs::Position* enu_absolute_pos)
 {
   double enu_pos[3];
   double ecef_pos[3];
@@ -361,7 +372,9 @@ void position_estimate(rtklib_msgs::RtklibNav rtklib_nav,eagleye_msgs::VelocityS
   position_estimate_(velocity_scale_factor, distance, heading_interpolate_3rd, enu_vel, position_parameter, position_status, enu_absolute_pos);
 }
 
-void position_estimate(nmea_msgs::Gpgga gga,eagleye_msgs::VelocityScaleFactor velocity_scale_factor,eagleye_msgs::Distance distance,eagleye_msgs::Heading heading_interpolate_3rd,geometry_msgs::Vector3Stamped enu_vel,PositionParameter position_parameter, PositionStatus* position_status, eagleye_msgs::Position* enu_absolute_pos)
+void position_estimate(nmea_msgs::Gpgga gga,eagleye_msgs::VelocityScaleFactor velocity_scale_factor,eagleye_msgs::Distance distance,
+  eagleye_msgs::Heading heading_interpolate_3rd,geometry_msgs::Vector3Stamped enu_vel,PositionParameter position_parameter, PositionStatus* position_status,
+  eagleye_msgs::Position* enu_absolute_pos)
 {
   double llh_pos[3];
   double enu_pos[3];

--- a/eagleye_core/navigation/src/position_interpolate.cpp
+++ b/eagleye_core/navigation/src/position_interpolate.cpp
@@ -31,7 +31,9 @@
 #include "coordinate/coordinate.hpp"
 #include "navigation/navigation.hpp"
 
-void position_interpolate_estimate(eagleye_msgs::Position enu_absolute_pos, geometry_msgs::Vector3Stamped enu_vel, eagleye_msgs::Position gnss_smooth_pos, eagleye_msgs::Height height,PositionInterpolateParameter position_interpolate_parameter, PositionInterpolateStatus* position_interpolate_status, eagleye_msgs::Position* enu_absolute_pos_interpolate,sensor_msgs::NavSatFix* eagleye_fix)
+void position_interpolate_estimate(eagleye_msgs::Position enu_absolute_pos, geometry_msgs::Vector3Stamped enu_vel, eagleye_msgs::Position gnss_smooth_pos,
+  eagleye_msgs::Height height,PositionInterpolateParameter position_interpolate_parameter, PositionInterpolateStatus* position_interpolate_status,
+  eagleye_msgs::Position* enu_absolute_pos_interpolate,sensor_msgs::NavSatFix* eagleye_fix)
 {
 
   int i;
@@ -68,11 +70,15 @@ void position_interpolate_estimate(eagleye_msgs::Position enu_absolute_pos, geom
     position_estimate_status = false;
   }
 
-  if(position_interpolate_status->time_last != 0 && std::sqrt((enu_vel.vector.x * enu_vel.vector.x) + (enu_vel.vector.y * enu_vel.vector.y) + (enu_vel.vector.z * enu_vel.vector.z)) > position_interpolate_parameter.stop_judgment_velocity_threshold)
+  if(position_interpolate_status->time_last != 0 && std::sqrt((enu_vel.vector.x * enu_vel.vector.x) + (enu_vel.vector.y * enu_vel.vector.y) +
+    (enu_vel.vector.z * enu_vel.vector.z)) > position_interpolate_parameter.stop_judgment_velocity_threshold)
   {
-    position_interpolate_status->provisional_enu_pos_x = enu_absolute_pos_interpolate->enu_pos.x + enu_vel.vector.x * (enu_vel.header.stamp.toSec() - position_interpolate_status->time_last);
-    position_interpolate_status->provisional_enu_pos_y = enu_absolute_pos_interpolate->enu_pos.y + enu_vel.vector.y * (enu_vel.header.stamp.toSec() - position_interpolate_status->time_last);
-    position_interpolate_status->provisional_enu_pos_z = enu_absolute_pos_interpolate->enu_pos.z + enu_vel.vector.z * (enu_vel.header.stamp.toSec() - position_interpolate_status->time_last);
+    position_interpolate_status->provisional_enu_pos_x = enu_absolute_pos_interpolate->enu_pos.x + enu_vel.vector.x *
+      (enu_vel.header.stamp.toSec() - position_interpolate_status->time_last);
+    position_interpolate_status->provisional_enu_pos_y = enu_absolute_pos_interpolate->enu_pos.y + enu_vel.vector.y *
+      (enu_vel.header.stamp.toSec() - position_interpolate_status->time_last);
+    position_interpolate_status->provisional_enu_pos_z = enu_absolute_pos_interpolate->enu_pos.z + enu_vel.vector.z *
+      (enu_vel.header.stamp.toSec() - position_interpolate_status->time_last);
   }
 
   // data buffer generate
@@ -103,16 +109,20 @@ void position_interpolate_estimate(eagleye_msgs::Position enu_absolute_pos, geom
       }
     }
 
-    if (position_estimate_status == true && estimate_index > 0 && position_interpolate_status->number_buffer >= estimate_index && position_interpolate_status->position_estimate_status_count > 1)
+    if (position_estimate_status == true && estimate_index > 0 && position_interpolate_status->number_buffer >= estimate_index &&
+      position_interpolate_status->position_estimate_status_count > 1)
     {
       diff_estimate_enu_pos_x = (position_interpolate_status->provisional_enu_pos_x_buffer[estimate_index-1] - enu_absolute_pos.enu_pos.x);
       diff_estimate_enu_pos_y = (position_interpolate_status->provisional_enu_pos_y_buffer[estimate_index-1] - enu_absolute_pos.enu_pos.y);
       diff_estimate_enu_pos_z = (position_interpolate_status->provisional_enu_pos_z_buffer[estimate_index-1] - enu_absolute_pos.enu_pos.z);
       for (i = estimate_index; i <= position_interpolate_status->number_buffer; i++)
       {
-        position_interpolate_status->provisional_enu_pos_x_buffer[i-1] = position_interpolate_status->provisional_enu_pos_x_buffer[i-1] - diff_estimate_enu_pos_x;
-        position_interpolate_status->provisional_enu_pos_y_buffer[i-1] = position_interpolate_status->provisional_enu_pos_y_buffer[i-1] - diff_estimate_enu_pos_y;
-        position_interpolate_status->provisional_enu_pos_z_buffer[i-1] = position_interpolate_status->provisional_enu_pos_z_buffer[i-1] - diff_estimate_enu_pos_z;
+        position_interpolate_status->provisional_enu_pos_x_buffer[i-1] = position_interpolate_status->provisional_enu_pos_x_buffer[i-1] -
+          diff_estimate_enu_pos_x;
+        position_interpolate_status->provisional_enu_pos_y_buffer[i-1] = position_interpolate_status->provisional_enu_pos_y_buffer[i-1] -
+          diff_estimate_enu_pos_y;
+        position_interpolate_status->provisional_enu_pos_z_buffer[i-1] = position_interpolate_status->provisional_enu_pos_z_buffer[i-1] -
+          diff_estimate_enu_pos_z;
       }
       position_interpolate_status->provisional_enu_pos_x = position_interpolate_status->provisional_enu_pos_x_buffer[position_interpolate_status->number_buffer-1];
       position_interpolate_status->provisional_enu_pos_y = position_interpolate_status->provisional_enu_pos_y_buffer[position_interpolate_status->number_buffer-1];

--- a/eagleye_core/navigation/src/rtk_deadreckoning.cpp
+++ b/eagleye_core/navigation/src/rtk_deadreckoning.cpp
@@ -31,7 +31,9 @@
 #include "coordinate/coordinate.hpp"
 #include "navigation/navigation.hpp"
 
-void rtk_deadreckoning_estimate_(geometry_msgs::Vector3Stamped enu_vel, nmea_msgs::Gpgga gga,  eagleye_msgs::Heading heading, RtkDeadreckoningParameter rtk_deadreckoning_parameter, RtkDeadreckoningStatus* rtk_deadreckoning_status, eagleye_msgs::Position* enu_absolute_rtk_deadreckoning,sensor_msgs::NavSatFix* eagleye_fix)
+void rtk_deadreckoning_estimate_(geometry_msgs::Vector3Stamped enu_vel, nmea_msgs::Gpgga gga,  eagleye_msgs::Heading heading,
+  RtkDeadreckoningParameter rtk_deadreckoning_parameter, RtkDeadreckoningStatus* rtk_deadreckoning_status,
+  eagleye_msgs::Position* enu_absolute_rtk_deadreckoning,sensor_msgs::NavSatFix* eagleye_fix)
 {
 
   double enu_pos[3],enu_rtk[3];

--- a/eagleye_core/navigation/src/rtk_heading.cpp
+++ b/eagleye_core/navigation/src/rtk_heading.cpp
@@ -31,7 +31,9 @@
 #include "coordinate/coordinate.hpp"
 #include "navigation/navigation.hpp"
 
-void rtk_heading_estimate(nmea_msgs::Gpgga gga,sensor_msgs::Imu imu,eagleye_msgs::VelocityScaleFactor velocity_scale_factor,eagleye_msgs::Distance distance,eagleye_msgs::YawrateOffset yawrate_offset_stop,eagleye_msgs::YawrateOffset yawrate_offset,eagleye_msgs::SlipAngle slip_angle,eagleye_msgs::Heading heading_interpolate,RtkHeadingParameter heading_parameter, RtkHeadingStatus* heading_status,eagleye_msgs::Heading* heading)
+void rtk_heading_estimate(nmea_msgs::Gpgga gga,sensor_msgs::Imu imu,eagleye_msgs::VelocityScaleFactor velocity_scale_factor,eagleye_msgs::Distance distance,
+  eagleye_msgs::YawrateOffset yawrate_offset_stop,eagleye_msgs::YawrateOffset yawrate_offset,eagleye_msgs::SlipAngle slip_angle,
+  eagleye_msgs::Heading heading_interpolate,RtkHeadingParameter heading_parameter, RtkHeadingStatus* heading_status,eagleye_msgs::Heading* heading)
 {
 
   int i,index_max;
@@ -96,7 +98,8 @@ void rtk_heading_estimate(nmea_msgs::Gpgga gga,sensor_msgs::Imu imu,eagleye_msgs
   double gga_length;
   gga_length = std::distance(heading_status->gga_status_buffer.begin(), heading_status->gga_status_buffer.end());
 
-  if (heading_status->gga_status_buffer[0] == 0 && heading_status->gga_status_buffer[gga_length-1] == 0 && abs(yawrate) < heading_parameter.estimated_yawrate_threshold)
+  if (heading_status->gga_status_buffer[0] == 0 && heading_status->gga_status_buffer[gga_length-1] == 0 &&
+    abs(yawrate) < heading_parameter.estimated_yawrate_threshold)
   {
     tmp_llh[0] = heading_status->latitude_buffer[0] *M_PI/180;
     tmp_llh[1] = heading_status->longitude_buffer[0]*M_PI/180;
@@ -118,8 +121,9 @@ void rtk_heading_estimate(nmea_msgs::Gpgga gga,sensor_msgs::Imu imu,eagleye_msgs
     rtk_heading_angle = rtk_heading_angle + 2*M_PI;
   }
 
-  if (heading_status->tow_last  == gga.header.stamp.toSec() || gga.header.stamp.toSec() == 0 || rtk_heading_angle == 0
-    || heading_status->last_rtk_heading_angle == rtk_heading_angle || velocity_scale_factor.correction_velocity.linear.x < heading_parameter.stop_judgment_velocity_threshold)
+  if (heading_status->tow_last  == gga.header.stamp.toSec() || gga.header.stamp.toSec() == 0 || rtk_heading_angle == 0 ||
+      heading_status->last_rtk_heading_angle == rtk_heading_angle ||
+      velocity_scale_factor.correction_velocity.linear.x < heading_parameter.stop_judgment_velocity_threshold)
   {
     gnss_status = false;
     rtk_heading_angle = 0;
@@ -161,7 +165,8 @@ void rtk_heading_estimate(nmea_msgs::Gpgga gga,sensor_msgs::Imu imu,eagleye_msgs
   std::vector<int> velocity_index;
   std::vector<int> index;
 
-  if (heading_status->estimated_number  > heading_parameter.estimated_number_min && heading_status->gnss_status_buffer [heading_status->estimated_number -1] == true &&
+  if (heading_status->estimated_number  > heading_parameter.estimated_number_min &&
+    heading_status->gnss_status_buffer [heading_status->estimated_number -1] == true &&
     heading_status->correction_velocity_buffer [heading_status->estimated_number -1] > heading_parameter.estimated_velocity_threshold &&
     fabsf(heading_status->yawrate_buffer [heading_status->estimated_number -1]) < heading_parameter.estimated_yawrate_threshold)
   {
@@ -201,12 +206,14 @@ void rtk_heading_estimate(nmea_msgs::Gpgga gga,sensor_msgs::Imu imu,eagleye_msgs
         {
           if (std::abs(heading_status->correction_velocity_buffer [heading_status->estimated_number -1]) > heading_parameter.stop_judgment_velocity_threshold)
           {
-            provisional_heading_angle_buffer[i] = provisional_heading_angle_buffer[i-1] + ((heading_status->yawrate_buffer [i] + heading_status->yawrate_offset_buffer [i]) *
+            provisional_heading_angle_buffer[i] = provisional_heading_angle_buffer[i-1] +
+              ((heading_status->yawrate_buffer [i] + heading_status->yawrate_offset_buffer [i]) *
               (heading_status->time_buffer [i] - heading_status->time_buffer [i-1]));
           }
           else
           {
-            provisional_heading_angle_buffer[i] = provisional_heading_angle_buffer[i-1] + ((heading_status->yawrate_buffer [i] + heading_status->yawrate_offset_stop_buffer [i]) *
+            provisional_heading_angle_buffer[i] = provisional_heading_angle_buffer[i-1] +
+              ((heading_status->yawrate_buffer [i] + heading_status->yawrate_offset_stop_buffer [i]) *
               (heading_status->time_buffer [i] - heading_status->time_buffer [i-1]));
           }
         }
@@ -230,7 +237,8 @@ void rtk_heading_estimate(nmea_msgs::Gpgga gga,sensor_msgs::Imu imu,eagleye_msgs
 
       for (i = 0; i < heading_status->estimated_number ; i++)
       {
-        base_heading_angle_buffer.push_back(heading_interpolate.heading_angle - provisional_heading_angle_buffer[index[index_length-1]] + provisional_heading_angle_buffer[i]);
+        base_heading_angle_buffer.push_back(heading_interpolate.heading_angle - provisional_heading_angle_buffer[index[index_length-1]] +
+          provisional_heading_angle_buffer[i]);
       }
 
       for (i = 0; i < index_length; i++)
@@ -247,7 +255,8 @@ void rtk_heading_estimate(nmea_msgs::Gpgga gga,sensor_msgs::Imu imu,eagleye_msgs
         base_heading_angle_buffer.clear();
         for (i = 0; i < heading_status->estimated_number ; i++)
         {
-          base_heading_angle_buffer.push_back(heading_angle_buffer2[index[index_length-1]] - provisional_heading_angle_buffer[index[index_length-1]] + provisional_heading_angle_buffer[i]);
+          base_heading_angle_buffer.push_back(heading_angle_buffer2[index[index_length-1]] - provisional_heading_angle_buffer[index[index_length-1]] +
+            provisional_heading_angle_buffer[i]);
         }
 
         diff_buffer.clear();
@@ -262,7 +271,8 @@ void rtk_heading_estimate(nmea_msgs::Gpgga gga,sensor_msgs::Imu imu,eagleye_msgs
         base_heading_angle_buffer2.clear();
         for (i = 0; i < heading_status->estimated_number ; i++)
         {
-          base_heading_angle_buffer2.push_back(tmp_heading_angle - provisional_heading_angle_buffer[index[index_length-1]] + provisional_heading_angle_buffer[i]);
+          base_heading_angle_buffer2.push_back(tmp_heading_angle - provisional_heading_angle_buffer[index[index_length-1]] +
+            provisional_heading_angle_buffer[i]);
         }
 
         diff_buffer.clear();
@@ -299,7 +309,8 @@ void rtk_heading_estimate(nmea_msgs::Gpgga gga,sensor_msgs::Imu imu,eagleye_msgs
         }
         else
         {
-          heading->heading_angle = tmp_heading_angle + (provisional_heading_angle_buffer[heading_status->estimated_number -1] - provisional_heading_angle_buffer[index[index_length-1]]);
+          heading->heading_angle = tmp_heading_angle + (provisional_heading_angle_buffer[heading_status->estimated_number -1] -
+            provisional_heading_angle_buffer[index[index_length-1]]);
         }
         heading->status.estimate_status = true;
       }

--- a/eagleye_core/navigation/src/slip_angle.cpp
+++ b/eagleye_core/navigation/src/slip_angle.cpp
@@ -31,7 +31,8 @@
 #include "coordinate/coordinate.hpp"
 #include "navigation/navigation.hpp"
 
-void slip_angle_estimate(sensor_msgs::Imu imu, eagleye_msgs::VelocityScaleFactor velocity_scale_factor, eagleye_msgs::YawrateOffset yawrate_offset_stop, eagleye_msgs::YawrateOffset yawrate_offset_2nd, SlipangleParameter slip_angle_parameter,eagleye_msgs::SlipAngle* slip_angle)
+void slip_angle_estimate(sensor_msgs::Imu imu, eagleye_msgs::VelocityScaleFactor velocity_scale_factor, eagleye_msgs::YawrateOffset yawrate_offset_stop,
+  eagleye_msgs::YawrateOffset yawrate_offset_2nd, SlipangleParameter slip_angle_parameter,eagleye_msgs::SlipAngle* slip_angle)
 {
 
   int i;
@@ -59,7 +60,8 @@ void slip_angle_estimate(sensor_msgs::Imu imu, eagleye_msgs::VelocityScaleFactor
 
   acceleration_y = velocity_scale_factor.correction_velocity.linear.x * yawrate;
 
-  if (velocity_scale_factor.status.enabled_status == true && yawrate_offset_stop.status.enabled_status == true && yawrate_offset_2nd.status.enabled_status == true)
+  if (velocity_scale_factor.status.enabled_status == true && yawrate_offset_stop.status.enabled_status == true &&
+    yawrate_offset_2nd.status.enabled_status == true)
   {
       slip_angle->coefficient = slip_angle_parameter.manual_coefficient;
       slip_angle->slip_angle = slip_angle_parameter.manual_coefficient * acceleration_y;

--- a/eagleye_core/navigation/src/slip_coefficient.cpp
+++ b/eagleye_core/navigation/src/slip_coefficient.cpp
@@ -31,7 +31,9 @@
 #include "coordinate/coordinate.hpp"
 #include "navigation/navigation.hpp"
 
-void slip_coefficient_estimate(sensor_msgs::Imu imu,rtklib_msgs::RtklibNav rtklib_nav,eagleye_msgs::VelocityScaleFactor velocity_scale_factor,eagleye_msgs::YawrateOffset yawrate_offset_stop,eagleye_msgs::YawrateOffset yawrate_offset_2nd,eagleye_msgs::Heading heading_interpolate_3rd,SlipCoefficientParameter slip_coefficient_parameter,SlipCoefficientStatus* slip_coefficient_status,double* estimate_coefficient)
+void slip_coefficient_estimate(sensor_msgs::Imu imu,rtklib_msgs::RtklibNav rtklib_nav,eagleye_msgs::VelocityScaleFactor velocity_scale_factor,
+  eagleye_msgs::YawrateOffset yawrate_offset_stop,eagleye_msgs::YawrateOffset yawrate_offset_2nd,eagleye_msgs::Heading heading_interpolate_3rd,
+  SlipCoefficientParameter slip_coefficient_parameter,SlipCoefficientStatus* slip_coefficient_status,double* estimate_coefficient)
 {
 
   int i;
@@ -90,7 +92,8 @@ void slip_coefficient_estimate(sensor_msgs::Imu imu,rtklib_msgs::RtklibNav rtkli
 
   if (heading_interpolate_3rd.status.estimate_status == true)
   {
-    if ((velocity_scale_factor.correction_velocity.linear.x > slip_coefficient_parameter.estimated_velocity_threshold) && (fabs(yawrate) > slip_coefficient_parameter.estimated_yawrate_threshold))
+    if ((velocity_scale_factor.correction_velocity.linear.x > slip_coefficient_parameter.estimated_velocity_threshold) &&
+      (fabs(yawrate) > slip_coefficient_parameter.estimated_yawrate_threshold))
     {
       double imu_heading;
 
@@ -140,7 +143,8 @@ void slip_coefficient_estimate(sensor_msgs::Imu imu,rtklib_msgs::RtklibNav rtkli
               sum_y += slip_coefficient_status->doppler_slip_buffer[i];
               sum_x2 += pow(slip_coefficient_status->acceleration_y_buffer[i], 2);
             }
-            *estimate_coefficient = (slip_coefficient_status->heading_estimate_status_count * sum_xy - sum_x * sum_y) / (slip_coefficient_status->heading_estimate_status_count * sum_x2 - pow(sum_x, 2));
+            *estimate_coefficient = (slip_coefficient_status->heading_estimate_status_count * sum_xy - sum_x * sum_y) /
+              (slip_coefficient_status->heading_estimate_status_count * sum_x2 - pow(sum_x, 2));
           }
         }
       }

--- a/eagleye_core/navigation/src/smoothing.cpp
+++ b/eagleye_core/navigation/src/smoothing.cpp
@@ -31,7 +31,8 @@
 #include "coordinate/coordinate.hpp"
 #include "navigation/navigation.hpp"
 
-void smoothing_estimate(rtklib_msgs::RtklibNav rtklib_nav, eagleye_msgs::VelocityScaleFactor velocity_scale_factor,SmoothingParameter smoothing_parameter, SmoothingStatus* smoothing_status,eagleye_msgs::Position* gnss_smooth_pos_enu)
+void smoothing_estimate(rtklib_msgs::RtklibNav rtklib_nav, eagleye_msgs::VelocityScaleFactor velocity_scale_factor,SmoothingParameter smoothing_parameter,
+  SmoothingStatus* smoothing_status,eagleye_msgs::Position* gnss_smooth_pos_enu)
 {
 
   int i;

--- a/eagleye_core/navigation/src/trajectory.cpp
+++ b/eagleye_core/navigation/src/trajectory.cpp
@@ -31,34 +31,42 @@
 #include "coordinate/coordinate.hpp"
 #include "navigation/navigation.hpp"
 
-void trajectory_estimate(const sensor_msgs::Imu imu, const eagleye_msgs::VelocityScaleFactor velocity_scale_factor, const eagleye_msgs::Heading heading_interpolate_3rd, const eagleye_msgs::YawrateOffset yawrate_offset_stop, const eagleye_msgs::YawrateOffset yawrate_offset_2nd, const TrajectoryParameter trajectory_parameter, TrajectoryStatus* trajectory_status, geometry_msgs::Vector3Stamped* enu_vel, eagleye_msgs::Position* enu_relative_pos, geometry_msgs::TwistStamped* eagleye_twist)
+void trajectory_estimate(const sensor_msgs::Imu imu, const eagleye_msgs::VelocityScaleFactor velocity_scale_factor,
+  const eagleye_msgs::Heading heading_interpolate_3rd, const eagleye_msgs::YawrateOffset yawrate_offset_stop,
+  const eagleye_msgs::YawrateOffset yawrate_offset_2nd, const TrajectoryParameter trajectory_parameter, TrajectoryStatus* trajectory_status,
+  geometry_msgs::Vector3Stamped* enu_vel, eagleye_msgs::Position* enu_relative_pos, geometry_msgs::TwistStamped* eagleye_twist)
 {
 
   if (trajectory_parameter.reverse_imu == false)
   {
-    if (std::abs(velocity_scale_factor.correction_velocity.linear.x) > trajectory_parameter.stop_judgment_velocity_threshold && yawrate_offset_2nd.status.enabled_status == true)
+    if (std::abs(velocity_scale_factor.correction_velocity.linear.x) > trajectory_parameter.stop_judgment_velocity_threshold &&
+    yawrate_offset_2nd.status.enabled_status == true)
     {
-      eagleye_twist->twist.angular.z = -1 * (imu.angular_velocity.z + yawrate_offset_2nd.yawrate_offset); //Inverted because the coordinate system is reversed
+      eagleye_twist->twist.angular.z = -1 * (imu.angular_velocity.z + yawrate_offset_2nd.yawrate_offset); // Inverted because the coordinate system is reversed
     }
     else
     {
-      eagleye_twist->twist.angular.z = -1 * (imu.angular_velocity.z + yawrate_offset_stop.yawrate_offset); //Inverted because the coordinate system is reversed
+      eagleye_twist->twist.angular.z = -1 * (imu.angular_velocity.z + yawrate_offset_stop.yawrate_offset); // Inverted because the coordinate system is reversed
     }
   }
   else if (trajectory_parameter.reverse_imu == true)
   {
-    if (std::abs(velocity_scale_factor.correction_velocity.linear.x) > trajectory_parameter.stop_judgment_velocity_threshold  && yawrate_offset_2nd.status.enabled_status == true)
+    if (std::abs(velocity_scale_factor.correction_velocity.linear.x) > trajectory_parameter.stop_judgment_velocity_threshold  &&
+      yawrate_offset_2nd.status.enabled_status == true)
     {
-      eagleye_twist->twist.angular.z = -1 * (-1 * imu.angular_velocity.z + yawrate_offset_2nd.yawrate_offset); //Inverted because the coordinate system is reversed
+      eagleye_twist->twist.angular.z = -1 * (-1 * imu.angular_velocity.z + yawrate_offset_2nd.yawrate_offset);
+      // Inverted because the coordinate system is reversed
     }
     else
     {
-      eagleye_twist->twist.angular.z = -1 * (-1 * imu.angular_velocity.z + yawrate_offset_stop.yawrate_offset); //Inverted because the coordinate system is reversed
+      eagleye_twist->twist.angular.z = -1 * (-1 * imu.angular_velocity.z + yawrate_offset_stop.yawrate_offset); 
+      // Inverted because the coordinate system is reversed
     }
   }
   eagleye_twist->twist.linear.x = velocity_scale_factor.correction_velocity.linear.x;
 
-  if (trajectory_status->estimate_status_count == 0 && velocity_scale_factor.status.enabled_status == true && heading_interpolate_3rd.status.enabled_status == true)
+  if (trajectory_status->estimate_status_count == 0 && velocity_scale_factor.status.enabled_status == true &&
+    heading_interpolate_3rd.status.enabled_status == true)
   {
     trajectory_status->estimate_status_count = 1;
     trajectory_status->heading_last = heading_interpolate_3rd.heading_angle;
@@ -85,8 +93,14 @@ void trajectory_estimate(const sensor_msgs::Imu imu, const eagleye_msgs::Velocit
     }
     else if((imu.angular_velocity.z + yawrate_offset_2nd.yawrate_offset) != 0)
     {
-      enu_relative_pos->enu_pos.x = enu_relative_pos->enu_pos.x + velocity_scale_factor.correction_velocity.linear.x/(imu.angular_velocity.z + yawrate_offset_2nd.yawrate_offset) * ( -cos(trajectory_status->heading_last+(imu.angular_velocity.z + yawrate_offset_2nd.yawrate_offset)*(imu.header.stamp.toSec() - trajectory_status->time_last)) + cos(trajectory_status->heading_last));
-      enu_relative_pos->enu_pos.y = enu_relative_pos->enu_pos.y + velocity_scale_factor.correction_velocity.linear.x/(imu.angular_velocity.z + yawrate_offset_2nd.yawrate_offset) * ( sin(trajectory_status->heading_last+(imu.angular_velocity.z + yawrate_offset_2nd.yawrate_offset)*(imu.header.stamp.toSec() - trajectory_status->time_last)) - sin(trajectory_status->heading_last));
+      enu_relative_pos->enu_pos.x = enu_relative_pos->enu_pos.x +
+        velocity_scale_factor.correction_velocity.linear.x/(imu.angular_velocity.z + yawrate_offset_2nd.yawrate_offset) *
+        ( -cos(trajectory_status->heading_last+(imu.angular_velocity.z + yawrate_offset_2nd.yawrate_offset) *
+        (imu.header.stamp.toSec() - trajectory_status->time_last)) + cos(trajectory_status->heading_last));
+      enu_relative_pos->enu_pos.y = enu_relative_pos->enu_pos.y +
+        velocity_scale_factor.correction_velocity.linear.x/(imu.angular_velocity.z + yawrate_offset_2nd.yawrate_offset) *
+        ( sin(trajectory_status->heading_last+(imu.angular_velocity.z + yawrate_offset_2nd.yawrate_offset) * 
+        (imu.header.stamp.toSec() - trajectory_status->time_last)) - sin(trajectory_status->heading_last));
       enu_relative_pos->enu_pos.z = 0;
     }
     else{
@@ -102,12 +116,15 @@ void trajectory_estimate(const sensor_msgs::Imu imu, const eagleye_msgs::Velocit
   trajectory_status->time_last = imu.header.stamp.toSec();
 }
 
-void trajectory3d_estimate(const sensor_msgs::Imu imu, const eagleye_msgs::VelocityScaleFactor velocity_scale_factor, const eagleye_msgs::Heading heading_interpolate_3rd, const eagleye_msgs::YawrateOffset yawrate_offset_stop, const eagleye_msgs::YawrateOffset yawrate_offset_2nd, const eagleye_msgs::Pitching pitching, const TrajectoryParameter trajectory_parameter, TrajectoryStatus* trajectory_status, geometry_msgs::Vector3Stamped* enu_vel, eagleye_msgs::Position* enu_relative_pos, geometry_msgs::TwistStamped* eagleye_twist)
+void trajectory3d_estimate(const sensor_msgs::Imu imu, const eagleye_msgs::VelocityScaleFactor velocity_scale_factor,
+  const eagleye_msgs::Heading heading_interpolate_3rd, const eagleye_msgs::YawrateOffset yawrate_offset_stop,
+  const eagleye_msgs::YawrateOffset yawrate_offset_2nd, const eagleye_msgs::Pitching pitching, const TrajectoryParameter trajectory_parameter, TrajectoryStatus* trajectory_status, geometry_msgs::Vector3Stamped* enu_vel, eagleye_msgs::Position* enu_relative_pos, geometry_msgs::TwistStamped* eagleye_twist)
 {
 
   if (trajectory_parameter.reverse_imu == false)
   {
-    if (std::abs(velocity_scale_factor.correction_velocity.linear.x) > trajectory_parameter.stop_judgment_velocity_threshold && yawrate_offset_2nd.status.enabled_status == true)
+    if (std::abs(velocity_scale_factor.correction_velocity.linear.x) > trajectory_parameter.stop_judgment_velocity_threshold &&
+      yawrate_offset_2nd.status.enabled_status == true)
     {
       eagleye_twist->twist.angular.z = -1 * (imu.angular_velocity.z + yawrate_offset_2nd.yawrate_offset); //Inverted because the coordinate system is reversed
     }
@@ -118,7 +135,8 @@ void trajectory3d_estimate(const sensor_msgs::Imu imu, const eagleye_msgs::Veloc
   }
   else if (trajectory_parameter.reverse_imu == true)
   {
-    if (std::abs(velocity_scale_factor.correction_velocity.linear.x) > trajectory_parameter.stop_judgment_velocity_threshold  && yawrate_offset_2nd.status.enabled_status == true)
+    if (std::abs(velocity_scale_factor.correction_velocity.linear.x) > trajectory_parameter.stop_judgment_velocity_threshold  &&
+      yawrate_offset_2nd.status.enabled_status == true)
     {
       eagleye_twist->twist.angular.z = -1 * (-1 * imu.angular_velocity.z + yawrate_offset_2nd.yawrate_offset); //Inverted because the coordinate system is reversed
     }
@@ -129,7 +147,8 @@ void trajectory3d_estimate(const sensor_msgs::Imu imu, const eagleye_msgs::Veloc
   }
   eagleye_twist->twist.linear.x = velocity_scale_factor.correction_velocity.linear.x;
 
-  if (trajectory_status->estimate_status_count == 0 && velocity_scale_factor.status.enabled_status == true && heading_interpolate_3rd.status.enabled_status == true)
+  if (trajectory_status->estimate_status_count == 0 && velocity_scale_factor.status.enabled_status == true &&
+    heading_interpolate_3rd.status.enabled_status == true)
   {
     trajectory_status->estimate_status_count = 1;
     trajectory_status->heading_last = heading_interpolate_3rd.heading_angle;
@@ -156,8 +175,14 @@ void trajectory3d_estimate(const sensor_msgs::Imu imu, const eagleye_msgs::Veloc
     }
     else
     {
-      enu_relative_pos->enu_pos.x = enu_relative_pos->enu_pos.x + velocity_scale_factor.correction_velocity.linear.x/(imu.angular_velocity.z + yawrate_offset_2nd.yawrate_offset) * ( -cos(trajectory_status->heading_last+(imu.angular_velocity.z + yawrate_offset_2nd.yawrate_offset)*(imu.header.stamp.toSec() - trajectory_status->time_last)) + cos(trajectory_status->heading_last));
-      enu_relative_pos->enu_pos.y = enu_relative_pos->enu_pos.y + velocity_scale_factor.correction_velocity.linear.x/(imu.angular_velocity.z + yawrate_offset_2nd.yawrate_offset) * ( sin(trajectory_status->heading_last+(imu.angular_velocity.z + yawrate_offset_2nd.yawrate_offset)*(imu.header.stamp.toSec() - trajectory_status->time_last)) - sin(trajectory_status->heading_last));
+      enu_relative_pos->enu_pos.x = enu_relative_pos->enu_pos.x +
+        velocity_scale_factor.correction_velocity.linear.x/(imu.angular_velocity.z + yawrate_offset_2nd.yawrate_offset) *
+        ( -cos(trajectory_status->heading_last+(imu.angular_velocity.z + yawrate_offset_2nd.yawrate_offset) * 
+        (imu.header.stamp.toSec() - trajectory_status->time_last)) + cos(trajectory_status->heading_last));
+      enu_relative_pos->enu_pos.y = enu_relative_pos->enu_pos.y +
+        velocity_scale_factor.correction_velocity.linear.x/(imu.angular_velocity.z + yawrate_offset_2nd.yawrate_offset) *
+        ( sin(trajectory_status->heading_last+(imu.angular_velocity.z + yawrate_offset_2nd.yawrate_offset) * 
+        (imu.header.stamp.toSec() - trajectory_status->time_last)) - sin(trajectory_status->heading_last));
       enu_relative_pos->enu_pos.z = enu_relative_pos->enu_pos.z + enu_vel->vector.z * (imu.header.stamp.toSec() - trajectory_status->time_last);
     }
 

--- a/eagleye_core/navigation/src/velocity_scale_factor.cpp
+++ b/eagleye_core/navigation/src/velocity_scale_factor.cpp
@@ -33,7 +33,8 @@
 
 #define knot2mps 0.51477
 
-void velocity_scale_factor_estimate_(const geometry_msgs::TwistStamped velocity, const VelocityScaleFactorParameter velocity_scale_factor_parameter, VelocityScaleFactorStatus* velocity_scale_factor_status,eagleye_msgs::VelocityScaleFactor* velocity_scale_factor)
+void velocity_scale_factor_estimate_(const geometry_msgs::TwistStamped velocity, const VelocityScaleFactorParameter velocity_scale_factor_parameter,
+  VelocityScaleFactorStatus* velocity_scale_factor_status,eagleye_msgs::VelocityScaleFactor* velocity_scale_factor)
 { 
 
   int i;
@@ -83,7 +84,10 @@ void velocity_scale_factor_estimate_(const geometry_msgs::TwistStamped velocity,
   std::vector<int> index;
   std::vector<double> velocity_scale_factor_buffer;
 
-  if (velocity_scale_factor_status->estimated_number >= velocity_scale_factor_parameter.estimated_number_min && velocity_scale_factor_status->gnss_status_buffer[velocity_scale_factor_status->estimated_number - 1] == true && velocity_scale_factor_status->velocity_buffer[velocity_scale_factor_status->estimated_number - 1] > velocity_scale_factor_parameter.estimated_velocity_threshold)
+  if (velocity_scale_factor_status->estimated_number >= velocity_scale_factor_parameter.estimated_number_min &&
+    velocity_scale_factor_status->gnss_status_buffer[velocity_scale_factor_status->estimated_number - 1] == true &&
+    velocity_scale_factor_status->velocity_buffer[velocity_scale_factor_status->estimated_number - 1] >
+    velocity_scale_factor_parameter.estimated_velocity_threshold)
   {
     for (i = 0; i < velocity_scale_factor_status->estimated_number; i++)
     {
@@ -106,7 +110,8 @@ void velocity_scale_factor_estimate_(const geometry_msgs::TwistStamped velocity,
     {
       for (i = 0; i < index_length; i++)
       {
-        velocity_scale_factor_buffer.push_back(velocity_scale_factor_status->doppler_velocity_buffer[index[i]] / velocity_scale_factor_status->velocity_buffer[index[i]]);
+        velocity_scale_factor_buffer.push_back(velocity_scale_factor_status->doppler_velocity_buffer[index[i]] /
+          velocity_scale_factor_status->velocity_buffer[index[i]]);
       }
 
       velocity_scale_factor->status.estimate_status = true;
@@ -155,7 +160,9 @@ void velocity_scale_factor_estimate_(const geometry_msgs::TwistStamped velocity,
 
 }
 
-void velocity_scale_factor_estimate(const rtklib_msgs::RtklibNav rtklib_nav, const geometry_msgs::TwistStamped velocity, const VelocityScaleFactorParameter velocity_scale_factor_parameter, VelocityScaleFactorStatus* velocity_scale_factor_status,eagleye_msgs::VelocityScaleFactor* velocity_scale_factor)
+void velocity_scale_factor_estimate(const rtklib_msgs::RtklibNav rtklib_nav, const geometry_msgs::TwistStamped velocity,
+  const VelocityScaleFactorParameter velocity_scale_factor_parameter, VelocityScaleFactorStatus* velocity_scale_factor_status,
+  eagleye_msgs::VelocityScaleFactor* velocity_scale_factor)
 {
 
     double ecef_vel[3];
@@ -208,7 +215,9 @@ void velocity_scale_factor_estimate(const rtklib_msgs::RtklibNav rtklib_nav, con
   velocity_scale_factor_estimate_(velocity, velocity_scale_factor_parameter, velocity_scale_factor_status, velocity_scale_factor);
 }
 
-void velocity_scale_factor_estimate(const nmea_msgs::Gprmc nmea_rmc, const geometry_msgs::TwistStamped velocity, const VelocityScaleFactorParameter velocity_scale_factor_parameter, VelocityScaleFactorStatus* velocity_scale_factor_status,eagleye_msgs::VelocityScaleFactor* velocity_scale_factor)
+void velocity_scale_factor_estimate(const nmea_msgs::Gprmc nmea_rmc, const geometry_msgs::TwistStamped velocity,
+  const VelocityScaleFactorParameter velocity_scale_factor_parameter, VelocityScaleFactorStatus* velocity_scale_factor_status,
+  eagleye_msgs::VelocityScaleFactor* velocity_scale_factor)
 {
   bool gnss_status;
   double doppler_velocity = 0.0;

--- a/eagleye_core/navigation/src/yawrate_offset.cpp
+++ b/eagleye_core/navigation/src/yawrate_offset.cpp
@@ -31,7 +31,9 @@
 #include "coordinate/coordinate.hpp"
 #include "navigation/navigation.hpp"
 
-void yawrate_offset_estimate(const eagleye_msgs::VelocityScaleFactor velocity_scale_factor, const eagleye_msgs::YawrateOffset yawrate_offset_stop,const eagleye_msgs::Heading heading_interpolate,const sensor_msgs::Imu imu, const YawrateOffsetParameter yawrate_offset_parameter, YawrateOffsetStatus* yawrate_offset_status, eagleye_msgs::YawrateOffset* yawrate_offset)
+void yawrate_offset_estimate(const eagleye_msgs::VelocityScaleFactor velocity_scale_factor, const eagleye_msgs::YawrateOffset yawrate_offset_stop,
+  const eagleye_msgs::Heading heading_interpolate,const sensor_msgs::Imu imu, const YawrateOffsetParameter yawrate_offset_parameter,
+  YawrateOffsetStatus* yawrate_offset_status, eagleye_msgs::YawrateOffset* yawrate_offset)
 {
   int i;
   double yawrate = 0.0;
@@ -91,7 +93,8 @@ void yawrate_offset_estimate(const eagleye_msgs::VelocityScaleFactor velocity_sc
     yawrate_offset_status->yawrate_offset_stop_buffer.erase(yawrate_offset_status->yawrate_offset_stop_buffer.begin());
   }
 
-  if (yawrate_offset_status->estimated_preparation_conditions == 0 && yawrate_offset_status->heading_estimate_status_buffer[yawrate_offset_status->estimated_number - 1] == true)
+  if (yawrate_offset_status->estimated_preparation_conditions == 0 &&
+    yawrate_offset_status->heading_estimate_status_buffer[yawrate_offset_status->estimated_number - 1] == true)
   {
     yawrate_offset_status->estimated_preparation_conditions = 1;
   }
@@ -107,7 +110,9 @@ void yawrate_offset_estimate(const eagleye_msgs::VelocityScaleFactor velocity_sc
     }
   }
 
-  if (yawrate_offset_status->estimated_preparation_conditions == 2 && yawrate_offset_status->correction_velocity_buffer[yawrate_offset_status->estimated_number-1] > yawrate_offset_parameter.estimated_velocity_threshold && yawrate_offset_status->heading_estimate_status_buffer[yawrate_offset_status->estimated_number-1] == true)
+  if (yawrate_offset_status->estimated_preparation_conditions == 2 &&
+    yawrate_offset_status->correction_velocity_buffer[yawrate_offset_status->estimated_number-1] > yawrate_offset_parameter.estimated_velocity_threshold &&
+    yawrate_offset_status->heading_estimate_status_buffer[yawrate_offset_status->estimated_number-1] == true)
   {
     estimated_condition_status = true;
   }
@@ -147,7 +152,8 @@ void yawrate_offset_estimate(const eagleye_msgs::VelocityScaleFactor velocity_sc
       {
         if (i > 0)
         {
-          provisional_heading_angle_buffer[i] = provisional_heading_angle_buffer[i-1] + yawrate_offset_status->yawrate_buffer[i] * (yawrate_offset_status->time_buffer[i] - yawrate_offset_status->time_buffer[i-1]);
+          provisional_heading_angle_buffer[i] = provisional_heading_angle_buffer[i-1] + yawrate_offset_status->yawrate_buffer[i] *
+            (yawrate_offset_status->time_buffer[i] - yawrate_offset_status->time_buffer[i-1]);
         }
       }
 
@@ -162,15 +168,17 @@ void yawrate_offset_estimate(const eagleye_msgs::VelocityScaleFactor velocity_sc
       //base_heading_angle_buffer.clear();
       for (i = 0; i < yawrate_offset_status->estimated_number; i++)
       {
-        base_heading_angle_buffer.push_back(yawrate_offset_status->heading_angle_buffer[index[index_length-1]] - provisional_heading_angle_buffer[index[index_length-1]] + provisional_heading_angle_buffer[i]);
+        base_heading_angle_buffer.push_back(yawrate_offset_status->heading_angle_buffer[index[index_length-1]] -
+          provisional_heading_angle_buffer[index[index_length-1]] + provisional_heading_angle_buffer[i]);
       }
 
       //diff_buffer.clear();
       for (i = 0; i < index_length; i++)
       {
         // diff_buffer.push_back(base_heading_angle_buffer[index[i]] - heading_angle_buffer[index[i]]);
-        diff_buffer.push_back(yawrate_offset_status->heading_angle_buffer[index[index_length-1]] - provisional_heading_angle_buffer[index[index_length-1]] + provisional_heading_angle_buffer[index[i]] -
-                        yawrate_offset_status->heading_angle_buffer[index[i]]);
+        diff_buffer.push_back(yawrate_offset_status->heading_angle_buffer[index[index_length-1]] -
+          provisional_heading_angle_buffer[index[index_length-1]] + provisional_heading_angle_buffer[index[i]] -
+          yawrate_offset_status->heading_angle_buffer[index[i]]);
       }
 
       time_buffer2.clear();

--- a/eagleye_core/navigation/src/yawrate_offset_stop.cpp
+++ b/eagleye_core/navigation/src/yawrate_offset_stop.cpp
@@ -31,7 +31,9 @@
 #include "coordinate/coordinate.hpp"
 #include "navigation/navigation.hpp"
 
-void yawrate_offset_stop_estimate(const geometry_msgs::TwistStamped velocity, const sensor_msgs::Imu imu, const YawrateOffsetStopParameter yawrate_offset_stop_parameter, YawrateOffsetStopStatus* yawrate_offset_stop_status, eagleye_msgs::YawrateOffset* yawrate_offset_stop)
+void yawrate_offset_stop_estimate(const geometry_msgs::TwistStamped velocity, const sensor_msgs::Imu imu,
+  const YawrateOffsetStopParameter yawrate_offset_stop_parameter, YawrateOffsetStopStatus* yawrate_offset_stop_status,
+  eagleye_msgs::YawrateOffset* yawrate_offset_stop)
 {
 
   int i;
@@ -52,7 +54,8 @@ void yawrate_offset_stop_estimate(const geometry_msgs::TwistStamped velocity, co
       yawrate_offset_stop_status->yawrate_buffer.push_back(-1 * imu.angular_velocity.z);
     }
   }
-  else if ( std::fabs(std::fabs(yawrate_offset_stop_status->yawrate_offset_stop_last) - std::fabs(imu.angular_velocity.z)) < yawrate_offset_stop_parameter.outlier_threshold && yawrate_offset_stop_status->estimate_start_status == true)
+  else if ( std::fabs(std::fabs(yawrate_offset_stop_status->yawrate_offset_stop_last) - std::fabs(imu.angular_velocity.z)) <
+    yawrate_offset_stop_parameter.outlier_threshold && yawrate_offset_stop_status->estimate_start_status == true)
   {
     if (yawrate_offset_stop_parameter.reverse_imu == false)
     {

--- a/eagleye_rt/config/eagleye_config.yaml
+++ b/eagleye_rt/config/eagleye_config.yaml
@@ -141,3 +141,10 @@ rolling:
 
 monitor:
   print_status: true
+  update_rate: 10.0
+  th_gnss_deadrock_time: 10.0
+  th_velocity_scale_factor_percent: 10.0 
+  use_compare_yawrate: false                        #Whether to compare the yaw rate with the yaw rate calculated from the vehicle speed model
+  comparison_twist_topic: /calculated_twist
+  th_diff_rad_per_sec: 0.17453                      #Threshold of difference from comparison twist yaw rate(0.17453 rad/s = 10 degree/s)
+  th_num_continuous_abnormal_yawrate: 25            #Threshold for consecutive abnormal values in comparison twist

--- a/eagleye_rt/src/monitor_node.cpp
+++ b/eagleye_rt/src/monitor_node.cpp
@@ -89,6 +89,7 @@ static double eagleye_twist_time_last;
 
 static double update_rate = 10;
 static double th_gnss_deadrock_time = 10;
+static double th_velocity_scale_factor_percent = 0.2;
 
 void rtklib_nav_callback(const rtklib_msgs::RtklibNav::ConstPtr& msg)
 {
@@ -272,7 +273,8 @@ void velocity_scale_factor_topic_checker(diagnostic_updater::DiagnosticStatusWra
     level = diagnostic_msgs::DiagnosticStatus::WARN;
     msg = "not subscribed to topic";
   }
-  else if (!std::isfinite(velocity_scale_factor.scale_factor)) {
+  else if (!std::isfinite(velocity_scale_factor.scale_factor) ||
+    th_velocity_scale_factor_percent < std::abs(1.0 - velocity_scale_factor.scale_factor)) {
     level = diagnostic_msgs::DiagnosticStatus::ERROR;
     msg = "invalid number";
   }


### PR DESCRIPTION
・If the velocity scale factor is too small or too large, the error is output by Diagnosis.
・If the yaw rate is calculated using a geometric model, add an option to output an error in the diagnostic if the IMU yaw rate is too small or too large.