### PR TITLE
Feature/covariance output

### DIFF
--- a/eagleye_core/navigation/include/navigation/navigation.hpp
+++ b/eagleye_core/navigation/include/navigation/navigation.hpp
@@ -219,8 +219,8 @@ struct PositionParameter
   double tf_gnss_rotation_y;
   double tf_gnss_rotation_z;
   double tf_gnss_rotation_w;
-  std::string tf_gnss_parent_flame;
-  std::string tf_gnss_child_flame;
+  std::string tf_gnss_parent_frame;
+  std::string tf_gnss_child_frame;
 };
 
 struct PositionStatus
@@ -396,8 +396,8 @@ struct RtkDeadreckoningParameter
   double tf_gnss_rotation_y;
   double tf_gnss_rotation_z;
   double tf_gnss_rotation_w;
-  std::string tf_gnss_parent_flame;
-  std::string tf_gnss_child_flame;
+  std::string tf_gnss_parent_frame;
+  std::string tf_gnss_child_frame;
 };
 
 struct RtkDeadreckoningStatus

--- a/eagleye_core/navigation/src/position_interpolate.cpp
+++ b/eagleye_core/navigation/src/position_interpolate.cpp
@@ -174,6 +174,10 @@ void position_interpolate_estimate(eagleye_msgs::Position enu_absolute_pos, geom
     enu_absolute_pos_interpolate->enu_pos.z = enu_pos[2];
 
     eagleye_fix->altitude = llh_pos[2];
+    // TODO(Map IV): temporary covariance value
+    eagleye_fix->position_covariance[0] = 1.5 * 1.5; // [m^2]
+    eagleye_fix->position_covariance[4] = 1.5 * 1.5; // [m^2]
+    eagleye_fix->position_covariance[8] = 1.5 * 1.5; // [m^2]
 
   }
   else
@@ -184,6 +188,9 @@ void position_interpolate_estimate(eagleye_msgs::Position enu_absolute_pos, geom
     eagleye_fix->longitude = 0;
     eagleye_fix->latitude = 0;
     eagleye_fix->altitude = 0;
+    eagleye_fix->position_covariance[0] = 100 * 100; // [m^2]
+    eagleye_fix->position_covariance[4] = 100 * 100; // [m^2]
+    eagleye_fix->position_covariance[8] = 100 * 100; // [m^2]
   }
 
   position_interpolate_status->time_last = enu_vel.header.stamp.toSec();

