### PR TITLE
Add rtk_deadreckoning emergency

### DIFF
--- a/eagleye_rt/config/eagleye_config.yaml
+++ b/eagleye_rt/config/eagleye_config.yaml
@@ -170,3 +170,5 @@ monitor:
   comparison_twist_topic: /calculated_twist
   th_diff_rad_per_sec: 0.17453                      #Threshold of difference from comparison twist yaw rate(0.17453 rad/s = 10 degree/s)
   th_num_continuous_abnormal_yawrate: 25            #Threshold for consecutive abnormal values in comparison twist
+  th_dr_distance: 50.0                              #In rtk dead reckoning mode, if the distance traveled for this parameter in RTK no fix,
+                                                    #an emergency will be output. [m]

--- a/eagleye_rt/launch/eagleye_calibration.launch
+++ b/eagleye_rt/launch/eagleye_calibration.launch
@@ -10,6 +10,7 @@
     <arg name="use_rtk_heading" default="false"/>
 
     <rosparam command="load" file="$(find eagleye_rt)/config/eagleye_config.yaml"/>
+    <param name="use_rtk_deadreckoning" value="$(arg use_rtk_deadreckoning)"/>
     
     <node pkg="eagleye_rt" name="velocity_scale_factor_node" type="velocity_scale_factor" />
     <node pkg="eagleye_rt" name="yawrate_offset_stop_node" type="yawrate_offset_stop" />

--- a/eagleye_rt/launch/eagleye_rt.launch
+++ b/eagleye_rt/launch/eagleye_rt.launch
@@ -11,6 +11,7 @@
     <arg name="enable_additional_rolling" default="false"/>
 
     <param name ="velocity_scale_factor_save_str" value="$(find eagleye_rt)/config/velocity_scale_factor.txt"/>
+    <param name="use_rtk_deadreckoning" value="$(arg use_rtk_deadreckoning)"/>
 
     <rosparam command="load" file="$(find eagleye_rt)/config/eagleye_config.yaml"/>
 

--- a/eagleye_rt/launch/eagleye_rt_canless.launch
+++ b/eagleye_rt/launch/eagleye_rt_canless.launch
@@ -14,6 +14,7 @@
 
     <param name="yaml_file" value="$(arg yaml_file)"/>
     <param name="use_canless_mode" value="$(arg use_canless_mode)"/>
+    <param name="use_rtk_deadreckoning" value="$(arg use_rtk_deadreckoning)"/>
 
     <rosparam command="load" file="$(arg yaml_file)"/>
 

--- a/eagleye_rt/src/monitor_node.cpp
+++ b/eagleye_rt/src/monitor_node.cpp
@@ -39,11 +39,11 @@
 static sensor_msgs::Imu _imu;
 static rtklib_msgs::RtklibNav _rtklib_nav;
 static sensor_msgs::NavSatFix _rtklib_fix;
-static nmea_msgs::Gpgga _gga;
+static nmea_msgs::Gpgga::ConstPtr _gga_ptr;
 static geometry_msgs::TwistStamped _velocity;
 static geometry_msgs::TwistStamped _correction_velocity;
 static eagleye_msgs::VelocityScaleFactor _velocity_scale_factor;
-static eagleye_msgs::Distance _distance;
+eagleye_msgs::Distance::ConstPtr _distance_ptr;
 static eagleye_msgs::Heading _heading_1st;
 static eagleye_msgs::Heading _heading_interpolate_1st;
 static eagleye_msgs::Heading _heading_2nd;
@@ -98,9 +98,14 @@ bool _use_compare_yawrate = false;
 double _update_rate = 10.0;
 double _th_gnss_deadrock_time = 10;
 double _th_velocity_scale_factor_percent = 20;
-double _th_diff_rad_per_sec = 0.17453;
+double _th_diff_rad_per_sec = 0.17453; // [rad/sec]
 int _num_continuous_abnormal_yawrate = 0;
 int _th_num_continuous_abnormal_yawrate = 10;
