### PR TITLE
Fix/csv output about for analysis scripts

### DIFF
--- a/eagleye_core/navigation/src/rtk_heading.cpp
+++ b/eagleye_core/navigation/src/rtk_heading.cpp
@@ -91,7 +91,7 @@ void rtk_heading_estimate(nmea_msgs::Gpgga gga,sensor_msgs::Imu imu,eagleye_msgs
   double gga_length;
   gga_length = std::distance(heading_status->gga_status_buffer.begin(), heading_status->gga_status_buffer.end());
 
-  if (heading_status->gga_status_buffer[0] == 0 && heading_status->gga_status_buffer[gga_length-1] == 0 &&
+  if (heading_status->gga_status_buffer[0] == 4 && heading_status->gga_status_buffer[gga_length-1] == 4 &&
     abs(yawrate) < heading_parameter.estimated_yawrate_threshold)
   {
     tmp_llh[0] = heading_status->latitude_buffer[0] *M_PI/180;

--- a/eagleye_pp/eagleye_pp/src/eagleye_pp_output.cpp
+++ b/eagleye_pp/eagleye_pp/src/eagleye_pp_output.cpp
@@ -344,94 +344,94 @@ void eagleye_pp::writeDetailCSVOneWay(std::ofstream* output_log_csv_file, const 
       *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << velocity_[i].twist.angular.x << ",";
       *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << velocity_[i].twist.angular.y << ",";
       *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << velocity_[i].twist.angular.z << ",";
-      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.velocity_scale_factor[i].scale_factor << ",";
+      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state.velocity_scale_factor[i].scale_factor << ",";
       *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) <<
-        eagleye_state_forward_.velocity_scale_factor[i].correction_velocity.linear.x << ",";
+        eagleye_state.velocity_scale_factor[i].correction_velocity.linear.x << ",";
       *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) <<
-        eagleye_state_forward_.velocity_scale_factor[i].correction_velocity.linear.y << ",";
+        eagleye_state.velocity_scale_factor[i].correction_velocity.linear.y << ",";
       *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) <<
-        eagleye_state_forward_.velocity_scale_factor[i].correction_velocity.linear.z << ",";
+        eagleye_state.velocity_scale_factor[i].correction_velocity.linear.z << ",";
       *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) <<
-        eagleye_state_forward_.velocity_scale_factor[i].correction_velocity.angular.x << ",";
+        eagleye_state.velocity_scale_factor[i].correction_velocity.angular.x << ",";
       *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) <<
-        eagleye_state_forward_.velocity_scale_factor[i].correction_velocity.angular.y << ",";
+        eagleye_state.velocity_scale_factor[i].correction_velocity.angular.y << ",";
       *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) <<
