### PR TITLE
Add devcontainer for ROS2 Humble development

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,25 @@
+FROM ros:humble
+
+ARG USERNAME=ros
+ARG USER_UID=1000
+ARG USER_GID=${USER_UID}
+
+# Create non-root user
+RUN groupadd --gid ${USER_GID} ${USERNAME} \
+    && useradd --uid ${USER_UID} --gid ${USER_GID} -m ${USERNAME} \
+    && echo "${USERNAME} ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+# Install dependencies
+RUN apt-get update && apt-get install -y \
+    python3-vcstool \
+    python3-colcon-common-extensions \
+    libgeographic-dev \
+    geographiclib-tools \
+    geographiclib-doc \
+    ros-humble-rmw-cyclonedds-cpp \
+    && rm -rf /var/lib/apt/lists/*
+
+# Source ROS in bashrc
+RUN echo "source /opt/ros/humble/setup.bash" >> /home/${USERNAME}/.bashrc
+
+USER ${USERNAME}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,36 @@
+{
+  "name": "eagleye ROS2 Humble",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspaces/${localWorkspaceFolderBasename},type=bind",
+  "remoteUser": "ros",
+  "postCreateCommand": "bash .devcontainer/setup.sh",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-vscode.cpptools",
+        "ms-vscode.cpptools-extension-pack",
+        "ms-vscode.cmake-tools",
+        "twxs.cmake",
+        "ms-python.python",
+        "ms-iot.vscode-ros"
+      ],
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "bash",
+        "colcon.workspaceFolder": "/home/ros/ws",
+        "ros.distro": "humble",
+        "C_Cpp.default.compileCommands": "/home/ros/ws/build/compile_commands.json"
+      }
+    }
+  },
+  "mounts": [
+    "source=/tmp/.X11-unix,target=/tmp/.X11-unix,type=bind,consistency=cached"
+  ],
+  "containerEnv": {
+    "ROS_DOMAIN_ID": "42",
+    "RMW_IMPLEMENTATION": "rmw_cyclonedds_cpp"
+  }
+}

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e
+
+WORKSPACE=/home/ros/ws
+EAGLEYE_DIR=/workspaces/eagleye
+
+# Create ROS workspace
+mkdir -p ${WORKSPACE}/src
+
+# Symlink the eagleye repo into the workspace
+ln -sf ${EAGLEYE_DIR} ${WORKSPACE}/src/eagleye
+
+# Import dependency repos
+cd ${WORKSPACE}/src
+vcs import < ${EAGLEYE_DIR}/eagleye.repos
+
+# Install ROS dependencies
+cd ${WORKSPACE}
+sudo apt-get update
+rosdep update
+rosdep install --from-paths src --ignore-src -r -y
+
+# Build
+source /opt/ros/humble/setup.bash
+colcon build --symlink-install
+
+# Add workspace to bashrc
+echo "source ${WORKSPACE}/install/setup.bash" >> ~/.bashrc

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,84 +2,67 @@ name: build
 on: pull_request
 
 jobs:
-  humble_build:
-    runs-on:  ubuntu-22.04
+  build:
+    strategy:
+      matrix:
+        include:
+          - ros_distro: humble
+            os: ubuntu-22.04
+            geographiclib_pkg: libgeographic-dev geographiclib-tools geographiclib-doc
+          - ros_distro: jazzy
+            os: ubuntu-24.04
+            geographiclib_pkg: libgeographiclib-dev geographiclib-tools geographiclib-doc
 
-    container: ros:humble
-    services:
-      ros:
-        image: ros
-
-    defaults:
-      run:
-        shell: bash
-
-    steps:
-      - name: checkout
-        uses: actions/checkout@v4
-      - name: rosdep update
-        run: |
-          apt-get update
-          rosdep update
-      - name: Create Workspace
-        run: |
-          mkdir -p ~/eagleye/src/
-          cp -r `pwd` ~/eagleye/src/
-      - name: Clone rtklib_msgs
-        run: |
-          cd ~/eagleye/src/
-          git clone https://github.com/MapIV/rtklib_ros_bridge.git -b ros2-v0.1.0
-      - name: Clone llh_converter
-        run: |
-          cd ~/eagleye/src/
-          git clone https://github.com/MapIV/llh_converter.git -b ros2
-      - name: Install GeographicLib
-        run: |
-          apt-get install -y libgeographic-dev geographiclib-tools geographiclib-doc
-      - name: Build
-        run: |
-          cd ~/eagleye/
-          source /opt/ros/humble/setup.bash
-          rosdep install --from-paths src --ignore-src -r -y
-          colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release --catkin-skip-building-tests
-
-  jazzy_build:
-    runs-on: ubuntu-24.04
-
-    container: ros:jazzy
-    services:
-      ros:
-        image: ros
+    runs-on: ${{ matrix.os }}
+    container: ros:${{ matrix.ros_distro }}
 
     defaults:
       run:
         shell: bash
 
     steps:
-      - name: checkout
-        uses: actions/checkout@v4
-      - name: rosdep update
+      - uses: actions/checkout@v4
+        with:
+          path: ros_ws/src/eagleye
+
+      - name: Install system dependencies
         run: |
           apt-get update
+          apt-get install -y --no-install-recommends \
+            python3-vcstool \
+            ${{ matrix.geographiclib_pkg }}
+
+      - name: Import dependency repos
+        run: |
+          cd ros_ws/src
+          vcs import < eagleye/eagleye.repos
+
+      - name: Cache rosdep
+        uses: actions/cache@v4
+        with:
+          path: ~/.ros/rosdep
+          key: rosdep-${{ matrix.ros_distro }}-${{ hashFiles('ros_ws/src/**/package.xml') }}
+          restore-keys: rosdep-${{ matrix.ros_distro }}-
+
+      - name: rosdep install
+        run: |
           rosdep update
