### PR TITLE
[ros1]Resolve xacro warning

### DIFF
--- a/eagleye_util/tf/urdf/sensors.xacro
+++ b/eagleye_util/tf/urdf/sensors.xacro
@@ -3,7 +3,7 @@
   xmlns:xacro="http://ros.org/wiki/xacro">
 
   <xacro:arg name="config_dir" default="$(find eagleye_tf)"/>
-  <xacro:property name="calibration" value="${load_yaml('$(arg config_dir)/sensors_tf.yaml')}"/>
+  <xacro:property name="calibration" value="${xacro.load_yaml('$(arg config_dir)/sensors_tf.yaml')}"/>
   <xacro:property name="size" value="1" />
 
   <!-- base_link -->


### PR DESCRIPTION
noetic環境で実行するとload_yamlでなくxacro.load_yamlを使うように指示された。
この警告文にしたがって修正を加えた。