-        eagleye_state_forward_.velocity_scale_factor[i].correction_velocity.angular.z << ",";
-      *output_log_csv_file << (eagleye_state_forward_.velocity_scale_factor[i].status.enabled_status ? "1" : "0") << ",";
-      *output_log_csv_file << (eagleye_state_forward_.velocity_scale_factor[i].status.estimate_status ? "1" : "0") << ",";
-      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.distance[i].distance << ",";
-      *output_log_csv_file << (eagleye_state_forward_.distance[i].status.enabled_status ? "1" : "0") << ",";
-      *output_log_csv_file << (eagleye_state_forward_.distance[i].status.estimate_status ? "1" : "0") << ",";
-      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.heading_1st[i].heading_angle << ",";
-      *output_log_csv_file << (eagleye_state_forward_.heading_1st[i].status.enabled_status ? "1" : "0") << ",";
-      *output_log_csv_file << (eagleye_state_forward_.heading_1st[i].status.estimate_status ? "1" : "0") << ",";
-      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.heading_interpolate_1st[i].heading_angle << ",";
-      *output_log_csv_file << (eagleye_state_forward_.heading_interpolate_1st[i].status.enabled_status ? "1" : "0") << ",";
-      *output_log_csv_file << (eagleye_state_forward_.heading_interpolate_1st[i].status.estimate_status ? "1" : "0") << ",";
-      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.heading_2nd[i].heading_angle << ",";
-      *output_log_csv_file << (eagleye_state_forward_.heading_2nd[i].status.enabled_status ? "1" : "0") << ",";
-      *output_log_csv_file << (eagleye_state_forward_.heading_2nd[i].status.estimate_status ? "1" : "0") << ",";
-      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.heading_interpolate_2nd[i].heading_angle << ",";
-      *output_log_csv_file << (eagleye_state_forward_.heading_interpolate_2nd[i].status.enabled_status ? "1" : "0") << ",";
-      *output_log_csv_file << (eagleye_state_forward_.heading_interpolate_2nd[i].status.estimate_status ? "1" : "0") << ",";
-      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.heading_3rd[i].heading_angle << ",";
-      *output_log_csv_file << (eagleye_state_forward_.heading_3rd[i].status.enabled_status ? "1" : "0") << ",";
-      *output_log_csv_file << (eagleye_state_forward_.heading_3rd[i].status.estimate_status ? "1" : "0") << ",";
-      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.heading_interpolate_3rd[i].heading_angle << ",";
-      *output_log_csv_file << (eagleye_state_forward_.heading_interpolate_3rd[i].status.enabled_status ? "1" : "0") << ",";
-      *output_log_csv_file << (eagleye_state_forward_.heading_interpolate_3rd[i].status.estimate_status ? "1" : "0") << ",";
-      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.yawrate_offset_stop[i].yawrate_offset << ",";
-      *output_log_csv_file << (eagleye_state_forward_.yawrate_offset_stop[i].status.enabled_status ? "1" : "0") << ",";
-      *output_log_csv_file << (eagleye_state_forward_.yawrate_offset_stop[i].status.estimate_status ? "1" : "0") << ",";
-      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.yawrate_offset_1st[i].yawrate_offset << ",";
-      *output_log_csv_file << (eagleye_state_forward_.yawrate_offset_1st[i].status.enabled_status ? "1" : "0") << ",";
-      *output_log_csv_file << (eagleye_state_forward_.yawrate_offset_1st[i].status.estimate_status ? "1" : "0") << ",";
-      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.yawrate_offset_2nd[i].yawrate_offset << ",";
-      *output_log_csv_file << (eagleye_state_forward_.yawrate_offset_2nd[i].status.enabled_status ? "1" : "0") << ",";
-      *output_log_csv_file << (eagleye_state_forward_.yawrate_offset_2nd[i].status.estimate_status ? "1" : "0") << ",";
-      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.slip_angle[i].coefficient << ",";
-      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.slip_angle[i].slip_angle << ",";
-      *output_log_csv_file << (eagleye_state_forward_.slip_angle[i].status.enabled_status ? "1" : "0") << ",";
-      *output_log_csv_file << (eagleye_state_forward_.slip_angle[i].status.estimate_status ? "1" : "0") << ",";
-      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.enu_vel[i].vector.x << ",";
-      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.enu_vel[i].vector.y << ",";
-      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.enu_vel[i].vector.z << ",";
-      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.enu_absolute_pos[i].enu_pos.x << ",";
-      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.enu_absolute_pos[i].enu_pos.y << ",";
-      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.enu_absolute_pos[i].enu_pos.z << ",";
-      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.enu_absolute_pos[i].ecef_base_pos.x << ",";
-      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.enu_absolute_pos[i].ecef_base_pos.y << ",";
-      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.enu_absolute_pos[i].ecef_base_pos.z << ",";
-      *output_log_csv_file << (eagleye_state_forward_.enu_absolute_pos[i].status.enabled_status ? "1" : "0") << ",";
-      *output_log_csv_file << (eagleye_state_forward_.enu_absolute_pos[i].status.estimate_status ? "1" : "0") << ",";
-      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.enu_absolute_pos_interpolate[i].enu_pos.x << ",";
-      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.enu_absolute_pos_interpolate[i].enu_pos.y << ",";
-      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.enu_absolute_pos_interpolate[i].enu_pos.z << ",";
-      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.enu_absolute_pos_interpolate[i].ecef_base_pos.x << ",";
-      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.enu_absolute_pos_interpolate[i].ecef_base_pos.y << ",";
-      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.enu_absolute_pos_interpolate[i].ecef_base_pos.z << ",";
-      *output_log_csv_file << (eagleye_state_forward_.enu_absolute_pos_interpolate[i].status.enabled_status ? "1" : "0") << ",";
-      *output_log_csv_file << (eagleye_state_forward_.enu_absolute_pos_interpolate[i].status.estimate_status ? "1" : "0") << ",";
-      // *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.angular_velocity_offset_stop.rollrate_offset << ",";
-      // *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.angular_velocity_offset_stop.pitchrate_offset << ",";
-      // *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.angular_velocity_offset_stop.yawrate_offset << ",";
-      // *output_log_csv_file << (eagleye_state_forward_.angular_velocity_offset_stop.status.enabled_status ? "1" : "0") << ",";
-      // *output_log_csv_file << (eagleye_state_forward_.angular_velocity_offset_stop.status.estimate_status ? "1" : "0") << ",";
-      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.height[i].height << ",";
-      *output_log_csv_file << (eagleye_state_forward_.height[i].status.enabled_status ? "1" : "0") << ",";
-      *output_log_csv_file << (eagleye_state_forward_.height[i].status.estimate_status ? "1" : "0") << ",";
-      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.pitching[i].pitching_angle << ",";
-      *output_log_csv_file << (eagleye_state_forward_.pitching[i].status.enabled_status ? "1" : "0") << ",";
-      *output_log_csv_file << (eagleye_state_forward_.pitching[i].status.estimate_status ? "1" : "0") << ",";
-      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.acc_x_offset[i].acc_x_offset << ",";
-      *output_log_csv_file << (eagleye_state_forward_.acc_x_offset[i].status.enabled_status ? "1" : "0") << ",";
-      *output_log_csv_file << (eagleye_state_forward_.acc_x_offset[i].status.estimate_status ? "1" : "0") << ",";
-      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.acc_x_scale_factor[i].acc_x_scale_factor << ",";
-      *output_log_csv_file << (eagleye_state_forward_.acc_x_scale_factor[i].status.enabled_status ? "1" : "0") << ",";
-      *output_log_csv_file << (eagleye_state_forward_.acc_x_scale_factor[i].status.estimate_status ? "1" : "0") << ",";
-      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.rolling[i].rolling_angle << ",";
-      *output_log_csv_file << (eagleye_state_forward_.rolling[i].status.enabled_status ? "1" : "0") << ",";
-      *output_log_csv_file << (eagleye_state_forward_.rolling[i].status.estimate_status ? "1" : "0") << ",";
+        eagleye_state.velocity_scale_factor[i].correction_velocity.angular.z << ",";
+      *output_log_csv_file << (eagleye_state.velocity_scale_factor[i].status.enabled_status ? "1" : "0") << ",";
+      *output_log_csv_file << (eagleye_state.velocity_scale_factor[i].status.estimate_status ? "1" : "0") << ",";
+      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state.distance[i].distance << ",";
+      *output_log_csv_file << (eagleye_state.distance[i].status.enabled_status ? "1" : "0") << ",";
+      *output_log_csv_file << (eagleye_state.distance[i].status.estimate_status ? "1" : "0") << ",";
+      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state.heading_1st[i].heading_angle << ",";
+      *output_log_csv_file << (eagleye_state.heading_1st[i].status.enabled_status ? "1" : "0") << ",";
+      *output_log_csv_file << (eagleye_state.heading_1st[i].status.estimate_status ? "1" : "0") << ",";
+      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state.heading_interpolate_1st[i].heading_angle << ",";
+      *output_log_csv_file << (eagleye_state.heading_interpolate_1st[i].status.enabled_status ? "1" : "0") << ",";
+      *output_log_csv_file << (eagleye_state.heading_interpolate_1st[i].status.estimate_status ? "1" : "0") << ",";
+      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state.heading_2nd[i].heading_angle << ",";
+      *output_log_csv_file << (eagleye_state.heading_2nd[i].status.enabled_status ? "1" : "0") << ",";
+      *output_log_csv_file << (eagleye_state.heading_2nd[i].status.estimate_status ? "1" : "0") << ",";
+      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state.heading_interpolate_2nd[i].heading_angle << ",";
+      *output_log_csv_file << (eagleye_state.heading_interpolate_2nd[i].status.enabled_status ? "1" : "0") << ",";
+      *output_log_csv_file << (eagleye_state.heading_interpolate_2nd[i].status.estimate_status ? "1" : "0") << ",";
+      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state.heading_3rd[i].heading_angle << ",";
+      *output_log_csv_file << (eagleye_state.heading_3rd[i].status.enabled_status ? "1" : "0") << ",";
+      *output_log_csv_file << (eagleye_state.heading_3rd[i].status.estimate_status ? "1" : "0") << ",";
+      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state.heading_interpolate_3rd[i].heading_angle << ",";
+      *output_log_csv_file << (eagleye_state.heading_interpolate_3rd[i].status.enabled_status ? "1" : "0") << ",";
+      *output_log_csv_file << (eagleye_state.heading_interpolate_3rd[i].status.estimate_status ? "1" : "0") << ",";
+      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state.yawrate_offset_stop[i].yawrate_offset << ",";
+      *output_log_csv_file << (eagleye_state.yawrate_offset_stop[i].status.enabled_status ? "1" : "0") << ",";
+      *output_log_csv_file << (eagleye_state.yawrate_offset_stop[i].status.estimate_status ? "1" : "0") << ",";
+      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state.yawrate_offset_1st[i].yawrate_offset << ",";
+      *output_log_csv_file << (eagleye_state.yawrate_offset_1st[i].status.enabled_status ? "1" : "0") << ",";
+      *output_log_csv_file << (eagleye_state.yawrate_offset_1st[i].status.estimate_status ? "1" : "0") << ",";
+      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state.yawrate_offset_2nd[i].yawrate_offset << ",";
+      *output_log_csv_file << (eagleye_state.yawrate_offset_2nd[i].status.enabled_status ? "1" : "0") << ",";
+      *output_log_csv_file << (eagleye_state.yawrate_offset_2nd[i].status.estimate_status ? "1" : "0") << ",";
+      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state.slip_angle[i].coefficient << ",";
+      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state.slip_angle[i].slip_angle << ",";
+      *output_log_csv_file << (eagleye_state.slip_angle[i].status.enabled_status ? "1" : "0") << ",";
+      *output_log_csv_file << (eagleye_state.slip_angle[i].status.estimate_status ? "1" : "0") << ",";
+      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state.enu_vel[i].vector.x << ",";
+      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state.enu_vel[i].vector.y << ",";
+      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state.enu_vel[i].vector.z << ",";
+      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state.enu_absolute_pos[i].enu_pos.x << ",";
+      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state.enu_absolute_pos[i].enu_pos.y << ",";
+      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state.enu_absolute_pos[i].enu_pos.z << ",";
+      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state.enu_absolute_pos[i].ecef_base_pos.x << ",";
+      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state.enu_absolute_pos[i].ecef_base_pos.y << ",";
+      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state.enu_absolute_pos[i].ecef_base_pos.z << ",";
+      *output_log_csv_file << (eagleye_state.enu_absolute_pos[i].status.enabled_status ? "1" : "0") << ",";
+      *output_log_csv_file << (eagleye_state.enu_absolute_pos[i].status.estimate_status ? "1" : "0") << ",";
+      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state.enu_absolute_pos_interpolate[i].enu_pos.x << ",";
+      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state.enu_absolute_pos_interpolate[i].enu_pos.y << ",";
+      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state.enu_absolute_pos_interpolate[i].enu_pos.z << ",";
+      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state.enu_absolute_pos_interpolate[i].ecef_base_pos.x << ",";
+      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state.enu_absolute_pos_interpolate[i].ecef_base_pos.y << ",";
+      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state.enu_absolute_pos_interpolate[i].ecef_base_pos.z << ",";
+      *output_log_csv_file << (eagleye_state.enu_absolute_pos_interpolate[i].status.enabled_status ? "1" : "0") << ",";
+      *output_log_csv_file << (eagleye_state.enu_absolute_pos_interpolate[i].status.estimate_status ? "1" : "0") << ",";
+      // *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state.angular_velocity_offset_stop.rollrate_offset << ",";
+      // *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state.angular_velocity_offset_stop.pitchrate_offset << ",";
+      // *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state.angular_velocity_offset_stop.yawrate_offset << ",";
+      // *output_log_csv_file << (eagleye_state.angular_velocity_offset_stop.status.enabled_status ? "1" : "0") << ",";
+      // *output_log_csv_file << (eagleye_state.angular_velocity_offset_stop.status.estimate_status ? "1" : "0") << ",";
+      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state.height[i].height << ",";
+      *output_log_csv_file << (eagleye_state.height[i].status.enabled_status ? "1" : "0") << ",";
+      *output_log_csv_file << (eagleye_state.height[i].status.estimate_status ? "1" : "0") << ",";
+      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state.pitching[i].pitching_angle << ",";
+      *output_log_csv_file << (eagleye_state.pitching[i].status.enabled_status ? "1" : "0") << ",";
+      *output_log_csv_file << (eagleye_state.pitching[i].status.estimate_status ? "1" : "0") << ",";
+      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state.acc_x_offset[i].acc_x_offset << ",";
+      *output_log_csv_file << (eagleye_state.acc_x_offset[i].status.enabled_status ? "1" : "0") << ",";
+      *output_log_csv_file << (eagleye_state.acc_x_offset[i].status.estimate_status ? "1" : "0") << ",";
+      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state.acc_x_scale_factor[i].acc_x_scale_factor << ",";
+      *output_log_csv_file << (eagleye_state.acc_x_scale_factor[i].status.enabled_status ? "1" : "0") << ",";
+      *output_log_csv_file << (eagleye_state.acc_x_scale_factor[i].status.estimate_status ? "1" : "0") << ",";
+      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state.rolling[i].rolling_angle << ",";
+      *output_log_csv_file << (eagleye_state.rolling[i].status.enabled_status ? "1" : "0") << ",";
+      *output_log_csv_file << (eagleye_state.rolling[i].status.estimate_status ? "1" : "0") << ",";
       *output_log_csv_file << std::setprecision(std::numeric_limits<int>::max_digits10) << gga_[i].header.stamp.toNSec() << ","; // timestamp
       *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << gga_[i].lat << ","; // gga_llh.latitude
       *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << gga_[i].lon << ","; // gga_llh.longitude