-      - name: Create Workspace
-        run: |
-          mkdir -p ~/eagleye/src/
-          cp -r "$(pwd)" ~/eagleye/src/
-      - name: Clone rtklib_msgs
-        run: |
-          cd ~/eagleye/src/
-          git clone https://github.com/MapIV/rtklib_ros_bridge.git -b ros2-v0.1.0
-      - name: Clone llh_converter
-        run: |
-          cd ~/eagleye/src/
-          git clone https://github.com/MapIV/llh_converter.git -b ros2
-      - name: Install GeographicLib
-        run: |
-          apt-get install -y libgeographiclib-dev geographiclib-tools geographiclib-doc
+          rosdep install --from-paths ros_ws/src --ignore-src -r -y
+
+      - name: Cache colcon build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ros_ws/build
+            ros_ws/install
+          key: colcon-${{ matrix.ros_distro }}-${{ hashFiles('ros_ws/src/**/*.cpp', 'ros_ws/src/**/*.hpp', 'ros_ws/src/**/CMakeLists.txt', 'ros_ws/src/**/package.xml') }}
+          restore-keys: colcon-${{ matrix.ros_distro }}-
+
       - name: Build
         run: |
-          cd ~/eagleye/
-          source /opt/ros/jazzy/setup.bash
-          rosdep install --from-paths src --ignore-src -r -y
-          colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release --catkin-skip-building-tests
+          source /opt/ros/${{ matrix.ros_distro }}/setup.bash
+          cd ros_ws
+          colcon build \
+            --cmake-args -DCMAKE_BUILD_TYPE=Release \
+            --catkin-skip-building-tests \
+            --parallel-workers $(nproc)


### PR DESCRIPTION
## Summary

- Add `.devcontainer/` for VS Code Dev Containers support
- Base image: `ros:humble` (Ubuntu 22.04)
- `setup.sh` automatically clones dependency repos via `vcs import` and builds the workspace after container creation

## How to use

1. Open this repository in VS Code
2. Run **"Reopen in Container"** from the command palette
3. Wait for `setup.sh` to complete (deps install + colcon build)
4. The workspace is ready at `/home/ros/ws`