### PR TITLE
Fix yaml error and namespace

### DIFF
--- a/eagleye_rt/src/rtk_deadreckoning_node.cpp
+++ b/eagleye_rt/src/rtk_deadreckoning_node.cpp
@@ -129,7 +129,7 @@ int main(int argc, char** argv)
   rclcpp::init(argc, argv);
   auto node = rclcpp::Node::make_shared("rtk_deadreckoning");
 
-  std::string subscribe_rtklib_nav_topic_name = "/rtklib_nav";
+  std::string subscribe_rtklib_nav_topic_name = "gnss/rtklib_nav";
   std::string subscribe_gga_topic_name = "gnss/gga";
 
   std::string yaml_file;
@@ -142,7 +142,6 @@ int main(int argc, char** argv)
     YAML::Node conf = YAML::LoadFile(yaml_file);
 
     use_gnss_mode = conf["/**"]["ros__parameters"]["use_gnss_mode"].as<std::string>();
-    subscribe_rtklib_nav_topic_name = conf["/**"]["ros__parameters"]["rtklib_nav_topic"].as<std::string>();
 
     rtk_deadreckoning_parameter.ecef_base_pos_x = conf["/**"]["ros__parameters"]["ecef_base_pos"]["x"].as<double>();
     rtk_deadreckoning_parameter.ecef_base_pos_y = conf["/**"]["ros__parameters"]["ecef_base_pos"]["y"].as<double>();
@@ -153,7 +152,6 @@ int main(int argc, char** argv)
     rtk_deadreckoning_parameter.stop_judgment_threshold = conf["/**"]["ros__parameters"]["common"]["stop_judgment_threshold"].as<double>();
 
     std::cout << "use_gnss_mode " << use_gnss_mode << std::endl;
-    std::cout << "subscribe_rtklib_nav_topic_name " << subscribe_rtklib_nav_topic_name << std::endl;
 
     std::cout << "ecef_base_pos_x " << rtk_deadreckoning_parameter.ecef_base_pos_x << std::endl;
     std::cout << "ecef_base_pos_y " << rtk_deadreckoning_parameter.ecef_base_pos_y << std::endl;

--- a/eagleye_util/fix2pose/launch/fix2pose.xml
+++ b/eagleye_util/fix2pose/launch/fix2pose.xml
@@ -5,7 +5,9 @@
   <node pkg="eagleye_fix2pose" name="fix2pose_node" exec="fix2pose" output="screen" >
     <!-- /eagleye/fix or  /eagleye/rtk_fix(rtk_deadreckoning mode) -->
     <remap from="/eagleye/fix" to="/eagleye/fix" />
+    <!-- plane rectangular coordinate number -->
     <param name="plane" value="7"/>
+    <!-- 1 : plane rectangular coordinate  2 : MGRS -->
     <param name="tf_num" value="1"/>
     <!-- 0 : No convert  1 : ellipsoid -> altitude  2 : altitude -> ellipsoid -->
     <param name="convert_height_num" value="0"/>

--- a/eagleye_util/fix2pose/src/fix2pose.cpp
+++ b/eagleye_util/fix2pose/src/fix2pose.cpp
@@ -185,13 +185,13 @@ int main(int argc, char** argv)
   std::cout<< "parent_frame_id"<<parent_frame_id<<std::endl;
   std::cout<< "child_frame_id"<<child_frame_id<<std::endl;
 
-  auto sub1 = node->create_subscription<eagleye_msgs::msg::Heading>("/eagleye/heading_interpolate_3rd", 1000, heading_callback);
-  auto sub2 = node->create_subscription<eagleye_msgs::msg::Position>("/eagleye/enu_absolute_pos_interpolate", 1000, position_callback);
-  auto sub3 = node->create_subscription<sensor_msgs::msg::NavSatFix>("/eagleye/fix", 1000, fix_callback);
-  auto sub4 = node->create_subscription<eagleye_msgs::msg::Rolling>("/eagleye/rolling", 1000, rolling_callback);
-  auto sub5 = node->create_subscription<eagleye_msgs::msg::Pitching>("/eagleye/pitching", 1000, pitching_callback);
-  pub = node->create_publisher<geometry_msgs::msg::PoseStamped>("/eagleye/pose", 1000);
-  pub2 = node->create_publisher<geometry_msgs::msg::PoseWithCovarianceStamped>("/eagleye/pose_with_covariance", 1000);
+  auto sub1 = node->create_subscription<eagleye_msgs::msg::Heading>("eagleye/heading_interpolate_3rd", 1000, heading_callback);
+  auto sub2 = node->create_subscription<eagleye_msgs::msg::Position>("eagleye/enu_absolute_pos_interpolate", 1000, position_callback);
+  auto sub3 = node->create_subscription<sensor_msgs::msg::NavSatFix>("eagleye/fix", 1000, fix_callback);
+  auto sub4 = node->create_subscription<eagleye_msgs::msg::Rolling>("eagleye/rolling", 1000, rolling_callback);
+  auto sub5 = node->create_subscription<eagleye_msgs::msg::Pitching>("eagleye/pitching", 1000, pitching_callback);
+  pub = node->create_publisher<geometry_msgs::msg::PoseStamped>("eagleye/pose", 1000);
+  pub2 = node->create_publisher<geometry_msgs::msg::PoseWithCovarianceStamped>("eagleye/pose_with_covariance", 1000);
   br = std::make_shared<tf2_ros::TransformBroadcaster>(node, 100);
   br2 = std::make_shared<tf2_ros::TransformBroadcaster>(node, 100);
   rclcpp::spin(node);


### PR DESCRIPTION
・Fixed dead rtk_deadreckoning_node in yaml error.
・Removed the leading slash from the topic name in fix2pose.