--- a/eagleye_core/navigation/src/rtk_deadreckoning.cpp
+++ b/eagleye_core/navigation/src/rtk_deadreckoning.cpp
@@ -105,6 +105,10 @@ void rtk_deadreckoning_estimate_(geometry_msgs::Vector3Stamped enu_vel, nmea_msg
     eagleye_fix->latitude = llh_pos[0] * 180/M_PI;
     eagleye_fix->longitude = llh_pos[1] * 180/M_PI;
     eagleye_fix->altitude = llh_pos[2];
+    // TODO(Map IV): temporary covariance value
+    eagleye_fix->position_covariance[0] = (enu_absolute_rtk_deadreckoning->status.estimate_status) ? 0.02 * 0.02 : 1.5 * 1.5; // [m^2]
+    eagleye_fix->position_covariance[4] = (enu_absolute_rtk_deadreckoning->status.estimate_status) ? 0.02 * 0.02 : 1.5 * 1.5; // [m^2]
+    eagleye_fix->position_covariance[8] = (enu_absolute_rtk_deadreckoning->status.estimate_status) ? 0.02 * 0.02 : 1.5 * 1.5; // [m^2]
 
     enu_absolute_rtk_deadreckoning->enu_pos.x = enu_pos[0];
     enu_absolute_rtk_deadreckoning->enu_pos.y = enu_pos[1];

--- a/eagleye_pp/README.md
+++ b/eagleye_pp/README.md
@@ -24,11 +24,11 @@ The input topics can be changed in `config/eagleye_pp.config`.
 ### Output
 The output file will be created in the log directory, which is created in the same directory as the rosbag used.
 
- - <ROSBAG_NAME>_eagleye.csv  
+ - eagleye.csv  
 	Position and orientation file.  
 	eagleye_pp_llh.status indicates the status of the result: status 0 is 2D error less than 0.3m, status 1 is 2D error less than 1.5m, and status 2 is 2D error greater than 1.5m.  
 	eagleye_pp_llh.height_status indicates whether flag is true or false for pitching estimation.  
- - <ROSBAG_NAME>_eagleye.kml  
+ - eagleye.kml  
 	・RTKLIB section in the CAR Tragectory  
 	  The magenta point plot is the positioning solution for rtklib.  
 	  The square plot is the fix solution, and the circle plot is the float solution or the single positioning solution.  
@@ -41,11 +41,11 @@ The output file will be created in the log directory, which is created in the sa
 	  Green line plot of the trajectory of the eagleye turned in the opposite direction in time.  
 	・EAGLEYE_PP_LINE  
 	  Blue line plot of a trajectory that combines Forward and Backward processing.
- - <ROSBAG_NAME>_eagleye_line.kml  
- 　Only line plots are extracted from the plots in <ROSBAG_NAME>_eagleye.kml.  
- - <ROSBAG_NAME>_eagleye_log.csv  
+ - eagleye_line.kml  
+ 　Only line plots are extracted from the plots in eagleye.kml.  
+ - eagleye_log.csv  
  　Log files of observables and internal states in forward processing.  
- - <ROSBAG_NAME>_eagleye_log_back.csv  
+ - eagleye_log_back.csv  
  　Log files of observables and internal states in backward processing. 
 
 ## Parameter

--- a/eagleye_pp/eagleye_pp/config/eagleye_pp_config.yaml
+++ b/eagleye_pp/eagleye_pp/config/eagleye_pp_config.yaml
@@ -38,7 +38,8 @@ twist_topic: /can_twist
 imu_topic: /imu/data_raw
 rtklib_nav_topic: /rtklib_nav
 ## If RTK positioning is not used, the following topic settings are not necessary.
-nmea_sentence_topic: /mosaic/nmea_sentence
+## Forward/backward smoothing is not possible without nmea_msgs/Sentence.
+nmea_sentence_topic: /nmea_sentence
 
 #Parameter settings for Eagleye
 reverse_imu: false

--- a/eagleye_pp/eagleye_pp/src/eagleye_pp_output.cpp
+++ b/eagleye_pp/eagleye_pp/src/eagleye_pp_output.cpp
@@ -289,7 +289,7 @@ void eagleye_pp::writeDetailCSVOneWay(std::ofstream* output_log_csv_file, const 
     // ,angular_velocity_offset_stop.rollrate_offset,angular_velocity_offset_stop.pitchrate_offset,angular_velocity_offset_stop.yawrate_offset,angular_velocity_offset_stop.status.enabled_status,angular_velocity_offset_stop.status.estimate_status
     for(int i=0; i<data_length_; i++)
     {
-      *output_log_csv_file << std::setprecision(std::numeric_limits<int>::max_digits10) << imu_[i].header.stamp.toNSec() << ","; //timestamp
+      *output_log_csv_file << std::setprecision(15) << imu_[i].header.stamp.toSec() << ","; //timestamp
       *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << imu_[i].angular_velocity.x << ",";
       *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << imu_[i].angular_velocity.y << ",";
       *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << imu_[i].angular_velocity.z << ",";

--- a/eagleye_pp/eagleye_pp/src/eagleye_pp_output.cpp
+++ b/eagleye_pp/eagleye_pp/src/eagleye_pp_output.cpp
@@ -138,113 +138,113 @@ output_csv_file << "timestamp,eagleye_llh.latitude,eagleye_llh.longitude,eagleye
 ,eagleye_pp_llh.status\
 " << std::endl;
 
-  //output debug file
+  // output debug file
   for(int i=0; i<data_length_; i++)
   {
-    output_csv_file << std::setprecision(15) << imu_[i].header.stamp.toSec() << ","; //timestamp
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_fix[i].latitude << ","; //eagleye_llh.latitude
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_fix[i].longitude << ","; //eagleye_llh.longitude
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_fix[i].altitude << ","; //eagleye_llh.altitude
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_fix[i].position_covariance[0] << ","; //eagleye_llh.position_covariance[0]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_fix[i].position_covariance[1] << ","; //eagleye_llh.position_covariance[1]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_fix[i].position_covariance[2] << ","; //eagleye_llh.position_covariance[2]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_fix[i].position_covariance[3] << ","; //eagleye_llh.position_covariance[3]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_fix[i].position_covariance[4] << ","; //eagleye_llh.position_covariance[4]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_fix[i].position_covariance[5] << ","; //eagleye_llh.position_covariance[5]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_fix[i].position_covariance[6] << ","; //eagleye_llh.position_covariance[6]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_fix[i].position_covariance[7] << ","; //eagleye_llh.position_covariance[7]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_fix[i].position_covariance[8] << ","; //eagleye_llh.position_covariance[8]
-    output_csv_file << bool(eagleye_state_forward_.enu_absolute_pos_interpolate[i].status.estimate_status) << ","; //eagleye_llh.status
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_twist[i].twist.linear.x << ","; //eagleye_twist.linear.x
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_twist[i].twist.linear.y << ","; //eagleye_twist.linear.y
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_twist[i].twist.linear.z << ","; //eagleye_twist.linear.z
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_twist[i].twist.angular.x << ","; //eagleye_twist.angular.x
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_twist[i].twist.angular.y << ","; //eagleye_twist.angular.y
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_twist[i].twist.angular.z << ","; //eagleye_twist.angular.z
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_twist.covariance[0]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_twist.covariance[1]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_twist.covariance[2]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_twist.covariance[3]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_twist.covariance[4]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_twist.covariance[5]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_twist.covariance[6]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_twist.covariance[7]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_twist.covariance[8]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_twist.covariance[9]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_twist.covariance[10]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_twist.covariance[11]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_twist.covariance[12]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_twist.covariance[13]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_twist.covariance[14]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_twist.covariance[15]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_twist.covariance[16]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_twist.covariance[17]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << imu_[i].linear_acceleration.x << ","; //eagleye_acceleration.x TODO Change to acceleration estimated by eagleye
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << imu_[i].linear_acceleration.y << ","; //eagleye_acceleration.y
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << imu_[i].linear_acceleration.z << ","; //eagleye_acceleration.z
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_acceleration.orientation_covariance[0]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_acceleration.orientation_covariance[1]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_acceleration.orientation_covariance[2]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_acceleration.orientation_covariance[3]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_acceleration.orientation_covariance[4]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_acceleration.orientation_covariance[5]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_acceleration.orientation_covariance[6]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_acceleration.orientation_covariance[7]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_acceleration.orientation_covariance[8]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.rolling[i].rolling_angle << ","; //eagleye_posture.roll
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.pitching[i].pitching_angle << ","; //eagleye_posture.pitch
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.heading_interpolate_3rd[i].heading_angle << ","; //eagleye_posture.yaw
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_posture.orientation_covariance[0]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_posture.orientation_covariance[1]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_posture.orientation_covariance[2]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_posture.orientation_covariance[3]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_posture.orientation_covariance[4]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_posture.orientation_covariance[5]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_posture.orientation_covariance[6]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_posture.orientation_covariance[7]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_posture.orientation_covariance[8]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << gga_[i].lat << ","; //navsat_llh.latitude
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << gga_[i].lon << ","; //navsat_llh.longitude
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << gga_[i].alt +  gga_[i].undulation<< ","; //navsat_llh.altitude
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //navsat_llh.position_covariance[0]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //navsat_llh.position_covariance[1]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //navsat_llh.position_covariance[2]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //navsat_llh.position_covariance[3]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //navsat_llh.position_covariance[4]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //navsat_llh.position_covariance[5]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //navsat_llh.position_covariance[6]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //navsat_llh.position_covariance[7]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //navsat_llh.position_covariance[8]
-    output_csv_file << std::setprecision(std::numeric_limits<int>::max_digits10) << int(gga_[i].gps_qual) << ","; //navsat_llh.gps_qual
+    output_csv_file << std::setprecision(15) << imu_[i].header.stamp.toSec() << ","; // timestamp
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_fix[i].latitude << ","; // eagleye_llh.latitude
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_fix[i].longitude << ","; // eagleye_llh.longitude
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_fix[i].altitude << ","; // eagleye_llh.altitude
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_fix[i].position_covariance[0] << ","; // eagleye_llh.position_covariance[0]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_fix[i].position_covariance[1] << ","; // eagleye_llh.position_covariance[1]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_fix[i].position_covariance[2] << ","; // eagleye_llh.position_covariance[2]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_fix[i].position_covariance[3] << ","; // eagleye_llh.position_covariance[3]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_fix[i].position_covariance[4] << ","; // eagleye_llh.position_covariance[4]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_fix[i].position_covariance[5] << ","; // eagleye_llh.position_covariance[5]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_fix[i].position_covariance[6] << ","; // eagleye_llh.position_covariance[6]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_fix[i].position_covariance[7] << ","; // eagleye_llh.position_covariance[7]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_fix[i].position_covariance[8] << ","; // eagleye_llh.position_covariance[8]
+    output_csv_file << bool(eagleye_state_forward_.enu_absolute_pos_interpolate[i].status.estimate_status) << ","; // eagleye_llh.status
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_twist[i].twist.linear.x << ","; // eagleye_twist.linear.x
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_twist[i].twist.linear.y << ","; // eagleye_twist.linear.y
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_twist[i].twist.linear.z << ","; // eagleye_twist.linear.z
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_twist[i].twist.angular.x << ","; // eagleye_twist.angular.x
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_twist[i].twist.angular.y << ","; // eagleye_twist.angular.y
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_twist[i].twist.angular.z << ","; // eagleye_twist.angular.z
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_twist.covariance[0]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_twist.covariance[1]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_twist.covariance[2]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_twist.covariance[3]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_twist.covariance[4]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_twist.covariance[5]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_twist.covariance[6]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_twist.covariance[7]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_twist.covariance[8]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_twist.covariance[9]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_twist.covariance[10]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_twist.covariance[11]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_twist.covariance[12]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_twist.covariance[13]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_twist.covariance[14]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_twist.covariance[15]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_twist.covariance[16]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_twist.covariance[17]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << imu_[i].linear_acceleration.x << ","; // eagleye_acceleration.x TODO Change to acceleration estimated by eagleye
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << imu_[i].linear_acceleration.y << ","; // eagleye_acceleration.y
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << imu_[i].linear_acceleration.z << ","; // eagleye_acceleration.z
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_acceleration.orientation_covariance[0]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_acceleration.orientation_covariance[1]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_acceleration.orientation_covariance[2]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_acceleration.orientation_covariance[3]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_acceleration.orientation_covariance[4]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_acceleration.orientation_covariance[5]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_acceleration.orientation_covariance[6]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_acceleration.orientation_covariance[7]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_acceleration.orientation_covariance[8]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.rolling[i].rolling_angle << ","; // eagleye_posture.roll
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.pitching[i].pitching_angle << ","; // eagleye_posture.pitch
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.heading_interpolate_3rd[i].heading_angle << ","; // eagleye_posture.yaw
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_posture.orientation_covariance[0]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_posture.orientation_covariance[1]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_posture.orientation_covariance[2]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_posture.orientation_covariance[3]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_posture.orientation_covariance[4]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_posture.orientation_covariance[5]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_posture.orientation_covariance[6]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_posture.orientation_covariance[7]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_posture.orientation_covariance[8]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << gga_[i].lat << ","; // navsat_llh.latitude
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << gga_[i].lon << ","; // navsat_llh.longitude
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << gga_[i].alt +  gga_[i].undulation<< ","; // navsat_llh.altitude
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // navsat_llh.position_covariance[0]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // navsat_llh.position_covariance[1]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // navsat_llh.position_covariance[2]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // navsat_llh.position_covariance[3]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // navsat_llh.position_covariance[4]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // navsat_llh.position_covariance[5]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // navsat_llh.position_covariance[6]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // navsat_llh.position_covariance[7]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // navsat_llh.position_covariance[8]
+    output_csv_file << std::setprecision(std::numeric_limits<int>::max_digits10) << int(gga_[i].gps_qual) << ","; // navsat_llh.gps_qual
     if(getUseCombination())
     {
-      output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << llh_smoothing_trajectory_lat_[i] << ","; //eagleye_pp_llh.latitude
-      output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << llh_smoothing_trajectory_lon_[i] << ","; //eagleye_pp_llh.longitude
-      output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << llh_smoothing_trajectory_hei_[i] << ","; //eagleye_pp_llh.altitude
+      output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << llh_smoothing_trajectory_lat_[i] << ","; // eagleye_pp_llh.latitude
+      output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << llh_smoothing_trajectory_lon_[i] << ","; // eagleye_pp_llh.longitude
+      output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << llh_smoothing_trajectory_hei_[i] << ","; // eagleye_pp_llh.altitude
     }
     else
     {
-      output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_pp_llh.latitude
-      output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_pp_llh.longitude
-      output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_pp_llh.altitude      
+      output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_pp_llh.latitude
+      output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_pp_llh.longitude
+      output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_pp_llh.altitude      
     }
     
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_pp_llh.orientation_covariance[0]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_pp_llh.orientation_covariance[1]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_pp_llh.orientation_covariance[2]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_pp_llh.orientation_covariance[3]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_pp_llh.orientation_covariance[4]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_pp_llh.orientation_covariance[5]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_pp_llh.orientation_covariance[6]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_pp_llh.orientation_covariance[7]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_pp_llh.orientation_covariance[8]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_pp_llh.orientation_covariance[0]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_pp_llh.orientation_covariance[1]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_pp_llh.orientation_covariance[2]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_pp_llh.orientation_covariance[3]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_pp_llh.orientation_covariance[4]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_pp_llh.orientation_covariance[5]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_pp_llh.orientation_covariance[6]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_pp_llh.orientation_covariance[7]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_pp_llh.orientation_covariance[8]
     if(getUseCombination())
     {
-      output_csv_file << std::setprecision(std::numeric_limits<int>::max_digits10) << smoothing_trajectory_status_[i]; //eagleye_pp_llh.status
+      output_csv_file << std::setprecision(std::numeric_limits<int>::max_digits10) << smoothing_trajectory_status_[i]; // eagleye_pp_llh.status
     }
     else
     {
-      output_csv_file << std::setprecision(std::numeric_limits<int>::max_digits10) << 0; //eagleye_pp_llh.status    
+      output_csv_file << std::setprecision(std::numeric_limits<int>::max_digits10) << 0; // eagleye_pp_llh.status    
     }
     output_csv_file << "\n";
   }
@@ -315,12 +315,18 @@ void eagleye_pp::writeDetailCSVOneWay(std::ofstream* output_log_csv_file, const 
       *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << velocity_[i].twist.angular.y << ",";
       *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << velocity_[i].twist.angular.z << ",";
       *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.velocity_scale_factor[i].scale_factor << ",";
-      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.velocity_scale_factor[i].correction_velocity.linear.x << ",";
-      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.velocity_scale_factor[i].correction_velocity.linear.y << ",";
-      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.velocity_scale_factor[i].correction_velocity.linear.z << ",";
-      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.velocity_scale_factor[i].correction_velocity.angular.x << ",";
-      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.velocity_scale_factor[i].correction_velocity.angular.y << ",";
-      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.velocity_scale_factor[i].correction_velocity.angular.z << ",";
+      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) <<
+        eagleye_state_forward_.velocity_scale_factor[i].correction_velocity.linear.x << ",";
+      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) <<
+        eagleye_state_forward_.velocity_scale_factor[i].correction_velocity.linear.y << ",";
+      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) <<
+        eagleye_state_forward_.velocity_scale_factor[i].correction_velocity.linear.z << ",";
+      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) <<
+        eagleye_state_forward_.velocity_scale_factor[i].correction_velocity.angular.x << ",";
+      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) <<
+        eagleye_state_forward_.velocity_scale_factor[i].correction_velocity.angular.y << ",";
+      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) <<
+        eagleye_state_forward_.velocity_scale_factor[i].correction_velocity.angular.z << ",";
       *output_log_csv_file << (eagleye_state_forward_.velocity_scale_factor[i].status.enabled_status ? "1" : "0") << ",";
       *output_log_csv_file << (eagleye_state_forward_.velocity_scale_factor[i].status.estimate_status ? "1" : "0") << ",";
       *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.distance[i].distance << ",";
