### PR TITLE
fixed stop judgment bug

### DIFF
--- a/eagleye_core/navigation/src/angular_velocity_offset_stop.cpp
+++ b/eagleye_core/navigation/src/angular_velocity_offset_stop.cpp
@@ -70,7 +70,7 @@ void angular_velocity_offset_stop_estimate(const geometry_msgs::msg::TwistStampe
     angular_velocity_stop_status->yaw_rate_buffer.erase(angular_velocity_stop_status->yaw_rate_buffer.begin());
   }
 
-  if (velocity.twist.linear.x < angular_velocity_stop_parameter.stop_judgment_threshold)
+  if (std::abs(velocity.twist.linear.x) < angular_velocity_stop_parameter.stop_judgment_threshold)
   {
     ++angular_velocity_stop_status->stop_count;
   }

--- a/eagleye_core/navigation/src/yaw_rate_offset_stop.cpp
+++ b/eagleye_core/navigation/src/yaw_rate_offset_stop.cpp
@@ -59,7 +59,7 @@ void yaw_rate_offset_stop_estimate(const geometry_msgs::msg::TwistStamped veloci
     yaw_rate_offset_stop_status->yaw_rate_buffer.erase(yaw_rate_offset_stop_status->yaw_rate_buffer.begin());
   }
 
-  if (velocity.twist.linear.x < yaw_rate_offset_stop_parameter.stop_judgment_threshold)
+  if (std::abs(velocity.twist.linear.x) < yaw_rate_offset_stop_parameter.stop_judgment_threshold)
   {
     ++yaw_rate_offset_stop_status->stop_count;
   }


### PR DESCRIPTION
Solved the problem of position estimation error when backing up.
The following items have been corrected:

- Fixed a problem in which a stop was determined even though the speed was negative.

Please refer to the documents for details.