### PR TITLE
fix: referencing to status in RTKLIB msg from gnss_converter_node

### DIFF
--- a/eagleye_util/gnss_converter/src/gnss_converter_node.cpp
+++ b/eagleye_util/gnss_converter/src/gnss_converter_node.cpp
@@ -201,6 +201,9 @@ void gnss_velocity_callback(const geometry_msgs::TwistWithCovarianceStamped::Con
   rtklib_msgs::RtklibNav r;
   r.header.frame_id = "gps";
   r.header.stamp = msg->header.stamp;
+  if (nav_msg_ptr != nullptr){
+    r.status = *nav_msg_ptr;
+  }
   double gnss_velocity_time = msg->header.stamp.toSec();
   r.tow = gnss_velocity_time;
 


### PR DESCRIPTION
Fixed issue where status of /eagleye/navsat/rtklib_nav topic's status wasn't populated because of missing assignment of data.