@@ -445,9 +445,9 @@ void eagleye_pp::writeDetailCSVOneWay(std::ofstream* output_log_csv_file, const 
       }
       else
       {
-        *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_pp_llh.latitude
-        *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_pp_llh.longitude
-        *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_pp_llh.altitude     
+        *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state.eagleye_fix[i].latitude << ","; // eagleye_pp_llh.latitude
+        *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state.eagleye_fix[i].longitude << ","; // eagleye_pp_llh.longitude
+        *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state.eagleye_fix[i].altitude << ","; // eagleye_pp_llh.altitude     
       }
       *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_pp_llh.orientation_covariance[0]
       *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // eagleye_pp_llh.orientation_covariance[1]
@@ -466,11 +466,11 @@ void eagleye_pp::writeDetailCSVOneWay(std::ofstream* output_log_csv_file, const 
       {
         *output_log_csv_file << std::setprecision(std::numeric_limits<int>::max_digits10) << 0 << ","; // eagleye_pp_llh.status    
       }
-      *output_log_csv_file << std::setprecision(std::numeric_limits<int>::max_digits10) << eagleye_state_forward_.flag_reliability_buffer[i] << ","; // eagleye_pp_llh.status
-      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.enu_relative_pos[i].enu_pos.x << ",";
-      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.enu_relative_pos[i].enu_pos.y << ",";
-      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state_forward_.enu_relative_pos[i].enu_pos.z << ",";
-      *output_log_csv_file << (eagleye_state_forward_.enu_relative_pos[i].status.enabled_status ? "1" : "0");
+      *output_log_csv_file << std::setprecision(std::numeric_limits<int>::max_digits10) << eagleye_state.flag_reliability_buffer[i] << ","; // eagleye_pp_llh.status
+      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state.enu_relative_pos[i].enu_pos.x << ",";
+      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state.enu_relative_pos[i].enu_pos.y << ",";
+      *output_log_csv_file << std::setprecision(std::numeric_limits<double>::max_digits10) << eagleye_state.enu_relative_pos[i].enu_pos.z << ",";
+      *output_log_csv_file << (eagleye_state.enu_relative_pos[i].status.enabled_status ? "1" : "0");
       *output_log_csv_file << "\n";
     }
 }

