### PR TITLE
[autoware-main] feat(gnss_converter): enable to read septentrio_gnss_driver/PVTGeodetic for velocity source

### DIFF
--- a/eagleye_rt/config/README.md
+++ b/eagleye_rt/config/README.md
@@ -17,7 +17,7 @@ The parameters for estimation in Eagleye can be set in the `config/eagleye_confi
 | imu_topic                     | string | Topic name to be subscribed to in node (sensor_msgs/Imu.msg)            | /imu/data_raw            |
 | twist.twist_type                   | int | Topic type to be subscribed to in node (TwistStamped : 0, TwistWithCovarianceStamped: 1) | 0               |
 | twist.twist_topic                   | string | Topic name to be subscribed to in node | /can_twist               |
-| gnss.velocity_source_type              | int | Topic type to be subscribed to in node (rtklib_msgs/RtklibNav: 0, nmea_msgs/Sentence: 1, ublox_msgs/NavPVT: 2, geometry_msgs/TwistWithCovarianceStamped: 3)      | 0        |
+| gnss.velocity_source_type              | int | Topic type to be subscribed to in node (rtklib_msgs/RtklibNav: 0, nmea_msgs/Sentence: 1, ublox_msgs/NavPVT: 2, geometry_msgs/TwistWithCovarianceStamped: 3, septentrio_gnss_driver/PVTGeodetic: 4)      | 0        |
 | gnss.velocity_source_topic              | string | Topic name to be subscribed to in node      | /rtklib_nav        |
 | gnss.llh_source_type              | int | Topic type to be subscribed to in node (rtklib_msgs/RtklibNav: 0, nmea_msgs/Sentence: 1, sensor_msgs/NavSatFix: 2)      | 0        |
 | gnss.llh_source_topic              | string | Topic name to be subscribed to in node   | /rtklib_nav        |

--- a/eagleye_rt/config/eagleye_config.yaml
+++ b/eagleye_rt/config/eagleye_config.yaml
@@ -10,7 +10,7 @@
       twist_topic: /can_twist
     imu_topic: /imu/data_raw
     gnss:
-      velocity_source_type: 0 # rtklib_msgs/RtklibNav: 0, nmea_msgs/Sentence: 1, ublox_msgs/NavPVT: 2, geometry_msgs/TwistWithCovarianceStamped: 3
+      velocity_source_type: 0 # rtklib_msgs/RtklibNav: 0, nmea_msgs/Sentence: 1, ublox_msgs/NavPVT: 2, geometry_msgs/TwistWithCovarianceStamped: 3, septentrio_gnss_driver/PVTGeodetic: 4
       velocity_source_topic:  /rtklib_nav
       llh_source_type: 0 # rtklib_msgs/RtklibNav: 0, nmea_msgs/Sentence: 1, sensor_msgs/NavSatFix: 2
       llh_source_topic:  /rtklib_nav

--- a/eagleye_util/gnss_converter/package.xml
+++ b/eagleye_util/gnss_converter/package.xml
@@ -13,6 +13,7 @@
   <build_depend>sensor_msgs</build_depend>
   <build_depend>nmea_msgs</build_depend>
   <build_depend>ublox_msgs</build_depend>
+  <build_depend>septentrio_gnss_driver</build_depend>
   <build_depend>rtklib_msgs</build_depend>
   <build_depend>eagleye_coordinate</build_depend>
   <build_depend>eagleye_navigation</build_depend>
@@ -22,6 +23,7 @@
   <build_export_depend>sensor_msgs</build_export_depend>
   <build_export_depend>nmea_msgs</build_export_depend>
   <build_export_depend>ublox_msgs</build_export_depend>
+  <build_export_depend>septentrio_gnss_driver</build_export_depend>
   <build_export_depend>rtklib_msgs</build_export_depend>
   <build_export_depend>eagleye_coordinate</build_export_depend>
   <build_export_depend>eagleye_navigation</build_export_depend>
@@ -31,6 +33,7 @@
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>nmea_msgs</exec_depend>
   <exec_depend>ublox_msgs</exec_depend>
+  <exec_depend>septentrio_gnss_driver</exec_depend>
   <exec_depend>rtklib_msgs</exec_depend>
   <exec_depend>eagleye_coordinate</exec_depend>
   <exec_depend>eagleye_navigation</exec_depend>


### PR DESCRIPTION
## Description

This PR aims to enable Eagleye to read message types from `septentrio_gnss_driver` for velocity source.
This PR only supports the [`septentrio_gnss_driver/PVTGeodetic` message type](http://docs.ros.org/en/melodic/api/septentrio_gnss_driver/html/msg/PVTGeodetic.html).

## How is this tested?

This code is tested in one of the internal driving data of TIER IV, and confirmed Eagleye works well.
I apologize I cannot share the data with the reviewers.