### PR TITLE
Fix gsigeo2011_ver2_1 path(ROS2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Clone and build the necessary packages for Eagleye. ([rtklib_ros_bridge](https:/
 	sudo apt-get install -y libgeographic-dev geographiclib-tools geographiclib-doc
 	sudo geographiclib-get-geoids best
 	sudo mkdir /usr/share/GSIGEO
-	sudo cp eagleye/eagleye_util/llh_converter/data/gsigeo2011_ver2_1.asc /usr/share/GSIGEO/
+	sudo cp llh_converter/data/gsigeo2011_ver2_1.asc /usr/share/GSIGEO/
 	cd ..
 	rosdep install --from-paths src --ignore-src -r -y
 	colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release


### PR DESCRIPTION
## Update the setup instruction for a cleanly built environment.

Replace 
```bash
sudo cp eagleye/eagleye_util/llh_converter/data/gsigeo2011_ver2_1.asc /usr/share/GSIGEO/
```
with 
```bash
sudo cp llh_converter/data/gsigeo2011_ver2_1.asc /usr/share/GSIGEO/
```

To reproduce this fix, create a new ros2 project and follow the instruction. The original command should pop up an error complaining file is not found.