### PR TITLE
Fix rmc config

### DIFF
--- a/eagleye_rt/config/eagleye_config.yaml
+++ b/eagleye_rt/config/eagleye_config.yaml
@@ -9,7 +9,6 @@ twist_topic: /can_twist
 imu_topic: /imu/data_raw
 rtklib_nav_topic: /rtklib_nav
 nmea_sentence_topic: /nmea_sentence
-gga_topic: /navsat/gga
 localization_pose_topic: /localization/pose # This parameter is used to input external poses such as map matching to eagleye. (Normally it is not used.)
 
 #Parameter settings for Eagleye

--- a/eagleye_rt/src/heading_node.cpp
+++ b/eagleye_rt/src/heading_node.cpp
@@ -126,7 +126,7 @@ int main(int argc, char** argv)
   ros::NodeHandle nh;
 
   std::string subscribe_rtklib_nav_topic_name = "/rtklib_nav";
-  std::string subscribe_rmc_topic_name = "/mosaic/rmc";
+  std::string subscribe_rmc_topic_name = "/navsat/rmc";
 
   nh.getParam("rtklib_nav_topic",subscribe_rtklib_nav_topic_name);
   nh.getParam("rmc_topic",subscribe_rmc_topic_name);

--- a/eagleye_rt/src/velocity_scale_factor_node.cpp
+++ b/eagleye_rt/src/velocity_scale_factor_node.cpp
@@ -163,7 +163,7 @@ int main(int argc, char** argv)
   std::string subscribe_twist_topic_name = "/can_twist";
   std::string subscribe_imu_topic_name = "/imu/data_raw";
   std::string subscribe_rtklib_nav_topic_name = "/rtklib_nav";
-  std::string subscribe_rmc_topic_name = "/mosaic/rmc";
+  std::string subscribe_rmc_topic_name = "/navsat/rmc";
 
   double velocity_scale_factor_save_duration; // [sec]
 

--- a/eagleye_util/nmea2fix/launch/nmea2fix.launch
+++ b/eagleye_util/nmea2fix/launch/nmea2fix.launch
@@ -8,7 +8,7 @@
   <arg name="pub_gga_topic_name" default="/navsat/gga"/>
   <arg name="pub_rmc_topic_name" default="/navsat/rmc"/>
   <arg name="output_gga" default="true"/>
-  <arg name="output_rmc" default="false"/>
+  <arg name="output_rmc" default="true"/>
 
   <node pkg="eagleye_nmea2fix" name="nmea2fix_node" type="nmea2fix_node" output="screen">
     <param name="pub_fix_topic_name" value="$(arg pub_fix_topic_name)"/>


### PR DESCRIPTION
Fixed a problem that the mode using NMEA RMC speed (use_gnss_mode: NMEA in eagleye_rt/config/eagleye_config.yaml) instead of /rtklib_nav does not work well with default settings