### PR TITLE
Stop parameterizing the gga and rmc topics

### DIFF
--- a/eagleye_rt/config/README.md
+++ b/eagleye_rt/config/README.md
@@ -18,9 +18,6 @@ The parameters for estimation in Eagleye can be set in the `config/eagleye_confi
 | twist_topic                   | string | Topic name to be subscribed to in node (geometry_msgs/TwistStamped.msg) | /can_twist               |
 | rtklib_nav_topic              | string | Topic name to be subscribed to in node (rtklib_msgs/RtklibNav.msg)      | /rtklib_nav_topic        |
 | nmea_sentence_topic           | string | Topic name to be subscribed to in node (nmea_msgs/Sentence.msg)         | /nmea_sentence_topic     |
-| gga_topic                     | string | Topic name to be subscribed to in node (nmea_msgs/Gpgga.msg)            | /navsat/gga              |
-| rmc_topic                     | string | Topic name to be subscribed to in node (nmea_msgs/Gprmc.msg)            | /navsat/rmc              |
-| localization_pose_topic       | string | Topic name to be subscribed to in node (geometry_msgs/PoseStamped.msg)  | /localization_pose_topic |
 
 
 ## TF

--- a/eagleye_rt/config/eagleye_config.yaml
+++ b/eagleye_rt/config/eagleye_config.yaml
@@ -9,9 +9,6 @@
     imu_topic: /imu/data_raw
     rtklib_nav_topic: /rtklib_nav
     nmea_sentence_topic: /nmea_sentence
-    gga_topic: /navsat/gga
-    rmc_topic: /navsat/rmc
-    localization_pose_topic: /localization/pose 
 
     # TF
     tf_gnss_frame:

--- a/eagleye_rt/launch/eagleye_rt.launch.xml
+++ b/eagleye_rt/launch/eagleye_rt.launch.xml
@@ -122,11 +122,12 @@
             <param from="$(find-pkg-share eagleye_rt)/config/$(var config_yaml)"/>
             <param name="yaml_file" value="$(find-pkg-share eagleye_rt)/config/$(var config_yaml)"/>
     </node>
+    <include file="$(find-pkg-share eagleye_nmea2fix)/launch/nmea2fix.xml">
+            <arg name="config_yaml" value="$(var config_yaml)"/>
+    </include>
   </group>
 
-  <include file="$(find-pkg-share eagleye_nmea2fix)/launch/nmea2fix.xml">
-        <arg name="config_yaml" value="$(var config_yaml)"/>
-  </include>
+
 
   <include file="$(find-pkg-share eagleye_tf)/launch/tf.xml" if="$(var use_tf)"/>
 

--- a/eagleye_rt/src/heading_node.cpp
+++ b/eagleye_rt/src/heading_node.cpp
@@ -129,7 +129,7 @@ int main(int argc, char** argv)
   auto node = rclcpp::Node::make_shared(node_name);
 
   std::string subscribe_rtklib_nav_topic_name = "/rtklib_nav";
-  std::string subscribe_rmc_topic_name = "/navsat/rmc";
+  std::string subscribe_rmc_topic_name = "gnss/rmc";
 
   std::string yaml_file;
   node->declare_parameter("yaml_file",yaml_file);

--- a/eagleye_rt/src/height_node.cpp
+++ b/eagleye_rt/src/height_node.cpp
@@ -107,7 +107,7 @@ int main(int argc, char** argv)
   rclcpp::init(argc, argv);
   auto node = rclcpp::Node::make_shared("height");
 
-  std::string subscribe_gga_topic_name = "/navsat/gga";
+  std::string subscribe_gga_topic_name = "gnss/gga";
 
   std::string yaml_file;
   node->declare_parameter("yaml_file",yaml_file);

--- a/eagleye_rt/src/monitor_node.cpp
+++ b/eagleye_rt/src/monitor_node.cpp
@@ -1096,7 +1096,7 @@ int main(int argc, char** argv)
   std::string subscribe_twist_topic_name = "/can_twist";
 
   std::string subscribe_rtklib_nav_topic_name = "/rtklib_nav";
-  std::string subscribe_gga_topic_name = "/navsat/gga";
+  std::string subscribe_gga_topic_name = "gnss/gga";
   std::string comparison_twist_topic_name = "/calculated_twist";
 
   node->declare_parameter("twist_topic",subscribe_twist_topic_name);

--- a/eagleye_rt/src/position_interpolate_node.cpp
+++ b/eagleye_rt/src/position_interpolate_node.cpp
@@ -99,7 +99,7 @@ int main(int argc, char** argv)
   rclcpp::init(argc, argv);
   auto node = rclcpp::Node::make_shared("position_interpolate");
 
-  std::string subscribe_gga_topic_name = "/navsat/gga";
+  std::string subscribe_gga_topic_name = "gnss/gga";
 
   std::string yaml_file;
   node->declare_parameter("yaml_file",yaml_file);

--- a/eagleye_rt/src/position_node.cpp
+++ b/eagleye_rt/src/position_node.cpp
@@ -153,7 +153,7 @@ int main(int argc, char** argv)
   // tfBuffer_(node->get_clock());
 
   std::string subscribe_rtklib_nav_topic_name = "/rtklib_nav";
-  std::string subscribe_gga_topic_name = "/navsat/gga";
+  std::string subscribe_gga_topic_name = "gnss/gga";
 
   std::string yaml_file;
   node->declare_parameter("yaml_file",yaml_file);

--- a/eagleye_rt/src/rtk_deadreckoning_node.cpp
+++ b/eagleye_rt/src/rtk_deadreckoning_node.cpp
@@ -130,7 +130,7 @@ int main(int argc, char** argv)
   auto node = rclcpp::Node::make_shared("rtk_deadreckoning");
 
   std::string subscribe_rtklib_nav_topic_name = "/rtklib_nav";
-  std::string subscribe_gga_topic_name = "/navsat/gga";
+  std::string subscribe_gga_topic_name = "gnss/gga";
 
   std::string yaml_file;
   node->declare_parameter("yaml_file",yaml_file);

--- a/eagleye_rt/src/rtk_heading_node.cpp
+++ b/eagleye_rt/src/rtk_heading_node.cpp
@@ -112,7 +112,7 @@ int main(int argc, char** argv)
   auto node = rclcpp::Node::make_shared("rtk_heading");
 
 
-  std::string subscribe_gga_topic_name = "/navsat/gga";
+  std::string subscribe_gga_topic_name = "gnss/gga";
 
   std::string yaml_file;
   node->declare_parameter("yaml_file",yaml_file);

--- a/eagleye_rt/src/velocity_scale_factor_node.cpp
+++ b/eagleye_rt/src/velocity_scale_factor_node.cpp
@@ -197,7 +197,7 @@ int main(int argc, char** argv)
   std::string subscribe_twist_topic_name = "/can_twist";
 
   std::string subscribe_rtklib_nav_topic_name = "/rtklib_nav";
-  std::string subscribe_rmc_topic_name = "/navsat/rmc";
+  std::string subscribe_rmc_topic_name = "gnss/rmc";
 
   std::string yaml_file;
   node->declare_parameter("yaml_file",yaml_file);

--- a/eagleye_util/nmea2fix/README.md
+++ b/eagleye_util/nmea2fix/README.md
@@ -14,13 +14,15 @@ roslaunch nmea2fix nmea2fix.launch
 # Node
 
 ## Subscribed Topics
- - /navsat/nmea_sentence (nmea_msgs/Sentence)
+ - /nmea_sentence (nmea_msgs/Sentence)
 
 ## Published Topics
 
- - /navsat/fix (sensor_msgs/NavSatFix) (This topic will not be published unless its location has been estimated.)
+ - /fix (sensor_msgs/NavSatFix)
 
  - /gga (nmea_msgs/Gpgga)
+
+ - /rmc (nmea_msgs/Grmc)
 
 
 # Parameter description
@@ -29,9 +31,4 @@ The parameters are set in `launch/nmea2fix.launch` .
 
 |Name|Type|Description|Default value|
 |:---|:---|:---|:---|
-|nmea_sentence_topic|bool|Topic name of nmea_msgs/Sentence to subscribe|/navsat/nmea_sentence|
-|pub_fix_topic_name|double|Topic name of sensor_msgs/NavSatFix to publish|/navsat/fix|
-|pub_gga_topic_name|bool|Topic name of nmea_msgs/Gpgga to publish|gnss/gga|
-|pub_rmc_topic_name|bool|Topic name of nmea_msgs/Gprmc to publish|gnss/rmc|
-|output_gga|bool|Whether to output nmea_msgs/Gpgga|false|
-|output_rmc|bool|Whether to output nmea_msgs/Gprmc|false|
+|nmea_sentence_topic|bool|Topic name of nmea_msgs/Sentence to subscribe|/nmea_sentence|

--- a/eagleye_util/nmea2fix/README.md
+++ b/eagleye_util/nmea2fix/README.md
@@ -31,7 +31,7 @@ The parameters are set in `launch/nmea2fix.launch` .
 |:---|:---|:---|:---|
 |nmea_sentence_topic|bool|Topic name of nmea_msgs/Sentence to subscribe|/navsat/nmea_sentence|
 |pub_fix_topic_name|double|Topic name of sensor_msgs/NavSatFix to publish|/navsat/fix|
-|pub_gga_topic_name|bool|Topic name of nmea_msgs/Gpgga to publish|/navsat/gga|
-|pub_rmc_topic_name|bool|Topic name of nmea_msgs/Gprmc to publish|/navsat/rmc|
+|pub_gga_topic_name|bool|Topic name of nmea_msgs/Gpgga to publish|gnss/gga|
+|pub_rmc_topic_name|bool|Topic name of nmea_msgs/Gprmc to publish|gnss/rmc|
 |output_gga|bool|Whether to output nmea_msgs/Gpgga|false|
 |output_rmc|bool|Whether to output nmea_msgs/Gprmc|false|

--- a/eagleye_util/nmea2fix/launch/nmea2fix.xml
+++ b/eagleye_util/nmea2fix/launch/nmea2fix.xml
@@ -2,20 +2,13 @@
 
 <launch>
 
-  <arg name="pub_fix_topic_name" default="/navsat/fix"/>
-  <arg name="pub_gga_topic_name" default="/navsat/gga"/>
-  <arg name="pub_rmc_topic_name" default="/navsat/rmc"/>
-  <arg name="output_gga" default="true"/>
-  <arg name="output_rmc" default="true"/>
   <arg name="config_yaml" default="eagleye_config.yaml"/>
 
-  <node pkg="eagleye_nmea2fix" name="nmea2fix_node" exec="nmea2fix" output="screen">
-        <param name="pub_fix_topic_name" value="$(var pub_fix_topic_name)"/>
-        <param name="pub_gga_topic_name" value="$(var pub_gga_topic_name)"/>
-        <param name="pub_rmc_topic_name" value="$(var pub_rmc_topic_name)"/>
-        <param name="output_gga" value="$(var output_gga)"/>
-        <param name="output_rmc" value="$(var output_rmc)"/>
-        <param from="$(find-pkg-share eagleye_rt)/config/$(var config_yaml)"/>      
-  </node>
+  <group>
+    <push-ros-namespace namespace="gnss"/>
+    <node pkg="eagleye_nmea2fix" name="nmea2fix_node" exec="nmea2fix" output="screen">
+          <param from="$(find-pkg-share eagleye_rt)/config/$(var config_yaml)"/>
+    </node>
+  </group>
 
 </launch>

--- a/eagleye_util/nmea2fix/src/nmea2fix_node.cpp
+++ b/eagleye_util/nmea2fix/src/nmea2fix_node.cpp
@@ -7,8 +7,8 @@ rclcpp::Publisher<nmea_msgs::msg::Gpgga>::SharedPtr pub2;
 rclcpp::Publisher<nmea_msgs::msg::Gprmc>::SharedPtr pub3;
 static nmea_msgs::msg::Sentence sentence;
 
-static std::string sub_topic_name, pub_fix_topic_name, pub_gga_topic_name, pub_rmc_topic_name;
-static bool output_gga, output_rmc;
+static std::string sub_topic_name, pub_fix_topic_name = "fix",
+  pub_gga_topic_name = "gga", pub_rmc_topic_name = "rmc";
 
 void nmea_callback(const nmea_msgs::msg::Sentence::ConstSharedPtr msg)
 {
@@ -27,9 +27,9 @@ void nmea_callback(const nmea_msgs::msg::Sentence::ConstSharedPtr msg)
   {
     gga.header.frame_id = fix.header.frame_id = "gnss";
     pub1->publish(fix);
-    if(output_gga) pub2->publish(gga);
+    pub2->publish(gga);
   }
-  if (ros_clock2.seconds() != 0 && output_rmc)
+  if (ros_clock2.seconds() != 0)
   {
     rmc.header.frame_id = "gnss";
     pub3->publish(rmc);
@@ -44,39 +44,13 @@ int main(int argc, char** argv)
   std::string use_gnss_mode;
 
   node->declare_parameter("nmea_sentence_topic",sub_topic_name);
-  node->declare_parameter("pub_fix_topic_name",pub_fix_topic_name);
-  node->declare_parameter("pub_gga_topic_name",pub_gga_topic_name);
-  node->declare_parameter("pub_rmc_topic_name",pub_rmc_topic_name);
-  node->declare_parameter("output_gga",output_gga);
-  node->declare_parameter("output_rmc",output_rmc);
-  node->declare_parameter("use_gnss_mode",use_gnss_mode);
-
   node->get_parameter("nmea_sentence_topic",sub_topic_name);
-  node->get_parameter("pub_fix_topic_name",pub_fix_topic_name);
-  node->get_parameter("pub_gga_topic_name",pub_gga_topic_name);
-  node->get_parameter("pub_rmc_topic_name",pub_rmc_topic_name);
-  node->get_parameter("output_gga",output_gga);
-  node->get_parameter("output_rmc",output_rmc);
-  node->get_parameter("use_gnss_mode",use_gnss_mode);
-
-  if (use_gnss_mode == "nmea" || use_gnss_mode == "NMEA") // use NMEA mode
-  {
-    output_gga = true;
-    output_rmc = true;
-  }
-
   std::cout<< "sub_topic_name "<<sub_topic_name<<std::endl;
-  std::cout<< "pub_fix_topic_name "<<pub_fix_topic_name<<std::endl;
-  std::cout<< "pub_gga_topic_name "<<pub_gga_topic_name<<std::endl;
-  std::cout<< "pub_rmc_topic_name "<<pub_rmc_topic_name<<std::endl;
-  std::cout<< "output_gga "<<output_gga<<std::endl;
-  std::cout<< "output_rmc "<<output_rmc<<std::endl;
-  std::cout<< "use_gnss_mode "<<use_gnss_mode<<std::endl;
 
   auto sub = node->create_subscription<nmea_msgs::msg::Sentence>(sub_topic_name, 1000, nmea_callback);
   pub1 = node->create_publisher<sensor_msgs::msg::NavSatFix>(pub_fix_topic_name, 1000);
-  if(output_gga) pub2 = node->create_publisher<nmea_msgs::msg::Gpgga>(pub_gga_topic_name, 1000);
-  if(output_rmc) pub3 = node->create_publisher<nmea_msgs::msg::Gprmc>(pub_rmc_topic_name, 1000);
+  pub2 = node->create_publisher<nmea_msgs::msg::Gpgga>(pub_gga_topic_name, 1000);
+  pub3 = node->create_publisher<nmea_msgs::msg::Gprmc>(pub_rmc_topic_name, 1000);
 
   rclcpp::spin(node);
 


### PR DESCRIPTION
I don't think users need to specify gga and rmc topics in yaml parameters, so I removed them from yaml.

The nmea_msgs/sentence, which is the input of the nmea2fix node, is converted to the following
```
/eagleye/gnss/fix
/eagleye/gnss/gga
/eagleye/gnss/rmc
```