### PR TITLE
fix(eagleye_coordinate): fix misc-throw-by-value-catch-by-reference

### DIFF
--- a/eagleye_core/coordinate/src/convertheight.cpp
+++ b/eagleye_core/coordinate/src/convertheight.cpp
@@ -48,7 +48,7 @@ double ConvertHeight::convert2altitude()
     GeographicLib::Geoid egm2008("egm2008-1");
     converted_height = egm2008.ConvertHeight(_latitude, _longitude, _height, GeographicLib::Geoid::ELLIPSOIDTOGEOID);
   }
-  catch (const GeographicLib::GeographicErr err)
+  catch (const GeographicLib::GeographicErr& err)
   {
     std::cerr << "\033[31;1mError: Failed to convert height from Ellipsoid to Altitude. " << err.what() << std::endl;
     exit(4);
@@ -64,7 +64,7 @@ double ConvertHeight::convert2ellipsoid()
     GeographicLib::Geoid egm2008("egm2008-1");
     converted_height = egm2008.ConvertHeight(_latitude, _longitude, _height, GeographicLib::Geoid::GEOIDTOELLIPSOID);
   }
-  catch (const GeographicLib::GeographicErr err)
+  catch (const GeographicLib::GeographicErr& err)
   {
     std::cerr << "\033[31;1mError: Failed to convert height from Ellipsoid to Altitude. " << err.what() << std::endl;
     exit(4);


### PR DESCRIPTION
This is a fix based on clang-tidy `misc-throw-by-value-catch-by-reference` error.

```
/home/emb4/autoware/autoware/src/universe/external/eagleye/eagleye_core/coordinate/src/convertheight.cpp:51:10: error: catch handler catches by value; should catch by reference instead [misc-throw-by-value-catch-by-reference,-warnings-as-errors]
  catch (const GeographicLib::GeographicErr err)
         ^
/home/emb4/autoware/autoware/src/universe/external/eagleye/eagleye_core/coordinate/src/convertheight.cpp:67:10: error: catch handler catches by value; should catch by reference instead [misc-throw-by-value-catch-by-reference,-warnings-as-errors]
  catch (const GeographicLib::GeographicErr err)
         ^
```
I have already confirmed that the build passes with autoware's colcon build.
