### PR TITLE
Feature/covariance position(ROS1)

### DIFF
--- a/eagleye_core/navigation/include/navigation/navigation.hpp
+++ b/eagleye_core/navigation/include/navigation/navigation.hpp
@@ -237,6 +237,7 @@ struct PositionParameter
   double gnss_receiving_threshold;
   double outlier_threshold;
   double outlier_ratio_threshold;
+  double gnss_error_covariance;
 };
 
 struct PositionStatus
@@ -261,6 +262,7 @@ struct PositionInterpolateParameter
   double imu_rate;
   double stop_judgment_threshold;
   double sync_search_period;
+  double proc_noise;
 };
 
 struct PositionInterpolateStatus
@@ -268,6 +270,7 @@ struct PositionInterpolateStatus
   int position_estimate_status_count;
   int number_buffer;
   bool position_estimate_start_status;
+  bool is_estimate_start{false};
   double position_stamp_last;
   double time_last;
   double provisional_enu_pos_x;
@@ -277,6 +280,7 @@ struct PositionInterpolateStatus
   std::vector<double> provisional_enu_pos_y_buffer;
   std::vector<double> provisional_enu_pos_z_buffer;
   std::vector<double> imu_stamp_buffer;
+  Eigen::MatrixXd position_covariance_last;
 };
 
 struct SlipangleParameter
