### PR TITLE
covariance output(ROS2)

### DIFF
--- a/eagleye_core/navigation/include/eagleye_navigation/eagleye_navigation.hpp
+++ b/eagleye_core/navigation/include/eagleye_navigation/eagleye_navigation.hpp
@@ -244,6 +244,7 @@ struct PositionParameter
   double gnss_receiving_threshold;
   double outlier_threshold;
   double outlier_ratio_threshold;
+  double gnss_error_covariance;
 };
 
 struct PositionStatus
@@ -268,6 +269,7 @@ struct PositionInterpolateParameter
   double imu_rate;
   double stop_judgment_threshold;
   double sync_search_period;
+  double proc_noise;
 };
 
 
@@ -276,6 +278,7 @@ struct PositionInterpolateStatus
   int position_estimate_status_count;
   int number_buffer;
   bool position_estimate_start_status;
+  bool is_estimate_start{false};
   double position_stamp_last;
   double time_last;
   double provisional_enu_pos_x;
@@ -285,6 +288,7 @@ struct PositionInterpolateStatus
   std::vector<double> provisional_enu_pos_y_buffer;
   std::vector<double> provisional_enu_pos_z_buffer;
   std::vector<double> imu_stamp_buffer;
+  Eigen::MatrixXd position_covariance_last;
 };
 
 struct SlipangleParameter
@@ -532,7 +536,7 @@ extern void heading_interpolate_estimate(const sensor_msgs::msg::Imu, const geom
   const eagleye_msgs::msg::YawrateOffset,const eagleye_msgs::msg::YawrateOffset, const eagleye_msgs::msg::Heading, const eagleye_msgs::msg::SlipAngle,
   const HeadingInterpolateParameter,HeadingInterpolateStatus*, eagleye_msgs::msg::Heading*);
 extern void position_interpolate_estimate(const eagleye_msgs::msg::Position, const geometry_msgs::msg::Vector3Stamped, const eagleye_msgs::msg::Position,
-  const eagleye_msgs::msg::Height,const PositionInterpolateParameter, PositionInterpolateStatus*,eagleye_msgs::msg::Position*,sensor_msgs::msg::NavSatFix*);
+  const eagleye_msgs::msg::Height,const eagleye_msgs::msg::Heading, const PositionInterpolateParameter, PositionInterpolateStatus*,eagleye_msgs::msg::Position*,sensor_msgs::msg::NavSatFix*);
 extern void pitching_estimate(const sensor_msgs::msg::Imu, const nmea_msgs::msg::Gpgga, const geometry_msgs::msg::TwistStamped,
   const eagleye_msgs::msg::Distance,const HeightParameter,HeightStatus*,eagleye_msgs::msg::Height*,eagleye_msgs::msg::Pitching*,eagleye_msgs::msg::AccXOffset*,
   eagleye_msgs::msg::AccXScaleFactor*);

