### PR TITLE
fix: add find_package(Boost) to eagleye_gnss_converter

### DIFF
--- a/eagleye_util/gnss_converter/CMakeLists.txt
+++ b/eagleye_util/gnss_converter/CMakeLists.txt
@@ -19,6 +19,7 @@ find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
 
 include_directories(include)
+find_package(Boost REQUIRED COMPONENTS system thread regex chrono)
 
 ament_auto_add_executable(gnss_converter
   src/nmea2fix_core.cpp


### PR DESCRIPTION
Some people have encountered the following errors.

```
Starting >>> eagleye_gnss_converter
--- stderr: eagleye_gnss_converter                           
CMake Error at /home/user/autoware/install/ament_cmake_auto/share/ament_cmake_auto/cmake/ament_auto_add_executable.cmake:66 (add_executable):
  Target "gnss_converter" links to target "Boost::system" but the target was
  not found.  Perhaps a find_package() call is missing for an IMPORTED
  target, or an ALIAS target is missing?
Call Stack (most recent call first):
  CMakeLists.txt:23 (ament_auto_add_executable)


CMake Error at /home/user/autoware/install/ament_cmake_auto/share/ament_cmake_auto/cmake/ament_auto_add_executable.cmake:66 (add_executable):
  Target "gnss_converter" links to target "Boost::thread" but the target was
  not found.  Perhaps a find_package() call is missing for an IMPORTED
  target, or an ALIAS target is missing?
Call Stack (most recent call first):
  CMakeLists.txt:23 (ament_auto_add_executable)
```

It seems that this issue will be fixed by the change in this pull request.