### PR TITLE
ci: remove llh_converter workaround from jazzy build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,24 +74,6 @@ jobs:
         run: |
           cd ~/eagleye/src/
           git clone https://github.com/MapIV/llh_converter.git -b ros2
-      - name: Patch llh_converter for Jazzy CI
-        run: |
-          python3 - <<'PY'
-          from pathlib import Path
-
-          path = Path.home() / "eagleye/src/llh_converter/CMakeLists.txt"
-          text = path.read_text()
-          text = text.replace("${GeographicLib_INCLUDE_DIRS}", "${GeographicLib_INCLUDE_DIR}")
-          text = text.replace(
-              "  PUBLIC\n    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>",
-              "  PUBLIC\n    ${GeographicLib_INCLUDE_DIR}\n    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>",
-          )
-          text = text.replace(
-              "ament_export_include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)",
-              "ament_export_include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include ${GeographicLib_INCLUDE_DIR})",
-          )
-          path.write_text(text)
-          PY
       - name: Install GeographicLib
         run: |
           apt-get install -y libgeographiclib-dev geographiclib-tools geographiclib-doc


### PR DESCRIPTION
## Summary
- remove the temporary llh_converter patch step from the Jazzy CI job
- rely on `MapIV/llh_converter` `ros2` after merge of #27

## Validation
- reproduced the Jazzy workflow locally without the workaround
- build passed with upstream `MapIV/llh_converter` `ros2` at `95b8a94`
