### PR TITLE
Change of coordinate system for Eagleye's standard input IMU

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,16 @@ Access mosaic's web ui and upload the following file in Admin/Configuration.
 
 https://www.dropbox.com/s/uckt9
 
+### IMU
+
+1. IMU settings.
+
+* Output rate 50Hz
+
+2. Please be careful with the coordinate system when using the [tamagawa ros driver](https://github.com/MapIV/tamagawa_imu_driver) created by MAP IV. If the x-direction indicated on the IMU is set to the vehicle's direction and the y-direction to the right side of the vehicle, please set the `roll` in the `eagleye/eagleye_util/tf/config/sensors_tf.yaml file` to `3.14159`.
+
+		 roll: 3.14159
+
 ### Eagleye parameters
 
 The parameters of eagleye can be set in the [eagleye_config.yaml](https://github.com/MapIV/eagleye/tree/ros2-galactic-v1.1.5/eagleye_rt/config/eagleye_config.yaml). The default settings are 5Hz for GNSS and 50Hz for IMU.

--- a/eagleye_rt/config/eagleye_config.yaml
+++ b/eagleye_rt/config/eagleye_config.yaml
@@ -31,7 +31,7 @@
       z : 0.0
       use_ecef_base_position : false
 
-    reverse_imu_wz: false
+    use_m4_tamagawa_driver : false
 
     # Eagleye Navigation Parameters
     # Basic Navigation Functions

--- a/eagleye_rt/config/eagleye_config.yaml
+++ b/eagleye_rt/config/eagleye_config.yaml
@@ -31,8 +31,6 @@
       z : 0.0
       use_ecef_base_position : false
 
-    use_m4_tamagawa_driver : false
-
     # Eagleye Navigation Parameters
     # Basic Navigation Functions
     common:

--- a/eagleye_rt/src/tf_converted_imu.cpp
+++ b/eagleye_rt/src/tf_converted_imu.cpp
@@ -64,7 +64,7 @@ private:
 
   std::string tf_base_link_frame_;
 
-  bool reverse_imu_wz_;
+  bool use_m4_tamagawa_driver_;
 
   void imu_callback(const sensor_msgs::msg::Imu::ConstPtr msg);
 
@@ -82,17 +82,17 @@ TFConvertedIMU::TFConvertedIMU() : Node("eagleye_tf_converted_imu"),
   declare_parameter("imu_topic", subscribe_imu_topic_name);
   declare_parameter("publish_imu_topic", publish_imu_topic_name);
   declare_parameter("tf_gnss_frame.parent", tf_base_link_frame_);
-  declare_parameter("reverse_imu_wz", reverse_imu_wz_);
+  declare_parameter("use_m4_tamagawa_driver", use_m4_tamagawa_driver_);
 
   get_parameter("imu_topic", subscribe_imu_topic_name);
   get_parameter("publish_imu_topic", publish_imu_topic_name);
   get_parameter("tf_gnss_frame.parent", tf_base_link_frame_);
-  get_parameter("reverse_imu_wz", reverse_imu_wz_);
+  get_parameter("use_m4_tamagawa_driver", use_m4_tamagawa_driver_);
 
   std::cout<< "subscribe_imu_topic_name: " << subscribe_imu_topic_name << std::endl;
   std::cout<< "publish_imu_topic_name: " << publish_imu_topic_name << std::endl;
   std::cout<< "tf_base_link_frame: " << tf_base_link_frame_ << std::endl;
-  std::cout<< "reverse_imu_wz: " << reverse_imu_wz_ << std::endl;
+  std::cout<< "use_m4_tamagawa_driver: " << use_m4_tamagawa_driver_ << std::endl;
 
   sub_ =  create_subscription<sensor_msgs::msg::Imu>(subscribe_imu_topic_name, rclcpp::QoS(10), std::bind(&TFConvertedIMU::imu_callback, this, std::placeholders::_1));
   pub_ = create_publisher<sensor_msgs::msg::Imu>("imu/data_tf_converted", rclcpp::QoS(10));
@@ -121,14 +121,14 @@ void TFConvertedIMU::imu_callback(const sensor_msgs::msg::Imu::ConstPtr msg)
     tf2::doTransform(linear_acceleration, transformed_linear_acceleration, transform);
 
     tf_converted_imu_.angular_velocity = transformed_angular_velocity.vector;
-    if(reverse_imu_wz_)
+    if(!use_m4_tamagawa_driver_)
     {
+      tf_converted_imu_.angular_velocity.y = (-1) * transformed_angular_velocity.vector.y;
       tf_converted_imu_.angular_velocity.z = (-1) * transformed_angular_velocity.vector.z;
+      tf_converted_imu_.linear_acceleration.y = (-1) * transformed_linear_acceleration.vector.y;
+      tf_converted_imu_.linear_acceleration.z = (-1) * transformed_linear_acceleration.vector.z;
     }
-    else
-    {
-      tf_converted_imu_.angular_velocity.z = transformed_angular_velocity.vector.z;
-    }
+
     tf_converted_imu_.linear_acceleration = transformed_linear_acceleration.vector;
     tf_converted_imu_.orientation = transformed_quaternion;
 

--- a/eagleye_rt/src/tf_converted_imu.cpp
+++ b/eagleye_rt/src/tf_converted_imu.cpp
@@ -64,8 +64,6 @@ private:
 
   std::string tf_base_link_frame_;
 
-  bool use_m4_tamagawa_driver_;
-
   void imu_callback(const sensor_msgs::msg::Imu::ConstPtr msg);
 
 };
@@ -82,17 +80,14 @@ TFConvertedIMU::TFConvertedIMU() : Node("eagleye_tf_converted_imu"),
   declare_parameter("imu_topic", subscribe_imu_topic_name);
   declare_parameter("publish_imu_topic", publish_imu_topic_name);
   declare_parameter("tf_gnss_frame.parent", tf_base_link_frame_);
-  declare_parameter("use_m4_tamagawa_driver", use_m4_tamagawa_driver_);
 
   get_parameter("imu_topic", subscribe_imu_topic_name);
   get_parameter("publish_imu_topic", publish_imu_topic_name);
   get_parameter("tf_gnss_frame.parent", tf_base_link_frame_);
-  get_parameter("use_m4_tamagawa_driver", use_m4_tamagawa_driver_);
 
   std::cout<< "subscribe_imu_topic_name: " << subscribe_imu_topic_name << std::endl;
   std::cout<< "publish_imu_topic_name: " << publish_imu_topic_name << std::endl;
   std::cout<< "tf_base_link_frame: " << tf_base_link_frame_ << std::endl;
-  std::cout<< "use_m4_tamagawa_driver: " << use_m4_tamagawa_driver_ << std::endl;
 
   sub_ =  create_subscription<sensor_msgs::msg::Imu>(subscribe_imu_topic_name, rclcpp::QoS(10), std::bind(&TFConvertedIMU::imu_callback, this, std::placeholders::_1));
   pub_ = create_publisher<sensor_msgs::msg::Imu>("imu/data_tf_converted", rclcpp::QoS(10));
@@ -121,13 +116,12 @@ void TFConvertedIMU::imu_callback(const sensor_msgs::msg::Imu::ConstPtr msg)
     tf2::doTransform(linear_acceleration, transformed_linear_acceleration, transform);
 
     tf_converted_imu_.angular_velocity = transformed_angular_velocity.vector;
-    if(!use_m4_tamagawa_driver_)
-    {
-      tf_converted_imu_.angular_velocity.y = (-1) * transformed_angular_velocity.vector.y;
-      tf_converted_imu_.angular_velocity.z = (-1) * transformed_angular_velocity.vector.z;
-      tf_converted_imu_.linear_acceleration.y = (-1) * transformed_linear_acceleration.vector.y;
-      tf_converted_imu_.linear_acceleration.z = (-1) * transformed_linear_acceleration.vector.z;
-    }
+
+    // The latter part of the process assumes the coordinate system of the IMU output from tamagawa_imu_driver, so conversion is necessary.
+    tf_converted_imu_.angular_velocity.y = (-1) * transformed_angular_velocity.vector.y;
+    tf_converted_imu_.angular_velocity.z = (-1) * transformed_angular_velocity.vector.z;
+    tf_converted_imu_.linear_acceleration.y = (-1) * transformed_linear_acceleration.vector.y;
+    tf_converted_imu_.linear_acceleration.z = (-1) * transformed_linear_acceleration.vector.z;
 
     tf_converted_imu_.linear_acceleration = transformed_linear_acceleration.vector;
     tf_converted_imu_.orientation = transformed_quaternion;


### PR DESCRIPTION
The current input IMU of Eagleye has an issue with the coordinate system.
https://github.com/MapIV/eagleye/issues/289
This is the PR to fix it.

Eagleye first converts the input IMU in the tf_converted_imu node through a tf transformation.
In this section, issues related to the coordinate system are corrected.