### PR TITLE
Add velocity subscriver in slip_angle_node

### DIFF
--- a/eagleye_rt/src/slip_angle_node.cpp
+++ b/eagleye_rt/src/slip_angle_node.cpp
@@ -124,6 +124,7 @@ int main(int argc, char** argv)
   auto sub2 = node->create_subscription<eagleye_msgs::msg::VelocityScaleFactor>("velocity_scale_factor", rclcpp::QoS(10), velocity_scale_factor_callback);  //ros::TransportHints().tcpNoDelay()
   auto sub3 = node->create_subscription<eagleye_msgs::msg::YawrateOffset>("yaw_rate_offset_stop", rclcpp::QoS(10), yaw_rate_offset_stop_callback);  //ros::TransportHints().tcpNoDelay()
   auto sub4 = node->create_subscription<eagleye_msgs::msg::YawrateOffset>("yaw_rate_offset_2nd", rclcpp::QoS(10), yaw_rate_offset_2nd_callback);  //ros::TransportHints().tcpNoDelay()
+  auto sub5 = node->create_subscription<geometry_msgs::msg::TwistStamped>("velocity", rclcpp::QoS(10), velocity_callback);  //ros::TransportHints().tcpNoDelay()
   pub = node->create_publisher<eagleye_msgs::msg::SlipAngle>("slip_angle", rclcpp::QoS(10));
 
   rclcpp::spin(node);


### PR DESCRIPTION
Fixed a problem with slip angles not being published correctly.

The slip angle is calculated as follows
```
acceleration_y = velocity.twist.linear.x * yaw_rate;
...
slip_angle->slip_angle = slip_angle_parameter.manual_coefficient * acceleration_y;
```

Therefore, without this correction, the slip angle correction will not be applied.