--- a/eagleye_core/navigation/src/position.cpp
+++ b/eagleye_core/navigation/src/position.cpp
@@ -292,11 +292,39 @@ void position_estimate_(geometry_msgs::msg::TwistStamped velocity,eagleye_msgs::
 
         if (index_length >= velocity_index_length * remain_data_ratio)
         {
+
+          std::vector<double> diff_x_buffer_for_covariance, diff_y_buffer_for_covariance, diff_z_buffer_for_covariance;
+          for (i = 0; i < index_length; i++)
+          {
+            diff_x_buffer_for_covariance.push_back(base_enu_pos_x_buffer2[index[i]] - position_status->enu_pos_x_buffer[index[i]]);
+            diff_y_buffer_for_covariance.push_back(base_enu_pos_y_buffer2[index[i]] - position_status->enu_pos_y_buffer[index[i]]);
+            diff_z_buffer_for_covariance.push_back(base_enu_pos_z_buffer2[index[i]] - position_status->enu_pos_z_buffer[index[i]]);
+          }
+
+          avg_x = std::accumulate(diff_x_buffer_for_covariance.begin(), diff_x_buffer_for_covariance.end(), 0.0) / index_length;
+          avg_y = std::accumulate(diff_y_buffer_for_covariance.begin(), diff_y_buffer_for_covariance.end(), 0.0) / index_length;
+          avg_z = std::accumulate(diff_z_buffer_for_covariance.begin(), diff_z_buffer_for_covariance.end(), 0.0) / index_length;
+
+          double cov_x, cov_y, cov_z;
+          double square_sum_x = 0, square_sum_y = 0, square_sum_z = 0;
+          for (i = 0; i < index_length; i++)
+          {
+            square_sum_x += (diff_x_buffer_for_covariance[i] - avg_x) * (diff_x_buffer_for_covariance[i] - avg_x);
+            square_sum_y += (diff_y_buffer_for_covariance[i] - avg_y) * (diff_y_buffer_for_covariance[i] - avg_y);
+            square_sum_z += (diff_z_buffer_for_covariance[i] - avg_z) * (diff_z_buffer_for_covariance[i] - avg_z);
+          }
+          cov_x = square_sum_x/index_length;
+          cov_y = square_sum_y/index_length;
+          cov_z = square_sum_z/index_length;
+
           if (index[index_length - 1] == position_status->estimated_number-1)
           {
             enu_absolute_pos->enu_pos.x = tmp_enu_pos_x;
             enu_absolute_pos->enu_pos.y = tmp_enu_pos_y;
             enu_absolute_pos->enu_pos.z = tmp_enu_pos_z;
+            enu_absolute_pos->covariance[0] = cov_x + position_parameter.gnss_error_covariance; // [m^2]
+            enu_absolute_pos->covariance[4] = cov_y + position_parameter.gnss_error_covariance; // [m^2]
+            enu_absolute_pos->covariance[8] = cov_z + position_parameter.gnss_error_covariance; // [m^2]
             enu_absolute_pos->status.enabled_status = true;
             enu_absolute_pos->status.estimate_status = true;
           }

--- a/eagleye_core/navigation/src/position_interpolate.cpp
+++ b/eagleye_core/navigation/src/position_interpolate.cpp
@@ -31,7 +31,7 @@
 #include "eagleye_coordinate/eagleye_coordinate.hpp"
 #include "eagleye_navigation/eagleye_navigation.hpp"
 
-void position_interpolate_estimate(eagleye_msgs::msg::Position enu_absolute_pos, geometry_msgs::msg::Vector3Stamped enu_vel, eagleye_msgs::msg::Position gnss_smooth_pos, eagleye_msgs::msg::Height height,PositionInterpolateParameter position_interpolate_parameter, PositionInterpolateStatus* position_interpolate_status, eagleye_msgs::msg::Position* enu_absolute_pos_interpolate,sensor_msgs::msg::NavSatFix* eagleye_fix)
+void position_interpolate_estimate(eagleye_msgs::msg::Position enu_absolute_pos, geometry_msgs::msg::Vector3Stamped enu_vel, eagleye_msgs::msg::Position gnss_smooth_pos, eagleye_msgs::msg::Height height, eagleye_msgs::msg::Heading heading, PositionInterpolateParameter position_interpolate_parameter, PositionInterpolateStatus* position_interpolate_status, eagleye_msgs::msg::Position* enu_absolute_pos_interpolate,sensor_msgs::msg::NavSatFix* eagleye_fix)
 {
 
   int i;
@@ -125,6 +125,7 @@ void position_interpolate_estimate(eagleye_msgs::msg::Position enu_absolute_pos,
       position_interpolate_status->provisional_enu_pos_y = position_interpolate_status->provisional_enu_pos_y_buffer[position_interpolate_status->number_buffer-1];
       position_interpolate_status->provisional_enu_pos_z = position_interpolate_status->provisional_enu_pos_z_buffer[position_interpolate_status->number_buffer-1];
 
+      position_interpolate_status->is_estimate_start = true;
       enu_absolute_pos_interpolate->status.enabled_status = true;
       enu_absolute_pos_interpolate->status.estimate_status = true;
     }
@@ -142,7 +143,7 @@ void position_interpolate_estimate(eagleye_msgs::msg::Position enu_absolute_pos,
     }
   }
 
-  if (position_interpolate_status->position_estimate_start_status == true)
+  if (position_interpolate_status->position_estimate_start_status && position_interpolate_status->is_estimate_start)
   {
     enu_pos[0] = position_interpolate_status->provisional_enu_pos_x;
     enu_pos[1] = position_interpolate_status->provisional_enu_pos_y;
@@ -153,6 +154,56 @@ void position_interpolate_estimate(eagleye_msgs::msg::Position enu_absolute_pos,
     ecef_base_pos[2] = enu_absolute_pos.ecef_base_pos.z;
 
     enu2llh(enu_pos, ecef_base_pos, llh_pos);
+
+    Eigen::MatrixXd init_covariance;
+    init_covariance = Eigen::MatrixXd::Zero(6, 6);
+    init_covariance(0,0) = enu_absolute_pos.covariance[0];
+    init_covariance(1,1) = enu_absolute_pos.covariance[4];
+    init_covariance(2,2) = enu_absolute_pos.covariance[8];
+    init_covariance(5,5) = heading.variance;
+
+    double proc_noise = position_interpolate_parameter.proc_noise;
+    Eigen::MatrixXd proc_covariance;
+    proc_covariance = Eigen::MatrixXd::Zero(6, 6);
+    proc_covariance(0,0) = proc_noise * proc_noise;
+    proc_covariance(1,1) = proc_noise * proc_noise;
+    proc_covariance(2,2) = proc_noise * proc_noise;
+
+    Eigen::MatrixXd position_covariance;
+    position_covariance = Eigen::MatrixXd::Zero(6, 6);
+
+    double velocity = std::sqrt(enu_vel.vector.x*enu_vel.vector.x + enu_vel.vector.y*enu_vel.vector.y + enu_vel.vector.z*enu_vel.vector.z);
+
+    if(enu_absolute_pos_interpolate->status.estimate_status)
+    {
+      position_covariance = init_covariance;
+      position_interpolate_status->position_covariance_last = position_covariance;
+    }
+    else if (velocity > position_interpolate_parameter.stop_judgment_threshold)
+    {
+      Eigen::MatrixXd jacobian;
+      jacobian = Eigen::MatrixXd::Zero(6, 6);
+      jacobian(0,0) = 1;
+      jacobian(1,1) = 1;
+      jacobian(2,2) = 1;
+      jacobian(3,3) = 1;
+      jacobian(4,4) = 1;
+      jacobian(5,5) = 1;
+      jacobian(0,5) = enu_vel.vector.y*(enu_vel_time - position_interpolate_status->time_last);
+      jacobian(1,5) = -enu_vel.vector.x*(enu_vel_time - position_interpolate_status->time_last);
+
+      // MEMO: Jacobean not included
+      // position_covariance = position_interpolate_status->position_covariance_last + proc_covariance;
+
+      // MEMO: Jacobean not included
+      position_covariance = jacobian * position_interpolate_status->position_covariance_last * (jacobian.transpose())   + proc_covariance;
+
+      position_interpolate_status->position_covariance_last = position_covariance;
+    }
+    else
+    {
+      position_covariance = position_interpolate_status->position_covariance_last;
+    }
 
     eagleye_fix->longitude = llh_pos[1] * 180/M_PI;
     eagleye_fix->latitude = llh_pos[0] * 180/M_PI;
@@ -169,6 +220,9 @@ void position_interpolate_estimate(eagleye_msgs::msg::Position enu_absolute_pos,
     enu_absolute_pos_interpolate->enu_pos.x = enu_pos[0];
     enu_absolute_pos_interpolate->enu_pos.y = enu_pos[1];
     enu_absolute_pos_interpolate->enu_pos.z = enu_pos[2];
+    enu_absolute_pos_interpolate->covariance[0] = position_covariance(0,0); // [m^2]
+    enu_absolute_pos_interpolate->covariance[4] = position_covariance(1,1); // [m^2]
+    enu_absolute_pos_interpolate->covariance[8] = position_covariance(2,2); // [m^2]
 
     eagleye_fix->altitude = llh_pos[2];
 
@@ -176,6 +230,9 @@ void position_interpolate_estimate(eagleye_msgs::msg::Position enu_absolute_pos,
     eagleye_fix->position_covariance[0] = 1.5 * 1.5; // [m^2]
     eagleye_fix->position_covariance[4] = 1.5 * 1.5; // [m^2]
     eagleye_fix->position_covariance[8] = 1.5 * 1.5; // [m^2]
+    eagleye_fix->position_covariance[0] = position_covariance(0,0); // [m^2]
+    eagleye_fix->position_covariance[4] = position_covariance(1,1); // [m^2]
+    eagleye_fix->position_covariance[8] = position_covariance(2,2); // [m^2]
 
   }
   else

--- a/eagleye_core/navigation/src/rtk_dead_reckoning.cpp
+++ b/eagleye_core/navigation/src/rtk_dead_reckoning.cpp
@@ -140,13 +140,14 @@ void rtk_dead_reckoning_estimate_(geometry_msgs::msg::Vector3Stamped enu_vel, nm
     Eigen::MatrixXd position_covariance;
     position_covariance = Eigen::MatrixXd::Zero(6, 6);
 
+    double velocity = std::sqrt(enu_vel.vector.x*enu_vel.vector.x + enu_vel.vector.y*enu_vel.vector.y + enu_vel.vector.z*enu_vel.vector.z);
 
     if(enu_absolute_rtk_dead_reckoning->status.estimate_status)
     {
       position_covariance = init_covariance;
       rtk_dead_reckoning_status->position_covariance_last = position_covariance;
     }
-    else
+    else if (velocity > rtk_dead_reckoning_parameter.stop_judgment_threshold)
     {
       Eigen::MatrixXd jacobian;
       jacobian = Eigen::MatrixXd::Zero(6, 6);
@@ -166,6 +167,10 @@ void rtk_dead_reckoning_estimate_(geometry_msgs::msg::Vector3Stamped enu_vel, nm
       position_covariance = jacobian * rtk_dead_reckoning_status->position_covariance_last * (jacobian.transpose())   + proc_covariance;
 
       rtk_dead_reckoning_status->position_covariance_last = position_covariance;
+    }
+    else
+    {
+      position_covariance = rtk_dead_reckoning_status->position_covariance_last;
     }
 
     eagleye_fix->latitude = llh_pos[0] * 180/M_PI;

--- a/eagleye_rt/config/eagleye_config.yaml
+++ b/eagleye_rt/config/eagleye_config.yaml
@@ -118,9 +118,11 @@
       outlier_threshold: 3.0
       gnss_receiving_threshold: 0.25
       outlier_ratio_threshold: 0.5
+      gnss_error_covariance: 0.5 #[m]
 
     position_interpolate:
       sync_search_period: 2
+      proc_noise: 0.05 #[m]
 
     monitor:
       print_status: true

--- a/eagleye_rt/src/position_node.cpp
+++ b/eagleye_rt/src/position_node.cpp
@@ -182,8 +182,10 @@ int main(int argc, char** argv)
     position_parameter.update_distance = conf["/**"]["ros__parameters"]["position"]["update_distance"].as<double>();
     position_parameter.outlier_threshold = conf["/**"]["ros__parameters"]["position"]["outlier_threshold"].as<double>();
 
-    position_parameter.gnss_receiving_threshold = conf["/**"]["ros__parameters"]["heading"]["gnss_receiving_threshold"].as<double>();
+    position_parameter.gnss_receiving_threshold = conf["/**"]["ros__parameters"]["position"]["gnss_receiving_threshold"].as<double>();
     position_parameter.outlier_ratio_threshold = conf["/**"]["ros__parameters"]["position"]["outlier_ratio_threshold"].as<double>();
+
+    position_parameter.gnss_error_covariance = conf["/**"]["ros__parameters"]["position"]["gnss_error_covariance"].as<double>();
 
     std::cout<< "use_gnss_mode " << use_gnss_mode << std::endl;
     std::cout<< "use_can_less_mode " << use_can_less_mode << std::endl;


### PR DESCRIPTION
(ROS2 ver)
Covariance can be estimated for position_node as well. The details are as follows.

- The covariance is determined by the variation of the GNSS with respect to the vehicle trajectory.
- Covariance estimation is computed when the estimate_status of the position_node is ture.
- In other cases, the covariance is updated using a motion model similar to rtk_deadreckoning.