### PR TITLE
fix: improve jazzy build compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: rosdep update
         run: |
           apt-get update
@@ -40,5 +40,64 @@ jobs:
         run: |
           cd ~/eagleye/
           source /opt/ros/humble/setup.bash
+          rosdep install --from-paths src --ignore-src -r -y
+          colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release --catkin-skip-building-tests
+
+  jazzy_build:
+    runs-on: ubuntu-24.04
+
+    container: ros:jazzy
+    services:
+      ros:
+        image: ros
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: rosdep update
+        run: |
+          apt-get update
+          rosdep update
+      - name: Create Workspace
+        run: |
+          mkdir -p ~/eagleye/src/
+          cp -r "$(pwd)" ~/eagleye/src/
+      - name: Clone rtklib_msgs
+        run: |
+          cd ~/eagleye/src/
+          git clone https://github.com/MapIV/rtklib_ros_bridge.git -b ros2-v0.1.0
+      - name: Clone llh_converter
+        run: |
+          cd ~/eagleye/src/
+          git clone https://github.com/MapIV/llh_converter.git -b ros2
+      - name: Patch llh_converter for Jazzy CI
+        run: |
+          python3 - <<'PY'
+          from pathlib import Path
+
+          path = Path.home() / "eagleye/src/llh_converter/CMakeLists.txt"
+          text = path.read_text()
+          text = text.replace("${GeographicLib_INCLUDE_DIRS}", "${GeographicLib_INCLUDE_DIR}")
+          text = text.replace(
+              "  PUBLIC\n    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>",
+              "  PUBLIC\n    ${GeographicLib_INCLUDE_DIR}\n    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>",
+          )
+          text = text.replace(
+              "ament_export_include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)",
+              "ament_export_include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include ${GeographicLib_INCLUDE_DIR})",
+          )
+          path.write_text(text)
+          PY
+      - name: Install GeographicLib
+        run: |
+          apt-get install -y libgeographiclib-dev geographiclib-tools geographiclib-doc
+      - name: Build
+        run: |
+          cd ~/eagleye/
+          source /opt/ros/jazzy/setup.bash
           rosdep install --from-paths src --ignore-src -r -y
           colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release --catkin-skip-building-tests

--- a/eagleye_core/coordinate/CMakeLists.txt
+++ b/eagleye_core/coordinate/CMakeLists.txt
@@ -15,17 +15,17 @@ ament_auto_find_build_dependencies()
 
 find_package(PkgConfig)
 find_package(geodesy)
+
+# GeographicLib
 find_path(GeographicLib_INCLUDE_DIR GeographicLib/Config.h
   PATH_SUFFIXES GeographicLib
 )