--- a/eagleye_rt/src/monitor_node.cpp
+++ b/eagleye_rt/src/monitor_node.cpp
@@ -1023,6 +1023,7 @@ int main(int argc, char** argv)
   n.getParam("twist_topic",subscribe_twist_topic_name);
   n.getParam("imu_topic",subscribe_imu_topic_name);
   n.getParam("rtklib_nav_topic",subscribe_rtklib_nav_topic_name);
+  n.getParam("gga_topic",subscribe_gga_topic_name)
   n.getParam("monitor/print_status",_print_status);
   n.getParam("monitor/log_output_status",_log_output_status);
   n.getParam("monitor/update_rate",_update_rate);

--- a/eagleye_rt/src/monitor_node.cpp
+++ b/eagleye_rt/src/monitor_node.cpp
@@ -1023,7 +1023,7 @@ int main(int argc, char** argv)
   n.getParam("twist_topic",subscribe_twist_topic_name);
   n.getParam("imu_topic",subscribe_imu_topic_name);
   n.getParam("rtklib_nav_topic",subscribe_rtklib_nav_topic_name);
-  n.getParam("gga_topic",subscribe_gga_topic_name)
+  n.getParam("gga_topic",subscribe_gga_topic_name);
   n.getParam("monitor/print_status",_print_status);
   n.getParam("monitor/log_output_status",_log_output_status);
   n.getParam("monitor/update_rate",_update_rate);