+
+bool _use_rtk_deadreckoning = false;
+eagleye_msgs::Distance _previous_distance;
+double _dr_distance = 0; // dead reckoning distance
+double _th_dr_distance = 100.0; // [m]
 
 void rtklib_nav_callback(const rtklib_msgs::RtklibNav::ConstPtr& msg)
 {
@@ -114,7 +119,7 @@ void rtklib_fix_callback(const sensor_msgs::NavSatFix::ConstPtr& msg)
 
 void navsatfix_gga_callback(const nmea_msgs::Gpgga::ConstPtr& msg)
 {
-  _gga = *msg;
+  _gga_ptr = msg;
   _gga_sub_status = true;
 }
 
@@ -135,7 +140,14 @@ void velocity_scale_factor_callback(const eagleye_msgs::VelocityScaleFactor::Con
 
 void distance_callback(const eagleye_msgs::Distance::ConstPtr& msg)
 {
-  _distance = *msg;
+  if (_distance_ptr != nullptr && _gga_ptr != nullptr){
+    double delta_distance = _distance_ptr->distance - _previous_distance.distance;
+    _dr_distance += delta_distance;
+    if(int(_gga_ptr->gps_qual) == 4) {
+      _dr_distance = 0;
+    }
+  }
+  _distance_ptr = msg;
 }
 
 void heading_1st_callback(const eagleye_msgs::Heading::ConstPtr& msg)
@@ -276,12 +288,12 @@ void navsat_fix_topic_checker(diagnostic_updater::DiagnosticStatusWrapper & stat
   int8_t level = diagnostic_msgs::DiagnosticStatus::OK;
   std::string msg = "OK";
 
-  if (_navsat_gga_time_last - _gga.header.stamp.toSec() > _th_gnss_deadrock_time || !_gga_sub_status) {
+  if (_gga_ptr == nullptr ||  _navsat_gga_time_last - _gga_ptr->header.stamp.toSec() > _th_gnss_deadrock_time || !_gga_sub_status) {
     level = diagnostic_msgs::DiagnosticStatus::WARN;
     msg = "not subscribed to topic";
   }
 
-  _navsat_gga_time_last = _gga.header.stamp.toSec();
+  if (_gga_ptr != nullptr)  _navsat_gga_time_last = _gga_ptr->header.stamp.toSec();
   stat.summary(level, msg);
 }
 
@@ -330,20 +342,20 @@ void distance_topic_checker(diagnostic_updater::DiagnosticStatusWrapper & stat)
   int8_t level = diagnostic_msgs::DiagnosticStatus::OK;
   std::string msg = "OK";
 
-  if (_distance_time_last == _distance.header.stamp.toSec()) {
+  if (_distance_ptr == nullptr || _distance_time_last == _distance_ptr->header.stamp.toSec()) {
     level = diagnostic_msgs::DiagnosticStatus::WARN;
     msg = "not subscribed to topic";
   }
-  else if (!std::isfinite(_distance.distance)) {
+  else if (!std::isfinite(_distance_ptr->distance)) {
     level = diagnostic_msgs::DiagnosticStatus::ERROR;
     msg = "invalid number";
   }
-  else if (!_distance.status.enabled_status) {
+  else if (!_distance_ptr->status.enabled_status) {
     level = diagnostic_msgs::DiagnosticStatus::WARN;
     msg = "estimates have not started yet";
   }
 
-  _distance_time_last = _distance.header.stamp.toSec();
+  if (_distance_ptr != nullptr) _distance_time_last = _distance_ptr->header.stamp.toSec();
   stat.summary(level, msg);
 }
 
@@ -722,6 +734,21 @@ void corrected_imu_topic_checker(diagnostic_updater::DiagnosticStatusWrapper & s
   stat.summary(level, msg);
 }
 
+void dr_distance_checker(diagnostic_updater::DiagnosticStatusWrapper & stat)
+{
+  int8_t level = diagnostic_msgs::DiagnosticStatus::OK;
+  std::string msg = "OK";
+
+  if(_th_dr_distance < _dr_distance)
+  {
+    level = diagnostic_msgs::DiagnosticStatus::ERROR;
+    msg = "The dead reckoning interval is too large";
+  }
+
+  stat.summary(level, msg);
+
+}
+
 void printStatus(void)
 {
   std::cout << std::endl;
@@ -753,11 +780,11 @@ void printStatus(void)
 
   if(_gga_sub_status)
   {
-    std::cout<< "\033[1m rtk status \033[m "<<int(_gga.gps_qual)<<std::endl;
-    std::cout<< "\033[1m rtk status \033[m "<<(int(_gga.gps_qual)!=4 ? "\033[1;31mNo Fix\033[m" : "\033[1;32mFix\033[m")<<std::endl;
-    std::cout<<"\033[1m latitude  \033[m"<<std::setprecision(8)<<_gga.lat<<" [deg]"<<std::endl;
-    std::cout<<"\033[1m longitude  \033[m"<<std::setprecision(8)<<_gga.lon<<" [deg]"<<std::endl;
-    std::cout<<"\033[1m altitude  \033[m"<<std::setprecision(4)<<_gga.alt + _gga.undulation<<" [m]"<<std::endl;
+    std::cout<< "\033[1m rtk status \033[m "<<int(_gga_ptr->gps_qual)<<std::endl;
+    std::cout<< "\033[1m rtk status \033[m "<<(int(_gga_ptr->gps_qual)!=4 ? "\033[1;31mNo Fix\033[m" : "\033[1;32mFix\033[m")<<std::endl;
+    std::cout<<"\033[1m latitude  \033[m"<<std::setprecision(8)<<_gga_ptr->lat<<" [deg]"<<std::endl;
+    std::cout<<"\033[1m longitude  \033[m"<<std::setprecision(8)<<_gga_ptr->lon<<" [deg]"<<std::endl;
+    std::cout<<"\033[1m altitude  \033[m"<<std::setprecision(4)<<_gga_ptr->alt + _gga_ptr->undulation<<" [m]"<<std::endl;
     std::cout << std::endl;
   }
   else
@@ -890,9 +917,9 @@ void outputLog(void)
   output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _correction_velocity.twist.angular.z << ",";
   output_log_file << (_velocity_scale_factor.status.enabled_status ? "1" : "0") << ",";
   output_log_file << (_velocity_scale_factor.status.estimate_status ? "1" : "0") << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _distance.distance << ",";
-  output_log_file << (_distance.status.enabled_status ? "1" : "0") << ",";
-  output_log_file << (_distance.status.estimate_status ? "1" : "0") << ",";
+  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _distance_ptr->distance << ",";
+  output_log_file << (_distance_ptr->status.enabled_status ? "1" : "0") << ",";
+  output_log_file << (_distance_ptr->status.estimate_status ? "1" : "0") << ",";
   output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _heading_1st.heading_angle << ",";
   output_log_file << (_heading_1st.status.enabled_status ? "1" : "0") << ",";
   output_log_file << (_heading_1st.status.estimate_status ? "1" : "0") << ",";
@@ -963,11 +990,11 @@ void outputLog(void)
   output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _rolling.rolling_angle << ",";
   output_log_file << (_rolling.status.enabled_status ? "1" : "0") << ",";
   output_log_file << (_rolling.status.estimate_status ? "1" : "0") << ",";
-  output_log_file << std::setprecision(std::numeric_limits<int>::max_digits10) << _gga.header.stamp.toNSec() << ","; //timestamp
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _gga.lat << ","; //gga_llh.latitude
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _gga.lon << ","; //gga_llh.longitude
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _gga.alt +  _gga.undulation<< ","; //gga_llh.altitude
-  output_log_file << std::setprecision(std::numeric_limits<int>::max_digits10) << int(_gga.gps_qual) << ","; //gga_llh.gps_qual
+  output_log_file << std::setprecision(std::numeric_limits<int>::max_digits10) << _gga_ptr->header.stamp.toNSec() << ","; //timestamp
+  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _gga_ptr->lat << ","; //gga_llh.latitude
+  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _gga_ptr->lon << ","; //gga_llh.longitude
+  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _gga_ptr->alt +  _gga_ptr->undulation<< ","; //gga_llh.altitude
+  output_log_file << std::setprecision(std::numeric_limits<int>::max_digits10) << int(_gga_ptr->gps_qual) << ","; //gga_llh.gps_qual
   output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _eagleye_fix.latitude << ","; //eagleye_pp_llh.latitude
   output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _eagleye_fix.longitude << ","; //eagleye_pp_llh.longitude
   output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _eagleye_fix.altitude << ","; //eagleye_pp_llh.altitude
@@ -1038,6 +1065,8 @@ int main(int argc, char** argv)
   n.getParam("monitor/comparison_twist_topic",comparison_twist_topic_name);
   n.getParam("monitor/th_diff_rad_per_sec",_th_diff_rad_per_sec);
   n.getParam("monitor/th_num_continuous_abnormal_yawrate",_th_num_continuous_abnormal_yawrate);
+  n.getParam("use_rtk_deadreckoning",_use_rtk_deadreckoning);
+  n.getParam("monitor/th_dr_distance",_th_dr_distance);
 
   std::cout<< "subscribe_twist_topic_name "<<subscribe_twist_topic_name<<std::endl;
   std::cout<< "subscribe_imu_topic_name "<<subscribe_imu_topic_name<<std::endl;
@@ -1051,6 +1080,8 @@ int main(int argc, char** argv)
   std::cout<< "use_compare_yawrate "<<_use_compare_yawrate<<std::endl;
   std::cout<< "comparison_twist_topic_name "<<comparison_twist_topic_name<<std::endl;
   std::cout<< "th_diff_rad_per_sec "<<_th_diff_rad_per_sec<<std::endl;
+  std::cout<< "use_rtk_deadreckoning "<<_use_rtk_deadreckoning<<std::endl;
+  std::cout<< "th_dr_distance "<<_th_dr_distance<<std::endl;
 
   // // Diagnostic Updater
   diagnostic_updater::Updater updater;
@@ -1072,7 +1103,8 @@ int main(int argc, char** argv)
   updater.add("eagleye_enu_absolute_pos", enu_absolute_pos_topic_checker);
   updater.add("eagleye_enu_absolute_pos_interpolate", enu_absolute_pos_interpolate_topic_checker);
   updater.add("eagleye_twist", twist_topic_checker);
-  updater.add("eagleye_corrected_imu", corrected_imu_topic_checker);
+  if(_use_compare_yawrate) updater.add("eagleye_corrected_imu", corrected_imu_topic_checker);
+  if(_use_rtk_deadreckoning) updater.add("eagleye_deadreckoning_distance", dr_distance_checker);
 
   time_t time_;
   time_ = time(NULL);
@@ -1081,7 +1113,7 @@ int main(int argc, char** argv)
   std::string time_str = time_ss.str();
   output_log_dir = ros::package::getPath("eagleye_rt") + "/log/eagleye_log_" + time_str + ".csv";
 
-  std::cout << output_log_dir << std::endl;
+  if(_log_output_status) std::cout << output_log_dir << std::endl;
 
   ros::Subscriber sub1 = n.subscribe("imu/data_tf_converted", 1000, imu_callback, ros::TransportHints().tcpNoDelay());
   ros::Subscriber sub2 = n.subscribe(subscribe_rtklib_nav_topic_name, 1000, rtklib_nav_callback, ros::TransportHints().tcpNoDelay());


### PR DESCRIPTION
Implementation of a function to emerge if n [m] dead reckoning from Fix to No FIX in eagleye self-location estimation.
This feature is enabled by setting use_rtk_deadreckoning to true in eagleye_rt's launch file.
How long it is safe to Dead Reckoning is set by monitor.th_dr_distance in eagleye_rt's yaml file.

The results of the operation check are as follows.

The following image shows the time on the trajectory.
![Figure_10](https://user-images.githubusercontent.com/18298605/186350396-e628c876-8994-4f8a-9d4b-d86974797201.png)

The following image is a screenshot of the Runtime Monitor confirming the emergence of an emergency when the DR distance becomes too large after a while after No FIX.
![image](https://user-images.githubusercontent.com/18298605/186350301-60efce7f-1341-4398-9cf0-3fccfc2b25df.png)