-set(GeographicLib_LIBRARIES
-  NAMES Geographic
-)
+find_library(GeographicLib_LIBRARIES NAMES Geographic GeographicLib)
 
 include_directories(
   include
   ${PROJECT_SOURCE_DIR}/include
-  ${GeographicLib_INCLUDE_DIRS}
+  ${GeographicLib_INCLUDE_DIR}
 )
 link_directories(
   /usr/local/lib
@@ -47,11 +47,11 @@ ament_auto_add_library(eagleye_coordinate SHARED
   include/eagleye_coordinate/eagleye_coordinate.hpp
 )
 
-ament_export_include_directories(include)
+ament_export_include_directories(include ${GeographicLib_INCLUDE_DIR})
 ament_target_dependencies(eagleye_coordinate)
 
 target_link_libraries(eagleye_coordinate
-  Geographic
+  ${GeographicLib_LIBRARIES}
 )
 
 install(
@@ -62,6 +62,7 @@ install(
 
 target_include_directories(eagleye_coordinate
   PUBLIC
+    ${GeographicLib_INCLUDE_DIR}
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
 )

--- a/eagleye_core/coordinate/package.xml
+++ b/eagleye_core/coordinate/package.xml
@@ -13,6 +13,7 @@
   <build_depend>geodesy</build_depend>
   <build_export_depend>rclcpp</build_export_depend>
   <build_export_depend>geodesy</build_export_depend>
+  <depend>ament_index_cpp</depend>
   <depend>eigen</depend>
   <depend>geographic_info</depend>
   <depend>geographic_msgs</depend>

--- a/eagleye_core/navigation/CMakeLists.txt
+++ b/eagleye_core/navigation/CMakeLists.txt
@@ -23,6 +23,7 @@ endif()
 find_package(ament_cmake_auto REQUIRED)
 find_package(eagleye_coordinate REQUIRED)
 find_package(PkgConfig REQUIRED)
+find_package(yaml-cpp REQUIRED)
 
 ament_auto_find_build_dependencies()
 
@@ -51,7 +52,7 @@ ament_auto_add_library(eagleye_navigation SHARED
   include/eagleye_navigation/eagleye_navigation.hpp
 )
 
-ament_auto_find_build_dependencies()
+target_link_libraries(eagleye_navigation yaml-cpp)
 
 install(TARGETS eagleye_navigation
   INCLUDES DESTINATION include

--- a/eagleye_rt/CMakeLists.txt
+++ b/eagleye_rt/CMakeLists.txt
@@ -41,13 +41,22 @@ ament_auto_add_executable(distance
 ament_auto_add_executable(heading_interpolate
   src/heading_interpolate_node.cpp
 )
+target_link_libraries(heading_interpolate
+  yaml-cpp
+)
 
 ament_auto_add_executable(heading
   src/heading_node.cpp
 )
+target_link_libraries(heading
+  yaml-cpp
+)
 
 ament_auto_add_executable(height
   src/height_node.cpp
+)
+target_link_libraries(height
+  yaml-cpp
 )
 
 ament_auto_add_executable(monitor
@@ -57,61 +66,106 @@ ament_auto_add_executable(monitor
 ament_auto_add_executable(position_interpolate
   src/position_interpolate_node.cpp
 )
+target_link_libraries(position_interpolate
+  yaml-cpp
+)
 
 ament_auto_add_executable(position
   src/position_node.cpp
+)
+target_link_libraries(position
+  yaml-cpp
 )
 
 ament_auto_add_executable(slip_angle
   src/slip_angle_node.cpp
 )
+target_link_libraries(slip_angle
+  yaml-cpp
+)
 
 ament_auto_add_executable(slip_coefficient
   src/slip_coefficient_node.cpp
+)
+target_link_libraries(slip_coefficient
+  yaml-cpp
 )
 
 ament_auto_add_executable(enable_additional_rolling
   src/enable_additional_rolling_node.cpp
 )
+target_link_libraries(enable_additional_rolling
+  yaml-cpp
+)
 
 ament_auto_add_executable(rolling
   src/rolling_node.cpp
+)
+target_link_libraries(rolling
+  yaml-cpp
 )
 
 ament_auto_add_executable(smoothing
   src/smoothing_node.cpp
 )
+target_link_libraries(smoothing
+  yaml-cpp
+)
 
 ament_auto_add_executable(trajectory
   src/trajectory_node.cpp
+)
+target_link_libraries(trajectory
+  yaml-cpp
 )
 
 ament_auto_add_executable(velocity_scale_factor
   src/velocity_scale_factor_node.cpp
 )
+target_link_libraries(velocity_scale_factor
+  yaml-cpp
+)
 
 ament_auto_add_executable(yaw_rate_offset
   src/yaw_rate_offset_node.cpp
+)
+target_link_libraries(yaw_rate_offset
+  yaml-cpp
 )
 
 ament_auto_add_executable(yaw_rate_offset_stop
   src/yaw_rate_offset_stop_node.cpp
 )
+target_link_libraries(yaw_rate_offset_stop
+  yaml-cpp
+)
 
 ament_auto_add_executable(angular_velocity_offset_stop
   src/angular_velocity_offset_stop_node.cpp
+)
+target_link_libraries(angular_velocity_offset_stop
+  yaml-cpp
 )
 
 ament_auto_add_executable(rtk_dead_reckoning
   src/rtk_dead_reckoning_node.cpp
 )
+target_link_libraries(rtk_dead_reckoning
+  yaml-cpp
+)
 
 ament_auto_add_executable(rtk_heading
   src/rtk_heading_node.cpp
 )
+target_link_libraries(rtk_heading
+  yaml-cpp
+)
 
 ament_auto_add_executable(velocity_estimator
   src/velocity_estimator_node.cpp
+)
+target_link_libraries(velocity_estimator
+  yaml-cpp
 )
 
 install(TARGETS 

--- a/eagleye_rt/package.xml
+++ b/eagleye_rt/package.xml
@@ -23,6 +23,7 @@
   <depend>eagleye_msgs</depend>
   <depend>eagleye_coordinate</depend>
   <depend>eagleye_navigation</depend>
+  <depend>eagleye_tf</depend>
   <depend>diagnostic_updater</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>

--- a/eagleye_rt/src/tf_converted_imu.cpp
+++ b/eagleye_rt/src/tf_converted_imu.cpp
@@ -41,11 +41,11 @@
 #else
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #endif
-#include <tf2_sensor_msgs/tf2_sensor_msgs.h>
+#include <tf2_sensor_msgs/tf2_sensor_msgs.hpp>
 #include <tf2/transform_datatypes.h>
-#include <tf2_eigen/tf2_eigen.h>
+#include <tf2_eigen/tf2_eigen.hpp>
 
-class TFConvertedIMU: public rclcpp::Node
+class TFConvertedIMU : public rclcpp::Node
 {
 public:
   TFConvertedIMU();
@@ -65,14 +65,13 @@ private:
   std::string tf_base_link_frame_;
 
   void imu_callback(const sensor_msgs::msg::Imu::ConstSharedPtr msg);
-
 };
 
 TFConvertedIMU::TFConvertedIMU() : Node("eagleye_tf_converted_imu"),
-    clock_(RCL_ROS_TIME),
-    tfbuffer_(std::make_shared<rclcpp::Clock>(clock_)),
-    tflistener_(tfbuffer_),
-    logger_(get_logger())
+                                   clock_(RCL_ROS_TIME),
+                                   tfbuffer_(std::make_shared<rclcpp::Clock>(clock_)),
+                                   tflistener_(tfbuffer_),
+                                   logger_(get_logger())
 {
   std::string subscribe_imu_topic_name = "/imu/data_raw";
   std::string publish_imu_topic_name = "imu/data_tf_converted";
@@ -85,27 +84,28 @@ TFConvertedIMU::TFConvertedIMU() : Node("eagleye_tf_converted_imu"),
   get_parameter("publish_imu_topic", publish_imu_topic_name);
   get_parameter("tf_gnss_frame.parent", tf_base_link_frame_);
 
-  std::cout<< "subscribe_imu_topic_name: " << subscribe_imu_topic_name << std::endl;
-  std::cout<< "publish_imu_topic_name: " << publish_imu_topic_name << std::endl;
-  std::cout<< "tf_base_link_frame: " << tf_base_link_frame_ << std::endl;
+  std::cout << "subscribe_imu_topic_name: " << subscribe_imu_topic_name << std::endl;
+  std::cout << "publish_imu_topic_name: " << publish_imu_topic_name << std::endl;
+  std::cout << "tf_base_link_frame: " << tf_base_link_frame_ << std::endl;
 
-  sub_ =  create_subscription<sensor_msgs::msg::Imu>(subscribe_imu_topic_name, rclcpp::QoS(10), std::bind(&TFConvertedIMU::imu_callback, this, std::placeholders::_1));
+  sub_ = create_subscription<sensor_msgs::msg::Imu>(subscribe_imu_topic_name, rclcpp::QoS(10), std::bind(&TFConvertedIMU::imu_callback, this, std::placeholders::_1));
   pub_ = create_publisher<sensor_msgs::msg::Imu>("imu/data_tf_converted", rclcpp::QoS(10));
 };
 
-TFConvertedIMU::~TFConvertedIMU(){}; 
+TFConvertedIMU::~TFConvertedIMU() {};
 
 void TFConvertedIMU::imu_callback(const sensor_msgs::msg::Imu::ConstSharedPtr msg)
 {
   imu_ = *msg;
   tf_converted_imu_.header = imu_.header;
 
-  try {
+  try
+  {
     const geometry_msgs::msg::TransformStamped transform = tfbuffer_.lookupTransform(
-     tf_base_link_frame_, msg->header.frame_id, tf2::TimePointZero);
+        tf_base_link_frame_, msg->header.frame_id, tf2::TimePointZero);
 
     geometry_msgs::msg::Vector3Stamped angular_velocity, linear_acceleration, transformed_angular_velocity, transformed_linear_acceleration;
-    geometry_msgs::msg::Quaternion  transformed_quaternion;
+    geometry_msgs::msg::Quaternion transformed_quaternion;
 
     angular_velocity.header = imu_.header;
     angular_velocity.vector = imu_.angular_velocity;
@@ -126,8 +126,8 @@ void TFConvertedIMU::imu_callback(const sensor_msgs::msg::Imu::ConstSharedPtr ms
     tf_converted_imu_.linear_acceleration = transformed_linear_acceleration.vector;
     tf_converted_imu_.orientation = transformed_quaternion;
 
-  } 
-  catch (tf2::TransformException& ex)
+  }
+  catch (tf2::TransformException &ex)
   {
     std::cout << "Failed to lookup transform" << std::endl;
     RCLCPP_WARN(rclcpp::get_logger("tf_converted_imu"), "Failed to lookup transform.");
@@ -136,7 +136,7 @@ void TFConvertedIMU::imu_callback(const sensor_msgs::msg::Imu::ConstSharedPtr ms
   pub_->publish(tf_converted_imu_);
 };
 
-int main(int argc, char** argv)
+int main(int argc, char **argv)
 {
   rclcpp::init(argc, argv);
 

--- a/eagleye_util/geo_pose_fusion/package.xml
+++ b/eagleye_util/geo_pose_fusion/package.xml
@@ -23,6 +23,7 @@
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 
+  <depend>ament_index_cpp</depend>
   <depend>tf2_geometry_msgs</depend>
 
   <export>


### PR DESCRIPTION
## Summary

- fix GeographicLib lookup and export for newer environments
- link `yaml-cpp` explicitly where `YAML::LoadFile` is used
- update tf2 sensor/eigen header includes for Jazzy-compatible builds
- add missing package dependencies used at build or launch time

## Details

- `eagleye_coordinate`
  - switch GeographicLib linking to `find_library()`
  - export `ament_index_cpp`
  - export GeographicLib include path for downstream consumers
- `eagleye_navigation`
  - link `yaml-cpp`
- `eagleye_rt`
  - link `yaml-cpp` for nodes that load YAML directly
  - add `eagleye_tf` dependency
  - update `tf2_sensor_msgs` and `tf2_eigen` includes to `.hpp`
- `eagleye_geo_pose_fusion`
  - add missing `ament_index_cpp` dependency

## Validation

- `colcon build --packages-up-to eagleye_navigation --cmake-args -DCMAKE_BUILD_TYPE=Release`
- `colcon build --packages-select eagleye_rt --cmake-args -DCMAKE_BUILD_TYPE=Release`
- `colcon build --packages-skip eagleye_gnss_converter --cmake-args -DCMAKE_BUILD_TYPE=Release`

## Notes

- I intentionally did not include the local `eagleye_config.yaml` parameter tuning in this PR.
- Full workspace build is still blocked in my current non-root test environment by `eagleye_gnss_converter` pulling a system GeographicLib path via external package dependencies.
