### PR TITLE
If yawrate_offset_stop is unestimated, no heading estimation

### DIFF
--- a/eagleye_rt/src/heading_node.cpp
+++ b/eagleye_rt/src/heading_node.cpp
@@ -101,7 +101,10 @@ void imu_callback(const sensor_msgs::Imu::ConstPtr& msg)
 {
   if (!_is_first_correction_velocity) return;
   if(_use_canless_mode && !_velocity_status.status.enabled_status) return;
-  if(!_yawrate_offset_stop.status.enabled_status) return;
+  if(!_yawrate_offset_stop.status.enabled_status){
+    ROS_WARN("Heading estimation is not started because the stop calibration is not yet completed");
+    return;
+  }
 
   _imu = *msg;
   _heading.header = msg->header;

--- a/eagleye_rt/src/heading_node.cpp
+++ b/eagleye_rt/src/heading_node.cpp
@@ -101,6 +101,7 @@ void imu_callback(const sensor_msgs::Imu::ConstPtr& msg)
 {
   if (!_is_first_correction_velocity) return;
   if(_use_canless_mode && !_velocity_status.status.enabled_status) return;
+  if(!_yawrate_offset_stop.status.enabled_status) return;
 
   _imu = *msg;
   _heading.header = msg->header;


### PR DESCRIPTION
Do not estimate yawrate offset,heading when yawrate offset stop is not estimated.

Reason
Heading and yawrate offset are interrelated, and estimating heading when yawrate offset is not correctly estimated will worsen accuracy, so we do not want it to be estimated.

Verified to work correctly with rosbag started on the move