--- a/eagleye_util/fix2pose/src/fix2pose.cpp
+++ b/eagleye_util/fix2pose/src/fix2pose.cpp
@@ -42,7 +42,6 @@
 static eagleye_msgs::Rolling _eagleye_rolling;
 static eagleye_msgs::Pitching _eagleye_pitching;
 static eagleye_msgs::Heading _eagleye_heading;
-static eagleye_msgs::Position _eagleye_position;
 static geometry_msgs::Quaternion _quat;
 
 static ros::Publisher _pose_pub, _pose_with_covariance_pub;
@@ -69,11 +68,6 @@ void rolling_callback(const eagleye_msgs::Rolling::ConstPtr& msg)
 void pitching_callback(const eagleye_msgs::Pitching::ConstPtr& msg)
 {
   _eagleye_pitching = *msg;
-}
-
-void position_callback(const eagleye_msgs::Position::ConstPtr& msg)
-{
-  _eagleye_position = *msg;
 }
 
 void fix_callback(const sensor_msgs::NavSatFix::ConstPtr& msg)
@@ -171,10 +165,9 @@ int main(int argc, char** argv)
   std::cout<< "child_frame_id " << _child_frame_id << std::endl;
 
   ros::Subscriber sub1 = nh.subscribe("eagleye/heading_interpolate_3rd", 1000, heading_callback);