@@ -501,7 +505,7 @@ extern void heading_interpolate_estimate(const sensor_msgs::Imu,const geometry_m
   const eagleye_msgs::YawrateOffset,const eagleye_msgs::Heading,const eagleye_msgs::SlipAngle,const HeadingInterpolateParameter,HeadingInterpolateStatus*,
   eagleye_msgs::Heading*);
 extern void position_interpolate_estimate(const eagleye_msgs::Position,const geometry_msgs::Vector3Stamped,const eagleye_msgs::Position,
-  const eagleye_msgs::Height,const PositionInterpolateParameter,PositionInterpolateStatus*,eagleye_msgs::Position*,sensor_msgs::NavSatFix*);
+  const eagleye_msgs::Height,const eagleye_msgs::Heading,const PositionInterpolateParameter,PositionInterpolateStatus*,eagleye_msgs::Position*,sensor_msgs::NavSatFix*);
 extern void pitching_estimate(const sensor_msgs::Imu,const nmea_msgs::Gpgga,const geometry_msgs::TwistStamped,const eagleye_msgs::Distance,
   const HeightParameter,HeightStatus*,eagleye_msgs::Height*,eagleye_msgs::Pitching*,eagleye_msgs::AccXOffset*,eagleye_msgs::AccXScaleFactor*);
 extern void trajectory3d_estimate(const sensor_msgs::Imu,const geometry_msgs::TwistStamped,const eagleye_msgs::StatusStamped,const eagleye_msgs::Heading,

--- a/eagleye_core/navigation/src/position.cpp
+++ b/eagleye_core/navigation/src/position.cpp
@@ -286,11 +286,39 @@ void position_estimate_(geometry_msgs::TwistStamped velocity,eagleye_msgs::Statu
 
         if (index_length >= velocity_index_length * remain_data_ratio)
         {
+
+          std::vector<double> diff_x_buffer_for_covariance, diff_y_buffer_for_covariance, diff_z_buffer_for_covariance;
+          for (i = 0; i < index_length; i++)
+          {
+            diff_x_buffer_for_covariance.push_back(base_enu_pos_x_buffer2[index[i]] - position_status->enu_pos_x_buffer[index[i]]);
+            diff_y_buffer_for_covariance.push_back(base_enu_pos_y_buffer2[index[i]] - position_status->enu_pos_y_buffer[index[i]]);
+            diff_z_buffer_for_covariance.push_back(base_enu_pos_z_buffer2[index[i]] - position_status->enu_pos_z_buffer[index[i]]);
+          }
+
+          avg_x = std::accumulate(diff_x_buffer_for_covariance.begin(), diff_x_buffer_for_covariance.end(), 0.0) / index_length;
+          avg_y = std::accumulate(diff_y_buffer_for_covariance.begin(), diff_y_buffer_for_covariance.end(), 0.0) / index_length;
+          avg_z = std::accumulate(diff_z_buffer_for_covariance.begin(), diff_z_buffer_for_covariance.end(), 0.0) / index_length;
+
+          double cov_x, cov_y, cov_z;
+          double square_sum_x = 0, square_sum_y = 0, square_sum_z = 0;
+          for (i = 0; i < index_length; i++)
+          {
+            square_sum_x += (diff_x_buffer_for_covariance[i] - avg_x) * (diff_x_buffer_for_covariance[i] - avg_x);
+            square_sum_y += (diff_y_buffer_for_covariance[i] - avg_y) * (diff_y_buffer_for_covariance[i] - avg_y);
+            square_sum_z += (diff_z_buffer_for_covariance[i] - avg_z) * (diff_z_buffer_for_covariance[i] - avg_z);
+          }
+          cov_x = square_sum_x/index_length;
+          cov_y = square_sum_y/index_length;
+          cov_z = square_sum_z/index_length;
+
           if (index[index_length - 1] == position_status->estimated_number-1)
           {
             enu_absolute_pos->enu_pos.x = tmp_enu_pos_x;
             enu_absolute_pos->enu_pos.y = tmp_enu_pos_y;
             enu_absolute_pos->enu_pos.z = tmp_enu_pos_z;
+            enu_absolute_pos->covariance[0] = cov_x + position_parameter.gnss_error_covariance; // [m^2]
+            enu_absolute_pos->covariance[4] = cov_y + position_parameter.gnss_error_covariance; // [m^2]
+            enu_absolute_pos->covariance[8] = cov_z + position_parameter.gnss_error_covariance; // [m^2]
             enu_absolute_pos->status.enabled_status = true;
             enu_absolute_pos->status.estimate_status = true;
           }

--- a/eagleye_core/navigation/src/position_interpolate.cpp
+++ b/eagleye_core/navigation/src/position_interpolate.cpp
@@ -32,7 +32,7 @@
 #include "navigation/navigation.hpp"
 
 void position_interpolate_estimate(eagleye_msgs::Position enu_absolute_pos, geometry_msgs::Vector3Stamped enu_vel, eagleye_msgs::Position gnss_smooth_pos,
-  eagleye_msgs::Height height,PositionInterpolateParameter position_interpolate_parameter, PositionInterpolateStatus* position_interpolate_status,
+  eagleye_msgs::Height height, eagleye_msgs::Heading heading,PositionInterpolateParameter position_interpolate_parameter, PositionInterpolateStatus* position_interpolate_status,
   eagleye_msgs::Position* enu_absolute_pos_interpolate,sensor_msgs::NavSatFix* eagleye_fix)
 {
 
@@ -130,6 +130,7 @@ void position_interpolate_estimate(eagleye_msgs::Position enu_absolute_pos, geom
       position_interpolate_status->provisional_enu_pos_y = position_interpolate_status->provisional_enu_pos_y_buffer[position_interpolate_status->number_buffer-1];
       position_interpolate_status->provisional_enu_pos_z = position_interpolate_status->provisional_enu_pos_z_buffer[position_interpolate_status->number_buffer-1];
 
+      position_interpolate_status->is_estimate_start = true;
       enu_absolute_pos_interpolate->status.enabled_status = true;
       enu_absolute_pos_interpolate->status.estimate_status = true;
     }
@@ -147,7 +148,7 @@ void position_interpolate_estimate(eagleye_msgs::Position enu_absolute_pos, geom
     }
   }
 
-  if (position_interpolate_status->position_estimate_start_status == true)
+  if (position_interpolate_status->position_estimate_start_status && position_interpolate_status->is_estimate_start)
   {
     enu_pos[0] = position_interpolate_status->provisional_enu_pos_x;
     enu_pos[1] = position_interpolate_status->provisional_enu_pos_y;
@@ -158,6 +159,56 @@ void position_interpolate_estimate(eagleye_msgs::Position enu_absolute_pos, geom
     ecef_base_pos[2] = enu_absolute_pos.ecef_base_pos.z;
 
     enu2llh(enu_pos, ecef_base_pos, llh_pos);
+
+    Eigen::MatrixXd init_covariance;
+    init_covariance = Eigen::MatrixXd::Zero(6, 6);
+    init_covariance(0,0) = enu_absolute_pos.covariance[0];
+    init_covariance(1,1) = enu_absolute_pos.covariance[4];
+    init_covariance(2,2) = enu_absolute_pos.covariance[8];
+    init_covariance(5,5) = heading.variance;
+
+    double proc_noise = position_interpolate_parameter.proc_noise;
+    Eigen::MatrixXd proc_covariance;
+    proc_covariance = Eigen::MatrixXd::Zero(6, 6);
+    proc_covariance(0,0) = proc_noise * proc_noise;
+    proc_covariance(1,1) = proc_noise * proc_noise;
+    proc_covariance(2,2) = proc_noise * proc_noise;
+
+    Eigen::MatrixXd position_covariance;
+    position_covariance = Eigen::MatrixXd::Zero(6, 6);
+
+    double velocity = std::sqrt(enu_vel.vector.x*enu_vel.vector.x + enu_vel.vector.y*enu_vel.vector.y + enu_vel.vector.z*enu_vel.vector.z);
+
+    if(enu_absolute_pos_interpolate->status.estimate_status)
+    {
+      position_covariance = init_covariance;
+      position_interpolate_status->position_covariance_last = position_covariance;
+    }
+    else if (velocity > position_interpolate_parameter.stop_judgment_threshold)
+    {
+      Eigen::MatrixXd jacobian;
+      jacobian = Eigen::MatrixXd::Zero(6, 6);
+      jacobian(0,0) = 1;
+      jacobian(1,1) = 1;
+      jacobian(2,2) = 1;
+      jacobian(3,3) = 1;
+      jacobian(4,4) = 1;
+      jacobian(5,5) = 1;
+      jacobian(0,5) = enu_vel.vector.y*(enu_vel.header.stamp.toSec() - position_interpolate_status->time_last);
+      jacobian(1,5) = -enu_vel.vector.x*(enu_vel.header.stamp.toSec() - position_interpolate_status->time_last);
+
+      // MEMO: Jacobean not included
+      // position_covariance = position_interpolate_status->position_covariance_last + proc_covariance;
+
+      // MEMO: Jacobean not included
+      position_covariance = jacobian * position_interpolate_status->position_covariance_last * (jacobian.transpose())   + proc_covariance;
+
+      position_interpolate_status->position_covariance_last = position_covariance;
+    }
+    else
+    {
+      position_covariance = position_interpolate_status->position_covariance_last;
+    }
 
     eagleye_fix->longitude = llh_pos[1] * 180/M_PI;
     eagleye_fix->latitude = llh_pos[0] * 180/M_PI;
@@ -174,12 +225,14 @@ void position_interpolate_estimate(eagleye_msgs::Position enu_absolute_pos, geom
     enu_absolute_pos_interpolate->enu_pos.x = enu_pos[0];
     enu_absolute_pos_interpolate->enu_pos.y = enu_pos[1];
     enu_absolute_pos_interpolate->enu_pos.z = enu_pos[2];
+    enu_absolute_pos_interpolate->covariance[0] = position_covariance(0,0); // [m^2]
+    enu_absolute_pos_interpolate->covariance[4] = position_covariance(1,1); // [m^2]
+    enu_absolute_pos_interpolate->covariance[8] = position_covariance(2,2); // [m^2]
 
     eagleye_fix->altitude = llh_pos[2];
-    // TODO(Map IV): temporary covariance value
-    eagleye_fix->position_covariance[0] = 1.5 * 1.5; // [m^2]
-    eagleye_fix->position_covariance[4] = 1.5 * 1.5; // [m^2]
-    eagleye_fix->position_covariance[8] = 1.5 * 1.5; // [m^2]
+    eagleye_fix->position_covariance[0] = position_covariance(0,0); // [m^2]
+    eagleye_fix->position_covariance[4] = position_covariance(1,1); // [m^2]
+    eagleye_fix->position_covariance[8] = position_covariance(2,2); // [m^2]
 
   }
   else

--- a/eagleye_core/navigation/src/rtk_deadreckoning.cpp
+++ b/eagleye_core/navigation/src/rtk_deadreckoning.cpp
@@ -126,13 +126,14 @@ void rtk_deadreckoning_estimate_(geometry_msgs::Vector3Stamped enu_vel, nmea_msg
     Eigen::MatrixXd position_covariance;
     position_covariance = Eigen::MatrixXd::Zero(6, 6);
 
+    double velocity = std::sqrt(enu_vel.vector.x*enu_vel.vector.x + enu_vel.vector.y*enu_vel.vector.y + enu_vel.vector.z*enu_vel.vector.z);
 
     if(enu_absolute_rtk_deadreckoning->status.estimate_status)
     {
       position_covariance = init_covariance;
       rtk_deadreckoning_status->position_covariance_last = position_covariance;
     }
-    else
+    else if (velocity > rtk_deadreckoning_parameter.stop_judgment_threshold)
     {
       Eigen::MatrixXd jacobian;
       jacobian = Eigen::MatrixXd::Zero(6, 6);
@@ -153,6 +154,11 @@ void rtk_deadreckoning_estimate_(geometry_msgs::Vector3Stamped enu_vel, nmea_msg
 
       rtk_deadreckoning_status->position_covariance_last = position_covariance;
     }
+    else
+    {
+      position_covariance = rtk_deadreckoning_status->position_covariance_last;
+    }
+
 
     eagleye_fix->latitude = llh_pos[0] * 180/M_PI;
     eagleye_fix->longitude = llh_pos[1] * 180/M_PI;

--- a/eagleye_pp/eagleye_pp/config/README.md
+++ b/eagleye_pp/eagleye_pp/config/README.md
@@ -103,14 +103,14 @@ Figure shows the relationship between these parameters.
 | outlier_threshold                   | double | Outlier threshold due to GNSS multipath [rad]                                   | 0.0524 (3 deg)       |
 | outlier_ratio_threshold             | double | Ratio of allowable outliers in the interval (Value from 0~1)                    | 0.5                  |
 | curve_judgment_threshold            | double | Yaw rate threshold for curve determination [rad/s]                              | 0.0873 (5 deg/s)     |
-| init_STD                   | double | Standard deviation of Doppler azimuth angle [rad] | 0.0035 (0.2 deg)          |
+| init_STD                            | double | Standard deviation of Doppler azimuth angle [rad]                               | 0.0035 (0.2 deg)     |
 
 ### heading_interpolate
 
 | Name                                | Type   | Description                                                                     | Default value        |
 | :---------------------------------- | :----- | :------------------------------------------------------------------------------ | :------------------- |
 | sync_search_period                  | double | Synchronous search time for delay interpolation [s]                             | 2                    |
-| proc_noise                   | double | Process Noise [rad] | 0.0005 (0.03 deg)          |
+| proc_noise                          | double | Process Noise [rad]                                                             | 0.0005 (0.03 deg)    |
 
 ### slip_angle
 
@@ -143,10 +143,10 @@ Figure shows the relationship between these parameters.
 | curve_judgment_threshold            | double | Yaw rate threshold for curve determination [rad/s]                              | 0.0174 (1 deg/s)     |
 | timer_updata_rate                   | double | Self-diagnostic cycle [Hz]                                                      | 10                   |
 | deadlock_threshold                  | double | Allowable communication deadlock time for error output [s]                      | 1                    |
-| sensor_noise_velocity                  | double | Sensor velocity noise                             | 0.05                    |
-| sensor_scale_noise_velocity                  | double | Sensor velocity scale noise                             | 0.02                    |
-| sensor_noise_yawrate                  | double | Sensor yaw rate noise                             | 0.01                    |
-| sensor_bias_noise_yawrate                  | double | Sensor yaw rate bias noise                             | 0.01                    |
+| sensor_noise_velocity               | double | Sensor velocity noise                                                           | 0.05                 |
+| sensor_scale_noise_velocity         | double | Sensor velocity scale noise                                                     | 0.02                 |
+| sensor_noise_yawrate                | double | Sensor yaw rate noise                                                           | 0.01                 |
+| sensor_bias_noise_yawrate           | double | Sensor yaw rate bias noise                                                      | 0.01                 |
 
 ### smoothing
 
@@ -178,6 +178,7 @@ Figure shows the relationship between these parameters.
 | gnss_receiving_threshold            | double | Threshold of minimum GNSS reception rate (Value from 0~1)                       | 0.25                 |
 | outlier_threshold                   | double | Outlier threshold due to GNSS multipath [m]                                     | 3                    |
 | outlier_ratio_threshold             | double | Ratio of allowable outliers in the interval (Value from 0~1)                    | 0.5                  |
+| gnss_error_covariance               | double | GNSS error covariance [m]                                                       | 0.5                  |
 
 
 ### position_interpolate
@@ -185,6 +186,7 @@ Figure shows the relationship between these parameters.
 | Name                                | Type   | Description                                                                     | Default value        |
 | :---------------------------------- | :----- | :------------------------------------------------------------------------------ | :------------------- |
 | sync_search_period                  | double | Synchronous search time for delay interpolation [s]                             | 2                    |
+| proc_noise                          | double | Process Noise [m]                                                               | 0.05                 |
 
 
 ### Optional Navigation Functions
@@ -200,10 +202,8 @@ Figure shows the relationship between these parameters.
 
 | Name                                | Type   | Description                                                                     | Default value        |
 | :---------------------------------- | :----- | :------------------------------------------------------------------------------ | :------------------- |
-| rtk_fix_STD                     | double | RTK-FIX position covariance
- [m]                 | 0.3                  |
-| proc_noise          | double | Process Noise
- [m]                               | 0.05                   |
+| rtk_fix_STD                         | double | RTK-FIX position covariance [m]                                                 | 0.3                  |
+| proc_noise                          | double | Process Noise [m]                                                               | 0.05                 |
 
 ### rtk_heading
 

--- a/eagleye_pp/eagleye_pp/config/eagleye_pp_config.yaml
+++ b/eagleye_pp/eagleye_pp/config/eagleye_pp_config.yaml
@@ -152,9 +152,11 @@ position:
   outlier_threshold: 3.0
   gnss_receiving_threshold: 0.25
   outlier_ratio_threshold: 0.5
+  gnss_error_covariance: 0.5
 
 position_interpolate:
   sync_search_period: 2
+  proc_noise: 0.05 #[m]
 
 # Optional Navigation Functions
 angular_velocity_offset_stop:

--- a/eagleye_pp/eagleye_pp/config/eagleye_pp_config_ci.yaml
+++ b/eagleye_pp/eagleye_pp/config/eagleye_pp_config_ci.yaml
@@ -2,7 +2,7 @@
 timestamp_sort: true
 # true: Look at the timestamp and determine the order of the buffers
 # false: Determine the order of the contents of the rosbag (This should be used when the time stamp is not recorded correctly)
-  
+
 # Output of Eagleye estimated parameters
 output_log: true
 
@@ -152,9 +152,11 @@ position:
   outlier_threshold: 3.0
   gnss_receiving_threshold: 0.25
   outlier_ratio_threshold: 0.5
+  gnss_error_covariance: 0.5
 
 position_interpolate:
   sync_search_period: 2
+  proc_noise: 0.05 # [m]
 
 # Optional Navigation Functions
 angular_velocity_offset_stop:

--- a/eagleye_pp/eagleye_pp/src/eagleye_pp_core.cpp
+++ b/eagleye_pp/eagleye_pp/src/eagleye_pp_core.cpp
@@ -162,6 +162,7 @@ void eagleye_pp::setParam(std::string arg_config_file, std::string *arg_twist_to
     position_interpolate_parameter_.imu_rate = conf["common"]["imu_rate"].as<double>();
     position_interpolate_parameter_.stop_judgment_threshold = conf["common"]["stop_judgment_threshold"].as<double>();
     position_interpolate_parameter_.sync_search_period = conf["position_interpolate"]["sync_search_period"].as<double>();
+    position_interpolate_parameter_.proc_noise = conf["position_interpolate"]["proc_noise"].as<double>();
 
     position_parameter_.ecef_base_pos_x = conf["ecef_base_pos"]["x"].as<double>();
     position_parameter_.ecef_base_pos_y = conf["ecef_base_pos"]["y"].as<double>();
@@ -176,6 +177,7 @@ void eagleye_pp::setParam(std::string arg_config_file, std::string *arg_twist_to
     position_parameter_.outlier_threshold = conf["position"]["outlier_threshold"].as<double>();
     position_parameter_.gnss_receiving_threshold = conf["heading"]["gnss_receiving_threshold"].as<double>();
     position_parameter_.outlier_ratio_threshold = conf["position"]["outlier_ratio_threshold"].as<double>();
+    position_parameter_.gnss_error_covariance = conf["position"]["gnss_error_covariance"].as<double>();
 
     rtk_deadreckoning_parameter_.ecef_base_pos_x = conf["ecef_base_pos"]["x"].as<double>();
     rtk_deadreckoning_parameter_.ecef_base_pos_y = conf["ecef_base_pos"]["y"].as<double>();
@@ -767,7 +769,7 @@ void eagleye_pp::estimatingEagleye(bool arg_forward_flag)
       else if (use_gnss_mode_ == "nmea" || use_gnss_mode_ == "NMEA")
         position_estimate(gga_[i], _correction_velocity, _velocity_status, _distance, _heading_interpolate_3rd, _enu_vel, position_parameter_, &position_status, &_enu_absolute_pos);
 
-      position_interpolate_estimate(_enu_absolute_pos, _enu_vel, _gnss_smooth_pos_enu, _height, position_interpolate_parameter_, &position_interpolate_status,
+      position_interpolate_estimate(_enu_absolute_pos, _enu_vel, _gnss_smooth_pos_enu, _height, _heading_interpolate_3rd, position_interpolate_parameter_, &position_interpolate_status,
         &_enu_absolute_pos_interpolate, &_eagleye_fix);
     }
     }

--- a/eagleye_rt/config/README.md
+++ b/eagleye_rt/config/README.md
@@ -15,12 +15,12 @@ The parameters for estimation in Eagleye can be set in the `config/eagleye_confi
 | Name                          | Type   | Description                                                             | Default value            |
 | :---------------------------- | :----- | :---------------------------------------------------------------------- | :----------------------- |
 | imu_topic                     | string | Topic name to be subscribed to in node (sensor_msgs/Imu.msg)            | /imu/data_raw            |
-| twist.twist_type                   | int | Topic type to be subscribed to in node (TwistStamped : 0, TwistWithCovarianceStamped: 1) | 0               |
-| twist.twist_topic                   | string | Topic name to be subscribed to in node | /can_twist               |
-| gnss.velocity_source_type              | int | Topic type to be subscribed to in node (rtklib_msgs/RtklibNav: 0, nmea_msgs/Sentence: 1, ublox_msgs/NavPVT: 2, geometry_msgs/TwistWithCovarianceStamped: 3)      | 0        |
-| gnss.velocity_source_topic              | string | Topic name to be subscribed to in node      | /rtklib_nav        |
-| gnss.llh_source_type              | int | Topic type to be subscribed to in node (rtklib_msgs/RtklibNav: 0, nmea_msgs/Sentence: 1, sensor_msgs/NavSatFix: 2)      | 0        |
-| gnss.llh_source_topic              | string | Topic name to be subscribed to in node   | /rtklib_nav        |
+| twist.twist_type              | int    | Topic type to be subscribed to in node (TwistStamped : 0, TwistWithCovarianceStamped: 1) | 0               |
+| twist.twist_topic             | string | Topic name to be subscribed to in node                                  | /can_twist               |
+| gnss.velocity_source_type     | int    | Topic type to be subscribed to in node (rtklib_msgs/RtklibNav: 0, nmea_msgs/Sentence: 1, ublox_msgs/NavPVT: 2, geometry_msgs/TwistWithCovarianceStamped: 3)      | 0        |
+| gnss.velocity_source_topic    | string | Topic name to be subscribed to in node                                  | /rtklib_nav        |
+| gnss.llh_source_type          | int    | Topic type to be subscribed to in node (rtklib_msgs/RtklibNav: 0, nmea_msgs/Sentence: 1, sensor_msgs/NavSatFix: 2)      | 0        |
+| gnss.llh_source_topic         | string | Topic name to be subscribed to in node                                  | /rtklib_nav        |
 
 ## TF
 
@@ -110,14 +110,14 @@ Figure shows the relationship between these parameters.
 | outlier_threshold                   | double | Outlier threshold due to GNSS multipath [rad]                                   | 0.0524 (3 deg)       |
 | outlier_ratio_threshold             | double | Ratio of allowable outliers in the interval (Value from 0~1)                    | 0.5                  |
 | curve_judgment_threshold            | double | Yaw rate threshold for curve determination [rad/s]                              | 0.0873 (5 deg/s)     |
-| init_STD                   | double | Standard deviation of Doppler azimuth angle [rad] | 0.0035 (0.2 deg)          |
+| init_STD                            | double | Standard deviation of Doppler azimuth angle [rad]                               | 0.0035 (0.2 deg)     |
 
 ### heading_interpolate
 
 | Name                                | Type   | Description                                                                     | Default value        |
 | :---------------------------------- | :----- | :------------------------------------------------------------------------------ | :------------------- |
 | sync_search_period                  | double | Synchronous search time for delay interpolation [s]                             | 2                    |
-| proc_noise                   | double | Process Noise [rad] | 0.0005 (0.03 deg)          |
+| proc_noise                          | double | Process Noise [rad]                                                             | 0.0005 (0.03 deg)    |
 
 ### slip_angle
 
@@ -185,14 +185,14 @@ Figure shows the relationship between these parameters.
 | gnss_receiving_threshold            | double | Threshold of minimum GNSS reception rate (Value from 0~1)                       | 0.25                 |
 | outlier_threshold                   | double | Outlier threshold due to GNSS multipath [m]                                     | 3                    |
 | outlier_ratio_threshold             | double | Ratio of allowable outliers in the interval (Value from 0~1)                    | 0.5                  |
-
+| gnss_error_covariance               | double | GNSS error covariance [m]                                                       | 0.5                  |
 
 ### position_interpolate
 
 | Name                                | Type   | Description                                                                     | Default value        |
 | :---------------------------------- | :----- | :------------------------------------------------------------------------------ | :------------------- |
 | sync_search_period                  | double | Synchronous search time for delay interpolation [s]                             | 2                    |
-
+| proc_noise                          | double | Process Noise [m]                                                               | 0.05                 |
 
 ### monitor
 

--- a/eagleye_rt/config/eagleye_config.yaml
+++ b/eagleye_rt/config/eagleye_config.yaml
@@ -111,9 +111,12 @@ position:
   outlier_threshold: 3.0
   gnss_receiving_threshold: 0.25
   outlier_ratio_threshold: 0.5
+  gnss_error_covariance: 0.5
 
 position_interpolate:
   sync_search_period: 2
+  proc_noise: 0.05 #[m]
+
 
 monitor:
   print_status: true

--- a/eagleye_rt/src/position_node.cpp
+++ b/eagleye_rt/src/position_node.cpp
@@ -176,9 +176,11 @@ int main(int argc, char** argv)
     _position_parameter.update_distance = conf["position"]["update_distance"].as<double>();
     _position_parameter.outlier_threshold = conf["position"]["outlier_threshold"].as<double>();
 
-    _position_parameter.gnss_receiving_threshold = conf["heading"]["gnss_receiving_threshold"].as<double>();
+    _position_parameter.gnss_receiving_threshold = conf["position"]["gnss_receiving_threshold"].as<double>();
     _position_parameter.outlier_ratio_threshold = conf["position"]["outlier_ratio_threshold"].as<double>();
 
+    _position_parameter.gnss_error_covariance = conf["position"]["gnss_error_covariance"].as<double>();
+    
     std::cout<< "use_gnss_mode " << _use_gnss_mode << std::endl;
     std::cout<< "use_canless_mode " << _use_canless_mode << std::endl;
 


### PR DESCRIPTION
Covariance can be estimated for position_node as well. The details are as follows.

- The covariance is determined by the variation of the GNSS with respect to the vehicle trajectory.
- Covariance estimation is computed when the estimate_status of the position_node is ture.
- In other cases, the covariance is updated using a motion model similar to rtk_deadreckoning.