### PR TITLE
Unify package versions to 1.0.0

### DIFF
--- a/eagleye_core/coordinate/package.xml
+++ b/eagleye_core/coordinate/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>eagleye_coordinate</name>
-  <version>0.0.0</version>
+  <version>1.0.0</version>
   <description>The coordinate package</description>
   <maintainer email="osamu.sekino@tier4.jp">osamu.sekino</maintainer>
   <license>BSD</license>

--- a/eagleye_core/navigation/package.xml
+++ b/eagleye_core/navigation/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>eagleye_navigation</name>
-  <version>0.0.0</version>
+  <version>1.0.0</version>
   <description>The navigation package</description>
   <maintainer email="osamu.sekino@tier4.jp">osamu.sekino</maintainer>
   <license>BSD</license>

--- a/eagleye_msgs/package.xml
+++ b/eagleye_msgs/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>eagleye_msgs</name>
-  <version>0.0.0</version>
+  <version>1.0.0</version>
   <description>The eagleye_msgs package</description>
   <maintainer email="osamu.sekino@tier4.jp">osamu.sekino</maintainer>
   <license>BSD</license>

--- a/eagleye_rt/package.xml
+++ b/eagleye_rt/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>eagleye_rt</name>
-  <version>0.0.0</version>
+  <version>1.0.0</version>
   <description>The eagleye_rt package</description>
 
   <maintainer email="osamu.sekino@tier4.jp">Osamu Sekino</maintainer>

--- a/eagleye_util/tf/package.xml
+++ b/eagleye_util/tf/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>eagleye_tf</name>
-  <version>0.0.0</version>
+  <version>1.0.0</version>
   <description>The eagleye_tf package</description>
 
   <maintainer email="osamu.sekino@tier4.jp">Osamu Sekino</maintainer>


### PR DESCRIPTION
## Summary

- Set `<version>1.0.0</version>` in all packages that had `0.0.0`
- Aligns with packages that already had `1.0.0` (`eagleye_util` series)