-  ros::Subscriber sub2 = nh.subscribe("eagleye/enu_absolute_pos_interpolate", 1000, position_callback);
-  ros::Subscriber sub3 = nh.subscribe("eagleye/fix", 1000, fix_callback);
-  ros::Subscriber sub4 = nh.subscribe("eagleye/rolling", 1000, rolling_callback);
-  ros::Subscriber sub5 = nh.subscribe("eagleye/pitching", 1000, pitching_callback);
+  ros::Subscriber sub2 = nh.subscribe("eagleye/fix", 1000, fix_callback);
+  ros::Subscriber sub3 = nh.subscribe("eagleye/rolling", 1000, rolling_callback);
+  ros::Subscriber sub4 = nh.subscribe("eagleye/pitching", 1000, pitching_callback);
   _pose_pub = nh.advertise<geometry_msgs::PoseStamped>("/eagleye/pose", 1000);
   _pose_with_covariance_pub = nh.advertise<geometry_msgs::PoseWithCovarianceStamped>("/eagleye/pose_with_covariance", 1000);
   ros::spin();


### PR DESCRIPTION
This fix resolves a problem with eagleye_util/trajectory_plot/scripts/eagleye_pp_single_evaluation.py not working.

The following bugs have also been fixed.
・There is an unused subscriber in fix2pose.cpp.
・Satellite quality used in rtk_heading.cpp is wrong.
・n.getParam("gga_topic",subscribe_gga_topic_name);" in monitor_node is missing.