### PR TITLE
Fixed problem with callback function not defined in main statement

### DIFF
--- a/eagleye_rt/launch/eagleye_rt.launch
+++ b/eagleye_rt/launch/eagleye_rt.launch
@@ -8,10 +8,12 @@
 
     <arg name="use_rtk_deadreckoning" default="false"/>
     <arg name="use_rtk_heading" default="false"/>
+    <arg name="use_canless_mode" default="false"/>
     <arg name="enable_additional_rolling" default="false"/>
 
     <param name ="velocity_scale_factor_save_str" value="$(find eagleye_rt)/config/velocity_scale_factor.txt"/>
     <param name="use_rtk_deadreckoning" value="$(arg use_rtk_deadreckoning)"/>
+    <param name="use_canless_mode" value="$(arg use_canless_mode)"/>
 
     <rosparam command="load" file="$(find eagleye_rt)/config/eagleye_config.yaml"/>
 

--- a/eagleye_rt/src/enable_additional_rolling_node.cpp
+++ b/eagleye_rt/src/enable_additional_rolling_node.cpp
@@ -145,6 +145,8 @@ int main(int argc, char** argv)
   ros::Subscriber sub5 = nh.subscribe(subscribe_localization_pose_topic_name, 1000, localization_pose_callback , ros::TransportHints().tcpNoDelay());
   ros::Subscriber sub6 = nh.subscribe("angular_velocity_offset_stop", 1000, angular_velocity_offset_stop_callback , ros::TransportHints().tcpNoDelay());
   ros::Subscriber sub7 = nh.subscribe("imu/data_tf_converted", 1000, imu_callback , ros::TransportHints().tcpNoDelay());
+  ros::Subscriber sub8 = nh.subscribe("velocity", 1000, velocity_callback , ros::TransportHints().tcpNoDelay());
+  ros::Subscriber sub9 = nh.subscribe("velocity_status", 1000, velocity_status_callback , ros::TransportHints().tcpNoDelay());
 
   _pub1 = nh.advertise<eagleye_msgs::AccYOffset>("acc_y_offset_additional_rolling", 1000);
   _pub2 = nh.advertise<eagleye_msgs::Rolling>("enable_additional_rolling", 1000);


### PR DESCRIPTION
The following issues have been addressed in the enable_additional_rolling node.
・The issue of callback is not mentioned in the main part of the document.
・The issue of use_canless_mode cannot be set.