@@ -396,41 +402,41 @@ void eagleye_pp::writeDetailCSVOneWay(std::ofstream* output_log_csv_file, const 
       *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.rolling[i].rolling_angle << ",";
       *output_log_csv_file << (eagleye_state_forward_.rolling[i].status.enabled_status ? "1" : "0") << ",";
       *output_log_csv_file << (eagleye_state_forward_.rolling[i].status.estimate_status ? "1" : "0") << ",";
-      *output_log_csv_file << std::setprecision(std::numeric_limits<int>::max_digits10) << gga_[i].header.stamp.toNSec() << ","; //timestamp
-      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << gga_[i].lat << ","; //gga_llh.latitude
-      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << gga_[i].lon << ","; //gga_llh.longitude
-      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << gga_[i].alt +  gga_[i].undulation << ","; //gga_llh.altitude
-      *output_log_csv_file << std::setprecision(std::numeric_limits<int>::max_digits10) << int(gga_[i].gps_qual) << ","; //gga_llh.gps_qual
+      *output_log_csv_file << std::setprecision(std::numeric_limits<int>::max_digits10) << gga_[i].header.stamp.toNSec() << ","; // timestamp
+      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << gga_[i].lat << ","; // gga_llh.latitude
+      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << gga_[i].lon << ","; // gga_llh.longitude
+      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << gga_[i].alt +  gga_[i].undulation << ","; // gga_llh.altitude
+      *output_log_csv_file << std::setprecision(std::numeric_limits<int>::max_digits10) << int(gga_[i].gps_qual) << ","; // gga_llh.gps_qual
       if(getUseCombination())
       {
-        *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << llh_smoothing_trajectory_lat_[i] << ","; //eagleye_pp_llh.latitude
-        *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << llh_smoothing_trajectory_lon_[i] << ","; //eagleye_pp_llh.longitude
-        *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << llh_smoothing_trajectory_hei_[i] << ","; //eagleye_pp_llh.altitude
+        *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << llh_smoothing_trajectory_lat_[i] << ","; // eagleye_pp_llh.latitude
+        *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << llh_smoothing_trajectory_lon_[i] << ","; // eagleye_pp_llh.longitude
+        *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << llh_smoothing_trajectory_hei_[i] << ","; // eagleye_pp_llh.altitude
       }
       else
       {
-        *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_pp_llh.latitude
-        *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_pp_llh.longitude
-        *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_pp_llh.altitude     
+        *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_pp_llh.latitude
+        *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_pp_llh.longitude
+        *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_pp_llh.altitude     
       }
-      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_pp_llh.orientation_covariance[0]
-      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_pp_llh.orientation_covariance[1]
-      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_pp_llh.orientation_covariance[2]
-      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_pp_llh.orientation_covariance[3]
-      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_pp_llh.orientation_covariance[4]
-      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_pp_llh.orientation_covariance[5]
-      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_pp_llh.orientation_covariance[6]
-      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_pp_llh.orientation_covariance[7]
-      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_pp_llh.orientation_covariance[8]
+      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_pp_llh.orientation_covariance[0]
+      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_pp_llh.orientation_covariance[1]
+      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_pp_llh.orientation_covariance[2]
+      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_pp_llh.orientation_covariance[3]
+      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_pp_llh.orientation_covariance[4]
+      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_pp_llh.orientation_covariance[5]
+      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_pp_llh.orientation_covariance[6]
+      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_pp_llh.orientation_covariance[7]
+      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_pp_llh.orientation_covariance[8]
       if(getUseCombination())
       {
-        *output_log_csv_file << std::setprecision(std::numeric_limits<int>::max_digits10) << smoothing_trajectory_status_[i] << ","; //eagleye_pp_llh.status
+        *output_log_csv_file << std::setprecision(std::numeric_limits<int>::max_digits10) << smoothing_trajectory_status_[i] << ","; // eagleye_pp_llh.status
       }
       else
       {
-        *output_log_csv_file << std::setprecision(std::numeric_limits<int>::max_digits10) << 0 << ","; //eagleye_pp_llh.status    
+        *output_log_csv_file << std::setprecision(std::numeric_limits<int>::max_digits10) << 0 << ","; // eagleye_pp_llh.status    
       }
-      *output_log_csv_file << std::setprecision(std::numeric_limits<int>::max_digits10) << eagleye_state_forward_.flag_reliability_buffer[i] << ","; //eagleye_pp_llh.status
+      *output_log_csv_file << std::setprecision(std::numeric_limits<int>::max_digits10) << eagleye_state_forward_.flag_reliability_buffer[i] << ","; // eagleye_pp_llh.status
       *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.enu_relative_pos[i].enu_pos.x << ",";
       *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.enu_relative_pos[i].enu_pos.y << ",";
       *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.enu_relative_pos[i].enu_pos.z << ",";

--- a/eagleye_pp/eagleye_pp/src/eagleye_pp_output.cpp
+++ b/eagleye_pp/eagleye_pp/src/eagleye_pp_output.cpp
@@ -122,7 +122,7 @@ void eagleye_pp::writeSimpleCSV(void)
 
   // output_csv_file header
 output_csv_file << "timestamp,eagleye_llh.latitude,eagleye_llh.longitude,eagleye_llh.altitude\
-,eagleye_llh.orientation_covariance[0],eagleye_llh.orientation_covariance[1],eagleye_llh.orientation_covariance[2],eagleye_llh.orientation_covariance[3],eagleye_llh.orientation_covariance[4],eagleye_llh.orientation_covariance[5],eagleye_llh.orientation_covariance[6],eagleye_llh.orientation_covariance[7],eagleye_llh.orientation_covariance[8]\
+,eagleye_llh.position_covariance[0],eagleye_llh.position_covariance[1],eagleye_llh.position_covariance[2],eagleye_llh.position_covariance[3],eagleye_llh.position_covariance[4],eagleye_llh.position_covariance[5],eagleye_llh.position_covariance[6],eagleye_llh.position_covariance[7],eagleye_llh.position_covariance[8]\
 ,eagleye_llh.status,eagleye_twist.linear.x,eagleye_twist.linear.y,eagleye_twist.linear.z,eagleye_twist.angular.x,eagleye_twist.angular.y,eagleye_twist.angular.z\
 ,eagleye_twist.orientation_covariance[0],eagleye_twist.orientation_covariance[1],eagleye_twist.orientation_covariance[2],eagleye_twist.orientation_covariance[3],eagleye_twist.orientation_covariance[4],eagleye_twist.orientation_covariance[5],eagleye_twist.orientation_covariance[6],eagleye_twist.orientation_covariance[7],eagleye_twist.orientation_covariance[8]\
 ,eagleye_twist.orientation_covariance[9],eagleye_twist.orientation_covariance[10],eagleye_twist.orientation_covariance[11],eagleye_twist.orientation_covariance[12],eagleye_twist.orientation_covariance[13],eagleye_twist.orientation_covariance[14],eagleye_twist.orientation_covariance[15],eagleye_twist.orientation_covariance[16],eagleye_twist.orientation_covariance[17]\
@@ -145,15 +145,15 @@ output_csv_file << "timestamp,eagleye_llh.latitude,eagleye_llh.longitude,eagleye
     output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_fix[i].latitude << ","; //eagleye_llh.latitude
     output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_fix[i].longitude << ","; //eagleye_llh.longitude
     output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_fix[i].altitude << ","; //eagleye_llh.altitude
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_fix[i].position_covariance[0] << ","; //eagleye_llh.orientation_covariance[0]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_fix[i].position_covariance[1] << ","; //eagleye_llh.orientation_covariance[1]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_fix[i].position_covariance[2] << ","; //eagleye_llh.orientation_covariance[2]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_fix[i].position_covariance[3] << ","; //eagleye_llh.orientation_covariance[3]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_fix[i].position_covariance[4] << ","; //eagleye_llh.orientation_covariance[4]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_fix[i].position_covariance[5] << ","; //eagleye_llh.orientation_covariance[5]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_fix[i].position_covariance[6] << ","; //eagleye_llh.orientation_covariance[6]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_fix[i].position_covariance[7] << ","; //eagleye_llh.orientation_covariance[7]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_fix[i].position_covariance[8] << ","; //eagleye_llh.orientation_covariance[8]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_fix[i].position_covariance[0] << ","; //eagleye_llh.position_covariance[0]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_fix[i].position_covariance[1] << ","; //eagleye_llh.position_covariance[1]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_fix[i].position_covariance[2] << ","; //eagleye_llh.position_covariance[2]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_fix[i].position_covariance[3] << ","; //eagleye_llh.position_covariance[3]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_fix[i].position_covariance[4] << ","; //eagleye_llh.position_covariance[4]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_fix[i].position_covariance[5] << ","; //eagleye_llh.position_covariance[5]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_fix[i].position_covariance[6] << ","; //eagleye_llh.position_covariance[6]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_fix[i].position_covariance[7] << ","; //eagleye_llh.position_covariance[7]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_fix[i].position_covariance[8] << ","; //eagleye_llh.position_covariance[8]
     output_csv_file << bool(eagleye_state_forward_.enu_absolute_pos_interpolate[i].status.estimate_status) << ","; //eagleye_llh.status
     output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_twist[i].twist.linear.x << ","; //eagleye_twist.linear.x
     output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_twist[i].twist.linear.y << ","; //eagleye_twist.linear.y
@@ -161,24 +161,24 @@ output_csv_file << "timestamp,eagleye_llh.latitude,eagleye_llh.longitude,eagleye
     output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_twist[i].twist.angular.x << ","; //eagleye_twist.angular.x
     output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_twist[i].twist.angular.y << ","; //eagleye_twist.angular.y
     output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.eagleye_twist[i].twist.angular.z << ","; //eagleye_twist.angular.z
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_twist.orientation_covariance[0]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_twist.orientation_covariance[1]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_twist.orientation_covariance[2]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_twist.orientation_covariance[3]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_twist.orientation_covariance[4]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_twist.orientation_covariance[5]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_twist.orientation_covariance[6]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_twist.orientation_covariance[7]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_twist.orientation_covariance[8]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_twist.orientation_covariance[9]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_twist.orientation_covariance[10]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_twist.orientation_covariance[11]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_twist.orientation_covariance[12]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_twist.orientation_covariance[13]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_twist.orientation_covariance[14]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_twist.orientation_covariance[15]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_twist.orientation_covariance[16]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_twist.orientation_covariance[17]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_twist.covariance[0]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_twist.covariance[1]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_twist.covariance[2]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_twist.covariance[3]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_twist.covariance[4]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_twist.covariance[5]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_twist.covariance[6]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_twist.covariance[7]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_twist.covariance[8]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_twist.covariance[9]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_twist.covariance[10]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_twist.covariance[11]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_twist.covariance[12]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_twist.covariance[13]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_twist.covariance[14]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_twist.covariance[15]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_twist.covariance[16]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_twist.covariance[17]
     output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << imu_[i].linear_acceleration.x << ","; //eagleye_acceleration.x TODO Change to acceleration estimated by eagleye
     output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << imu_[i].linear_acceleration.y << ","; //eagleye_acceleration.y
     output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << imu_[i].linear_acceleration.z << ","; //eagleye_acceleration.z
@@ -206,15 +206,15 @@ output_csv_file << "timestamp,eagleye_llh.latitude,eagleye_llh.longitude,eagleye
     output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << gga_[i].lat << ","; //navsat_llh.latitude
     output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << gga_[i].lon << ","; //navsat_llh.longitude
     output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << gga_[i].alt +  gga_[i].undulation<< ","; //navsat_llh.altitude
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //navsat_llh.orientation_covariance[0]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //navsat_llh.orientation_covariance[1]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //navsat_llh.orientation_covariance[2]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //navsat_llh.orientation_covariance[3]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //navsat_llh.orientation_covariance[4]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //navsat_llh.orientation_covariance[5]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //navsat_llh.orientation_covariance[6]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //navsat_llh.orientation_covariance[7]
-    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //navsat_llh.orientation_covariance[8]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //navsat_llh.position_covariance[0]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //navsat_llh.position_covariance[1]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //navsat_llh.position_covariance[2]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //navsat_llh.position_covariance[3]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //navsat_llh.position_covariance[4]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //navsat_llh.position_covariance[5]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //navsat_llh.position_covariance[6]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //navsat_llh.position_covariance[7]
+    output_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //navsat_llh.position_covariance[8]
     output_csv_file << std::setprecision(std::numeric_limits<int>::max_digits10) << int(gga_[i].gps_qual) << ","; //navsat_llh.gps_qual
     if(getUseCombination())
     {

--- a/eagleye_rt/README.md
+++ b/eagleye_rt/README.md
@@ -7,7 +7,7 @@ The parameters of eagleye_rt can be set in the [eagleye_config.yaml](https://git
 
 
 The TF between sensors can be set in [sensors_tf.yaml](https://github.com/MapIV/eagleye/blob/master/eagleye_util/tf/config/sensors_tf.yaml).
-The settings are reflected by describing the positional relationship of each sensor with respect to base_link. If you want to change the base frame, [change basic_parent_flame](https://github.com/MapIV/eagleye/blob/master/eagleye_util/tf/config/sensors_tf.yaml#L2) to reflect the change.
+The settings are reflected by describing the positional relationship of each sensor with respect to base_link. If you want to change the base frame, [change basic_parent_frame](https://github.com/MapIV/eagleye/blob/master/eagleye_util/tf/config/sensors_tf.yaml#L2) to reflect the change.
 
 ### Running real-time operation
 

--- a/eagleye_rt/config/eagleye_config.yaml
+++ b/eagleye_rt/config/eagleye_config.yaml
@@ -16,7 +16,7 @@ reverse_imu: false                                    # reverse imu angular_velo
 reverse_imu_angular_velocity_x: true                  # reverse imu angular_velocity.x
 reverse_imu_linear_acceleration_y: false              # reverse imu linear_acceleration.y
 
-tf_gnss_flame:
+tf_gnss_frame:
   parent: "base_link"
   child: "gnss"
 

--- a/eagleye_rt/src/position_interpolate_node.cpp
+++ b/eagleye_rt/src/position_interpolate_node.cpp
@@ -86,6 +86,10 @@ void enu_vel_callback(const geometry_msgs::Vector3Stamped::ConstPtr& msg)
     fix.latitude = _gga.lat;
     fix.longitude = _gga.lon;
     fix.altitude = _gga.alt + _gga.undulation;
+    // TODO(Map IV): temporary covariance value
+    fix.position_covariance[0] = 1.5 * 1.5; // [m^2]
+    fix.position_covariance[4] = 1.5 * 1.5; // [m^2]
+    fix.position_covariance[8] = 1.5 * 1.5; // [m^2]
     _pub2.publish(fix);
   }
 }

--- a/eagleye_rt/src/position_node.cpp
+++ b/eagleye_rt/src/position_node.cpp
@@ -79,7 +79,7 @@ void timer_callback(const ros::TimerEvent& e, tf2_ros::TransformListener* tfList
   geometry_msgs::TransformStamped transformStamped;
   try
   {
-    transformStamped = tfBuffer_->lookupTransform(_position_parameter.tf_gnss_parent_flame, _position_parameter.tf_gnss_child_flame, ros::Time(0));
+    transformStamped = tfBuffer_->lookupTransform(_position_parameter.tf_gnss_parent_frame, _position_parameter.tf_gnss_child_frame, ros::Time(0));
 
     _position_parameter.tf_gnss_translation_x = transformStamped.transform.translation.x;
     _position_parameter.tf_gnss_translation_y = transformStamped.transform.translation.y;
@@ -135,8 +135,8 @@ int main(int argc, char** argv)
   nh.getParam("ecef_base_pos/x",_position_parameter.ecef_base_pos_x);
   nh.getParam("ecef_base_pos/y",_position_parameter.ecef_base_pos_y);
   nh.getParam("ecef_base_pos/z",_position_parameter.ecef_base_pos_z);
-  nh.getParam("tf_gnss_flame/parent", _position_parameter.tf_gnss_parent_flame);
-  nh.getParam("tf_gnss_flame/child", _position_parameter.tf_gnss_child_flame);
+  nh.getParam("tf_gnss_frame/parent", _position_parameter.tf_gnss_parent_frame);
+  nh.getParam("tf_gnss_frame/child", _position_parameter.tf_gnss_child_frame);
   nh.getParam("use_gnss_mode",_use_gnss_mode);
 
   std::cout<< "subscribe_rtklib_nav_topic_name " << subscribe_rtklib_nav_topic_name << std::endl;
@@ -147,8 +147,8 @@ int main(int argc, char** argv)
   std::cout<< "outlier_threshold " << _position_parameter.outlier_threshold << std::endl;
   std::cout<< "estimated_enu_vel_coefficient " << _position_parameter.estimated_enu_vel_coefficient << std::endl;
   std::cout<< "estimated_position_coefficient " << _position_parameter.estimated_position_coefficient << std::endl;
-  std::cout<< "tf_gnss_flame/parent " << _position_parameter.tf_gnss_parent_flame << std::endl;
-  std::cout<< "tf_gnss_flame/child " << _position_parameter.tf_gnss_child_flame << std::endl;
+  std::cout<< "tf_gnss_frame/parent " << _position_parameter.tf_gnss_parent_frame << std::endl;
+  std::cout<< "tf_gnss_frame/child " << _position_parameter.tf_gnss_child_frame << std::endl;
   std::cout<< "use_gnss_mode " << _use_gnss_mode << std::endl;
 
   ros::Subscriber sub1 = nh.subscribe("enu_vel", 1000, enu_vel_callback, ros::TransportHints().tcpNoDelay());

--- a/eagleye_rt/src/rtk_deadreckoning_node.cpp
+++ b/eagleye_rt/src/rtk_deadreckoning_node.cpp
@@ -72,8 +72,8 @@ void timer_callback(const ros::TimerEvent& e, tf2_ros::TransformListener* tfList
   geometry_msgs::TransformStamped transformStamped;
   try
   {
-    transformStamped = tfBuffer_->lookupTransform(_rtk_deadreckoning_parameter.tf_gnss_parent_flame,
-                                                  _rtk_deadreckoning_parameter.tf_gnss_child_flame, ros::Time(0));
+    transformStamped = tfBuffer_->lookupTransform(_rtk_deadreckoning_parameter.tf_gnss_parent_frame,
+                                                  _rtk_deadreckoning_parameter.tf_gnss_child_frame, ros::Time(0));
 
     _rtk_deadreckoning_parameter.tf_gnss_translation_x = transformStamped.transform.translation.x;
     _rtk_deadreckoning_parameter.tf_gnss_translation_y = transformStamped.transform.translation.y;
@@ -136,8 +136,8 @@ int main(int argc, char** argv)
   nh.getParam("ecef_base_pos/z", _rtk_deadreckoning_parameter.ecef_base_pos_z);
   nh.getParam("ecef_base_pos/use_ecef_base_position", _rtk_deadreckoning_parameter.use_ecef_base_position);
   nh.getParam("rtk_deadreckoning/stop_judgment_velocity_threshold", _rtk_deadreckoning_parameter.stop_judgment_velocity_threshold);
-  nh.getParam("tf_gnss_flame/parent", _rtk_deadreckoning_parameter.tf_gnss_parent_flame);
-  nh.getParam("tf_gnss_flame/child", _rtk_deadreckoning_parameter.tf_gnss_child_flame);
+  nh.getParam("tf_gnss_frame/parent", _rtk_deadreckoning_parameter.tf_gnss_parent_frame);
+  nh.getParam("tf_gnss_frame/child", _rtk_deadreckoning_parameter.tf_gnss_child_frame);
   nh.getParam("use_gnss_mode",_use_gnss_mode);
 
   std::cout<< "subscribe_rtklib_nav_topic_name " << subscribe_rtklib_nav_topic_name << std::endl;
@@ -147,8 +147,8 @@ int main(int argc, char** argv)
   std::cout<< "ecef_base_pos_z " << _rtk_deadreckoning_parameter.ecef_base_pos_z << std::endl;
   std::cout<< "use_ecef_base_position " << _rtk_deadreckoning_parameter.use_ecef_base_position << std::endl;
   std::cout<< "stop_judgment_velocity_threshold " << _rtk_deadreckoning_parameter.stop_judgment_velocity_threshold << std::endl;
-  std::cout<< "tf_gnss_flame/parent " << _rtk_deadreckoning_parameter.tf_gnss_parent_flame << std::endl;
-  std::cout<< "tf_gnss_flame/child " << _rtk_deadreckoning_parameter.tf_gnss_child_flame << std::endl;
+  std::cout<< "tf_gnss_frame/parent " << _rtk_deadreckoning_parameter.tf_gnss_parent_frame << std::endl;
+  std::cout<< "tf_gnss_frame/child " << _rtk_deadreckoning_parameter.tf_gnss_child_frame << std::endl;
   std::cout<< "use_gnss_mode " << _use_gnss_mode << std::endl;
 
   ros::Subscriber sub1 = nh.subscribe(subscribe_rtklib_nav_topic_name, 1000, rtklib_nav_callback, ros::TransportHints().tcpNoDelay());

--- a/eagleye_util/fix2pose/src/fix2pose.cpp
+++ b/eagleye_util/fix2pose/src/fix2pose.cpp
@@ -130,19 +130,18 @@ void fix_callback(const sensor_msgs::NavSatFix::ConstPtr& msg)
   _pose_with_covariance.header = _pose.header;
   _pose_with_covariance.pose.pose = _pose.pose;
   // TODO(Map IV): temporary value
-  double std_dev_pos = 1.5; // [m]
   double std_dev_roll = 100; // [rad]
   double std_dev_pitch = 100; // [rad]
   double std_dev_yaw = 100; // [rad]
   if(_eagleye_rolling.status.enabled_status) std_dev_roll = 0.5 / 180 * M_PI;
   if(_eagleye_pitching.status.enabled_status) std_dev_pitch = 0.5 / 180 * M_PI;
   if(_eagleye_heading.status.enabled_status) std_dev_yaw = 0.2 / 180 * M_PI;
-  _pose_with_covariance.pose.covariance[0] = std_dev_pos;
-  _pose_with_covariance.pose.covariance[7] = std_dev_pos;
-  _pose_with_covariance.pose.covariance[14] = std_dev_pos;
-  _pose_with_covariance.pose.covariance[21] = std_dev_roll;
-  _pose_with_covariance.pose.covariance[28] = std_dev_pitch;
-  _pose_with_covariance.pose.covariance[35] = std_dev_yaw;
+  _pose_with_covariance.pose.covariance[0] = msg->position_covariance[0];
+  _pose_with_covariance.pose.covariance[7] = msg->position_covariance[7];
+  _pose_with_covariance.pose.covariance[14] = msg->position_covariance[14];
+  _pose_with_covariance.pose.covariance[21] = std_dev_roll * std_dev_roll;
+  _pose_with_covariance.pose.covariance[28] = std_dev_pitch * std_dev_pitch;
+  _pose_with_covariance.pose.covariance[35] = std_dev_yaw * std_dev_yaw;
   _pose_with_covariance_pub.publish(_pose_with_covariance);
 
   static tf::TransformBroadcaster br;

--- a/eagleye_util/fix2pose/src/fix2pose.cpp
+++ b/eagleye_util/fix2pose/src/fix2pose.cpp
@@ -137,8 +137,8 @@ void fix_callback(const sensor_msgs::NavSatFix::ConstPtr& msg)
   if(_eagleye_pitching.status.enabled_status) std_dev_pitch = 0.5 / 180 * M_PI;
   if(_eagleye_heading.status.enabled_status) std_dev_yaw = 0.2 / 180 * M_PI;
   _pose_with_covariance.pose.covariance[0] = msg->position_covariance[0];
-  _pose_with_covariance.pose.covariance[7] = msg->position_covariance[7];
-  _pose_with_covariance.pose.covariance[14] = msg->position_covariance[14];
+  _pose_with_covariance.pose.covariance[7] = msg->position_covariance[4];
+  _pose_with_covariance.pose.covariance[14] = msg->position_covariance[8];
   _pose_with_covariance.pose.covariance[21] = std_dev_roll * std_dev_roll;
   _pose_with_covariance.pose.covariance[28] = std_dev_pitch * std_dev_pitch;
   _pose_with_covariance.pose.covariance[35] = std_dev_yaw * std_dev_yaw;

--- a/eagleye_util/tf/config/sensors_tf.yaml
+++ b/eagleye_util/tf/config/sensors_tf.yaml
@@ -1,5 +1,5 @@
 
-basic_parent_flame: "base_link"
+basic_parent_frame: "base_link"
 
 base_link2imu:
   x: 0.0

--- a/eagleye_util/tf/urdf/sensors.xacro
+++ b/eagleye_util/tf/urdf/sensors.xacro
@@ -7,7 +7,7 @@
   <xacro:property name="size" value="1" />
 
   <!-- base_link -->
-  <link name="${calibration['basic_parent_flame']}">
+  <link name="${calibration['basic_parent_frame']}">
     <visual>
       <origin xyz="0 0 0" rpy="0 0 0"/>
       <geometry>
@@ -30,7 +30,7 @@
     </link>
   </xacro:macro>
 
-  <xacro:imu parent="${calibration['basic_parent_flame']}" x="${calibration['base_link2imu']['x']}" y="${calibration['base_link2imu']['y']}" z="${calibration['base_link2imu']['z']}" roll="${calibration['base_link2imu']['roll']}" pitch="${calibration['base_link2imu']['pitch']}" yaw="${calibration['base_link2imu']['yaw']}" />
+  <xacro:imu parent="${calibration['basic_parent_frame']}" x="${calibration['base_link2imu']['x']}" y="${calibration['base_link2imu']['y']}" z="${calibration['base_link2imu']['z']}" roll="${calibration['base_link2imu']['roll']}" pitch="${calibration['base_link2imu']['pitch']}" yaw="${calibration['base_link2imu']['yaw']}" />
 
   <!-- gnss -->
   <xacro:macro name="gnss" params="parent x y z roll pitch yaw">
@@ -46,7 +46,7 @@
     </link>
   </xacro:macro>
 
-  <xacro:gnss parent="${calibration['basic_parent_flame']}" x="${calibration['base_link2gnss']['x']}" y="${calibration['base_link2gnss']['y']}" z="${calibration['base_link2gnss']['z']}" roll="${calibration['base_link2gnss']['roll']}" pitch="${calibration['base_link2gnss']['pitch']}" yaw="${calibration['base_link2gnss']['yaw']}" />
+  <xacro:gnss parent="${calibration['basic_parent_frame']}" x="${calibration['base_link2gnss']['x']}" y="${calibration['base_link2gnss']['y']}" z="${calibration['base_link2gnss']['z']}" roll="${calibration['base_link2gnss']['roll']}" pitch="${calibration['base_link2gnss']['pitch']}" yaw="${calibration['base_link2gnss']['yaw']}" />
 
 
 </robot>


### PR DESCRIPTION
Added covarivance to eagleye.csv, the output of eagleye_pp, and eagleye/pose_with_covariance to eagleye_rt.
The covariance is not an exact value(For example, it is not recommended to put it in a Kalman filter). It is large when estimation has not started.

The attitude angle value is switched by enable_status of the corresponding message(eagleye_rolling, eagleye_pitchng, _eagleye_heading) in eagleye_msgs.