### PR TITLE
feat: add eagleye_result_logger for CSV regression logging

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,25 @@
+FROM ros:humble
+
+ARG USERNAME=ros
+ARG USER_UID=1000
+ARG USER_GID=${USER_UID}
+
+# Create non-root user
+RUN groupadd --gid ${USER_GID} ${USERNAME} \
+    && useradd --uid ${USER_UID} --gid ${USER_GID} -m ${USERNAME} \
+    && echo "${USERNAME} ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+# Install dependencies
+RUN apt-get update && apt-get install -y \
+    python3-vcstool \
+    python3-colcon-common-extensions \
+    libgeographic-dev \
+    geographiclib-tools \
+    geographiclib-doc \
+    ros-humble-rmw-cyclonedds-cpp \
+    && rm -rf /var/lib/apt/lists/*
+
+# Source ROS in bashrc
+RUN echo "source /opt/ros/humble/setup.bash" >> /home/${USERNAME}/.bashrc
+
+USER ${USERNAME}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,36 @@
+{
+  "name": "eagleye ROS2 Humble",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspaces/${localWorkspaceFolderBasename},type=bind",
+  "remoteUser": "ros",
+  "postCreateCommand": "bash .devcontainer/setup.sh",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-vscode.cpptools",
+        "ms-vscode.cpptools-extension-pack",
+        "ms-vscode.cmake-tools",
+        "twxs.cmake",
+        "ms-python.python",
+        "ms-iot.vscode-ros"
+      ],
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "bash",
+        "colcon.workspaceFolder": "/home/ros/ws",
+        "ros.distro": "humble",
+        "C_Cpp.default.compileCommands": "/home/ros/ws/build/compile_commands.json"
+      }
+    }
+  },
+  "mounts": [
+    "source=/tmp/.X11-unix,target=/tmp/.X11-unix,type=bind,consistency=cached"
+  ],
+  "containerEnv": {
+    "ROS_DOMAIN_ID": "42",
+    "RMW_IMPLEMENTATION": "rmw_cyclonedds_cpp"
+  }
+}

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e
+
+WORKSPACE=/home/ros/ws
+EAGLEYE_DIR=/workspaces/eagleye
+
+# Create ROS workspace
+mkdir -p ${WORKSPACE}/src
+
+# Symlink the eagleye repo into the workspace
+ln -sf ${EAGLEYE_DIR} ${WORKSPACE}/src/eagleye
+
+# Import dependency repos
+cd ${WORKSPACE}/src
+vcs import < ${EAGLEYE_DIR}/eagleye.repos
+
+# Install ROS dependencies
+cd ${WORKSPACE}
+sudo apt-get update
+rosdep update
+rosdep install --from-paths src --ignore-src -r -y
+
+# Build
+source /opt/ros/humble/setup.bash
+colcon build --symlink-install
+
+# Add workspace to bashrc
+echo "source ${WORKSPACE}/install/setup.bash" >> ~/.bashrc

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,84 +2,67 @@ name: build
 on: pull_request
 
 jobs:
-  humble_build:
-    runs-on:  ubuntu-22.04
+  build:
+    strategy:
+      matrix:
+        include:
+          - ros_distro: humble
+            os: ubuntu-22.04
+            geographiclib_pkg: libgeographic-dev geographiclib-tools geographiclib-doc
+          - ros_distro: jazzy
+            os: ubuntu-24.04
+            geographiclib_pkg: libgeographiclib-dev geographiclib-tools geographiclib-doc
 
-    container: ros:humble
-    services:
-      ros:
-        image: ros
-
-    defaults:
-      run:
-        shell: bash
-
-    steps:
-      - name: checkout
-        uses: actions/checkout@v4
-      - name: rosdep update
-        run: |
-          apt-get update
-          rosdep update
-      - name: Create Workspace
-        run: |
-          mkdir -p ~/eagleye/src/
-          cp -r `pwd` ~/eagleye/src/
-      - name: Clone rtklib_msgs
-        run: |
-          cd ~/eagleye/src/
-          git clone https://github.com/MapIV/rtklib_ros_bridge.git -b ros2-v0.1.0
-      - name: Clone llh_converter
-        run: |
-          cd ~/eagleye/src/
-          git clone https://github.com/MapIV/llh_converter.git -b ros2
-      - name: Install GeographicLib
-        run: |
-          apt-get install -y libgeographic-dev geographiclib-tools geographiclib-doc
-      - name: Build
-        run: |
-          cd ~/eagleye/
-          source /opt/ros/humble/setup.bash
-          rosdep install --from-paths src --ignore-src -r -y
-          colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release --catkin-skip-building-tests
-
-  jazzy_build:
-    runs-on: ubuntu-24.04
-
-    container: ros:jazzy
-    services:
-      ros:
-        image: ros
+    runs-on: ${{ matrix.os }}
+    container: ros:${{ matrix.ros_distro }}
 
     defaults:
       run:
         shell: bash
 
     steps:
-      - name: checkout
-        uses: actions/checkout@v4
-      - name: rosdep update
+      - uses: actions/checkout@v4
+        with:
+          path: ros_ws/src/eagleye
+
+      - name: Install system dependencies
         run: |
           apt-get update
+          apt-get install -y --no-install-recommends \
+            python3-vcstool \
+            ${{ matrix.geographiclib_pkg }}
+
+      - name: Import dependency repos
+        run: |
+          cd ros_ws/src
+          vcs import < eagleye/eagleye.repos
+
+      - name: Cache rosdep
+        uses: actions/cache@v4
+        with:
+          path: ~/.ros/rosdep
+          key: rosdep-${{ matrix.ros_distro }}-${{ hashFiles('ros_ws/src/**/package.xml') }}
+          restore-keys: rosdep-${{ matrix.ros_distro }}-
+
+      - name: rosdep install
+        run: |
           rosdep update
-      - name: Create Workspace
-        run: |
-          mkdir -p ~/eagleye/src/
-          cp -r "$(pwd)" ~/eagleye/src/
-      - name: Clone rtklib_msgs
-        run: |
-          cd ~/eagleye/src/
-          git clone https://github.com/MapIV/rtklib_ros_bridge.git -b ros2-v0.1.0
-      - name: Clone llh_converter
-        run: |
-          cd ~/eagleye/src/
-          git clone https://github.com/MapIV/llh_converter.git -b ros2
-      - name: Install GeographicLib
-        run: |
-          apt-get install -y libgeographiclib-dev geographiclib-tools geographiclib-doc
+          rosdep install --from-paths ros_ws/src --ignore-src -r -y
+
+      - name: Cache colcon build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ros_ws/build
+            ros_ws/install
+          key: colcon-${{ matrix.ros_distro }}-${{ hashFiles('ros_ws/src/**/*.cpp', 'ros_ws/src/**/*.hpp', 'ros_ws/src/**/CMakeLists.txt', 'ros_ws/src/**/package.xml') }}
+          restore-keys: colcon-${{ matrix.ros_distro }}-
+
       - name: Build
         run: |
-          cd ~/eagleye/
-          source /opt/ros/jazzy/setup.bash
-          rosdep install --from-paths src --ignore-src -r -y
-          colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release --catkin-skip-building-tests
+          source /opt/ros/${{ matrix.ros_distro }}/setup.bash
+          cd ros_ws
+          colcon build \
+            --cmake-args -DCMAKE_BUILD_TYPE=Release \
+            --catkin-skip-building-tests \
+            --parallel-workers $(nproc)

--- a/eagleye_rt/CMakeLists.txt
+++ b/eagleye_rt/CMakeLists.txt
@@ -10,7 +10,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-if($ENV{ROS_DISTRO} STREQUAL "galactic")
+if("$ENV{ROS_DISTRO}" STREQUAL "galactic")
   add_definitions(-DROS_DISTRO_GALACTIC)
 endif()
 

--- a/eagleye_rt/src/angular_velocity_offset_stop_node.cpp
+++ b/eagleye_rt/src/angular_velocity_offset_stop_node.cpp
@@ -80,7 +80,7 @@ private:
   sensor_msgs::msg::Imu imu_;
 
   struct AngularVelocityOffsetStopParameter angular_velocity_offset_stop_parameter_;
-  struct AngularVelocityOffsetStopStatus angular_velocity_offset_stop_status_;
+  struct AngularVelocityOffsetStopStatus angular_velocity_offset_stop_status_ = {};
 
   rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr sub1_;
   rclcpp::Subscription<sensor_msgs::msg::Imu>::SharedPtr sub2_;

--- a/eagleye_rt/src/angular_velocity_offset_stop_node.cpp
+++ b/eagleye_rt/src/angular_velocity_offset_stop_node.cpp
@@ -32,71 +32,83 @@
 #include "eagleye_coordinate/eagleye_coordinate.hpp"
 #include "eagleye_navigation/eagleye_navigation.hpp"
 
-static geometry_msgs::msg::TwistStamped velocity;
-rclcpp::Publisher<eagleye_msgs::msg::AngularVelocityOffset>::SharedPtr pub;
-static eagleye_msgs::msg::AngularVelocityOffset angular_velocity_offset_stop;
-static sensor_msgs::msg::Imu imu;
-
-struct AngularVelocityOffsetStopParameter angular_velocity_offset_stop_parameter;
-struct AngularVelocityOffsetStopStatus angular_velocity_offset_stop_status;
-
-void velocity_callback(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg)
+class AngularVelocityOffsetStopNode : public rclcpp::Node
 {
-  velocity = *msg;
-}
+public:
+  AngularVelocityOffsetStopNode() : Node("eagleye_angular_velocity_offset_stop")
+  {
+    std::string subscribe_twist_topic_name = "vehicle/twist";
 
-void imu_callback(const sensor_msgs::msg::Imu::ConstSharedPtr msg)
-{
-  imu.header = msg->header;
-  imu.orientation = msg->orientation;
-  imu.orientation_covariance = msg->orientation_covariance;
-  imu.angular_velocity = msg->angular_velocity;
-  imu.angular_velocity_covariance = msg->angular_velocity_covariance;
-  imu.linear_acceleration = msg->linear_acceleration;
-  imu.linear_acceleration_covariance = msg->linear_acceleration_covariance;
-  angular_velocity_offset_stop.header = msg->header;
-  angular_velocity_offset_stop_estimate(velocity, imu, angular_velocity_offset_stop_parameter, &angular_velocity_offset_stop_status, &angular_velocity_offset_stop);
-  pub->publish(angular_velocity_offset_stop);
-}
+    std::string yaml_file;
+    this->declare_parameter("yaml_file", yaml_file);
+    this->get_parameter("yaml_file", yaml_file);
+    std::cout << "yaml_file: " << yaml_file << std::endl;
+
+    try
+    {
+      YAML::Node conf = YAML::LoadFile(yaml_file);
+
+      angular_velocity_offset_stop_parameter_.imu_rate = conf["/**"]["ros__parameters"]["common"]["imu_rate"].as<double>();
+      angular_velocity_offset_stop_parameter_.stop_judgment_threshold = conf["/**"]["ros__parameters"]["common"]["stop_judgment_threshold"].as<double>();
+      angular_velocity_offset_stop_parameter_.estimated_interval = conf["/**"]["ros__parameters"]["angular_velocity_offset_stop"]["estimated_interval"].as<double>();
+      angular_velocity_offset_stop_parameter_.outlier_threshold = conf["/**"]["ros__parameters"]["angular_velocity_offset_stop"]["outlier_threshold"].as<double>();
+
+      std::cout << "subscribe_twist_topic_name " << subscribe_twist_topic_name << std::endl;
+      std::cout << "imu_rate " << angular_velocity_offset_stop_parameter_.imu_rate << std::endl;
+      std::cout << "stop_judgment_threshold " << angular_velocity_offset_stop_parameter_.stop_judgment_threshold << std::endl;
+      std::cout << "estimated_minimum_interval " << angular_velocity_offset_stop_parameter_.estimated_interval << std::endl;
+      std::cout << "outlier_threshold " << angular_velocity_offset_stop_parameter_.outlier_threshold << std::endl;
+    }
+    catch (YAML::Exception& e)
+    {
+      std::cerr << "\033[1;31mangular_velocity_offset_stop Node YAML Error: " << e.msg << "\033[0m" << std::endl;
+      exit(3);
+    }
+
+    sub1_ = this->create_subscription<geometry_msgs::msg::TwistStamped>(
+      subscribe_twist_topic_name, 1000,
+      std::bind(&AngularVelocityOffsetStopNode::velocityCallback, this, std::placeholders::_1));
+    sub2_ = this->create_subscription<sensor_msgs::msg::Imu>(
+      "imu/data_tf_converted", 1000,
+      std::bind(&AngularVelocityOffsetStopNode::imuCallback, this, std::placeholders::_1));
+    pub_ = this->create_publisher<eagleye_msgs::msg::AngularVelocityOffset>("angular_velocity_offset_stop", 1000);
+  }
+
+private:
+  geometry_msgs::msg::TwistStamped velocity_;
+  eagleye_msgs::msg::AngularVelocityOffset angular_velocity_offset_stop_;
+  sensor_msgs::msg::Imu imu_;
+
+  struct AngularVelocityOffsetStopParameter angular_velocity_offset_stop_parameter_;
+  struct AngularVelocityOffsetStopStatus angular_velocity_offset_stop_status_;
+
+  rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr sub1_;
+  rclcpp::Subscription<sensor_msgs::msg::Imu>::SharedPtr sub2_;
+  rclcpp::Publisher<eagleye_msgs::msg::AngularVelocityOffset>::SharedPtr pub_;
+
+  void velocityCallback(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg)
+  {
+    velocity_ = *msg;
+  }
+
+  void imuCallback(const sensor_msgs::msg::Imu::ConstSharedPtr msg)
+  {
+    imu_.header = msg->header;
+    imu_.orientation = msg->orientation;
+    imu_.orientation_covariance = msg->orientation_covariance;
+    imu_.angular_velocity = msg->angular_velocity;
+    imu_.angular_velocity_covariance = msg->angular_velocity_covariance;
+    imu_.linear_acceleration = msg->linear_acceleration;
+    imu_.linear_acceleration_covariance = msg->linear_acceleration_covariance;
+    angular_velocity_offset_stop_.header = msg->header;
+    angular_velocity_offset_stop_estimate(velocity_, imu_, angular_velocity_offset_stop_parameter_, &angular_velocity_offset_stop_status_, &angular_velocity_offset_stop_);
+    pub_->publish(angular_velocity_offset_stop_);
+  }
+};
 
 int main(int argc, char** argv)
 {
   rclcpp::init(argc, argv);
-  auto node = rclcpp::Node::make_shared("eagleye_angular_velocity_offset_stop");
-
-  std::string subscribe_twist_topic_name = "vehicle/twist";
-
-  std::string yaml_file;
-  node->declare_parameter("yaml_file",yaml_file);
-  node->get_parameter("yaml_file",yaml_file);
-  std::cout << "yaml_file: " << yaml_file << std::endl;
-
- try
-  {
-    YAML::Node conf = YAML::LoadFile(yaml_file);
-
-    angular_velocity_offset_stop_parameter.imu_rate = conf["/**"]["ros__parameters"]["common"]["imu_rate"].as<double>();
-    angular_velocity_offset_stop_parameter.stop_judgment_threshold = conf["/**"]["ros__parameters"]["common"]["stop_judgment_threshold"].as<double>();
-    angular_velocity_offset_stop_parameter.estimated_interval = conf["/**"]["ros__parameters"]["angular_velocity_offset_stop"]["estimated_interval"].as<double>();
-    angular_velocity_offset_stop_parameter.outlier_threshold = conf["/**"]["ros__parameters"]["angular_velocity_offset_stop"]["outlier_threshold"].as<double>();
-
-    std::cout << "subscribe_twist_topic_name " << subscribe_twist_topic_name << std::endl;
-    std::cout << "imu_rate " << angular_velocity_offset_stop_parameter.imu_rate << std::endl;
-    std::cout << "stop_judgment_threshold " << angular_velocity_offset_stop_parameter.stop_judgment_threshold << std::endl;
-    std::cout << "estimated_minimum_interval " << angular_velocity_offset_stop_parameter.estimated_interval << std::endl;
-    std::cout << "outlier_threshold " << angular_velocity_offset_stop_parameter.outlier_threshold << std::endl;
-  }
-  catch (YAML::Exception& e)
-  {
-    std::cerr << "\033[1;31mangular_velocity_offset_stop Node YAML Error: " << e.msg << "\033[0m" << std::endl;
-    exit(3);
-  }
-
-  auto sub1 = node->create_subscription<geometry_msgs::msg::TwistStamped>(subscribe_twist_topic_name, 1000, velocity_callback);
-  auto sub2 = node->create_subscription<sensor_msgs::msg::Imu>("imu/data_tf_converted", 1000, imu_callback);
-  pub = node->create_publisher<eagleye_msgs::msg::AngularVelocityOffset>("angular_velocity_offset_stop", 1000);
-
-  rclcpp::spin(node);
-
+  rclcpp::spin(std::make_shared<AngularVelocityOffsetStopNode>());
   return 0;
 }

--- a/eagleye_rt/src/correction_imu.cpp
+++ b/eagleye_rt/src/correction_imu.cpp
@@ -32,79 +32,98 @@
 #include "eagleye_coordinate/eagleye_coordinate.hpp"
 #include "eagleye_navigation/eagleye_navigation.hpp"
 
-rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr pub;
-static eagleye_msgs::msg::YawrateOffset yaw_rate_offset;
-static eagleye_msgs::msg::AngularVelocityOffset angular_velocity_offset_stop;
-static eagleye_msgs::msg::AccXOffset acc_x_offset;
-static eagleye_msgs::msg::AccXScaleFactor acc_x_scale_factor;
-static sensor_msgs::msg::Imu imu;
-
-static sensor_msgs::msg::Imu correction_imu;
-
-
-void yaw_rate_offset_callback(const eagleye_msgs::msg::YawrateOffset::ConstSharedPtr msg)
+class CorrectionImuNode : public rclcpp::Node
 {
-  yaw_rate_offset = *msg;
-}
-
-void angular_velocity_offset_stop_callback(const eagleye_msgs::msg::AngularVelocityOffset::ConstSharedPtr msg)
-{
-  angular_velocity_offset_stop = *msg;
-}
-
-void acc_x_offset_callback(const eagleye_msgs::msg::AccXOffset::ConstSharedPtr msg)
-{
-  acc_x_offset = *msg;
-}
-
-void acc_x_scale_factor_callback(const eagleye_msgs::msg::AccXScaleFactor::ConstSharedPtr msg)
-{
-  acc_x_scale_factor = *msg;
-}
-
-void imu_callback(const sensor_msgs::msg::Imu::ConstSharedPtr msg)
-{
-  imu = *msg;
-
-  correction_imu.header = imu.header;
-  correction_imu.orientation = imu.orientation;
-  correction_imu.orientation_covariance = imu.orientation_covariance;
-  correction_imu.angular_velocity_covariance = imu.angular_velocity_covariance;
-  correction_imu.linear_acceleration_covariance = imu.linear_acceleration_covariance;
-
-  if (acc_x_offset.status.enabled_status == true && acc_x_scale_factor.status.enabled_status)
+public:
+  CorrectionImuNode() : Node("eagleye_correction_imu")
   {
-    correction_imu.linear_acceleration.x = imu.linear_acceleration.x * acc_x_scale_factor.acc_x_scale_factor + acc_x_offset.acc_x_offset;
-    correction_imu.linear_acceleration.y = imu.linear_acceleration.y;
-    correction_imu.linear_acceleration.z = imu.linear_acceleration.z;
-  }
-  else
-  {
-    correction_imu.linear_acceleration.x = imu.linear_acceleration.x;
-    correction_imu.linear_acceleration.y = imu.linear_acceleration.y;
-    correction_imu.linear_acceleration.z = imu.linear_acceleration.z;
+    sub1_ = this->create_subscription<eagleye_msgs::msg::YawrateOffset>(
+      "yaw_rate_offset_2nd", rclcpp::QoS(10),
+      std::bind(&CorrectionImuNode::yawRateOffsetCallback, this, std::placeholders::_1));
+    sub2_ = this->create_subscription<eagleye_msgs::msg::AngularVelocityOffset>(
+      "angular_velocity_offset_stop", rclcpp::QoS(10),
+      std::bind(&CorrectionImuNode::angularVelocityOffsetStopCallback, this, std::placeholders::_1));
+    sub3_ = this->create_subscription<eagleye_msgs::msg::AccXOffset>(
+      "acc_x_offset", rclcpp::QoS(10),
+      std::bind(&CorrectionImuNode::accXOffsetCallback, this, std::placeholders::_1));
+    sub4_ = this->create_subscription<eagleye_msgs::msg::AccXScaleFactor>(
+      "acc_x_scale_factor", rclcpp::QoS(10),
+      std::bind(&CorrectionImuNode::accXScaleFactorCallback, this, std::placeholders::_1));
+    sub5_ = this->create_subscription<sensor_msgs::msg::Imu>(
+      "imu/data_tf_converted", 1000,
+      std::bind(&CorrectionImuNode::imuCallback, this, std::placeholders::_1));
+    pub_ = this->create_publisher<sensor_msgs::msg::Imu>("imu/data_corrected", rclcpp::QoS(10));
   }
 
-  correction_imu.angular_velocity.x = imu.angular_velocity.x + angular_velocity_offset_stop.angular_velocity_offset.x;
-  correction_imu.angular_velocity.y = imu.angular_velocity.y + angular_velocity_offset_stop.angular_velocity_offset.y;
-  correction_imu.angular_velocity.z = -1 * (imu.angular_velocity.z + angular_velocity_offset_stop.angular_velocity_offset.z);
+private:
+  eagleye_msgs::msg::YawrateOffset yaw_rate_offset_;
+  eagleye_msgs::msg::AngularVelocityOffset angular_velocity_offset_stop_;
+  eagleye_msgs::msg::AccXOffset acc_x_offset_;
+  eagleye_msgs::msg::AccXScaleFactor acc_x_scale_factor_;
+  sensor_msgs::msg::Imu imu_;
+  sensor_msgs::msg::Imu correction_imu_;
 
-  pub->publish(correction_imu);
-}
+  rclcpp::Subscription<eagleye_msgs::msg::YawrateOffset>::SharedPtr sub1_;
+  rclcpp::Subscription<eagleye_msgs::msg::AngularVelocityOffset>::SharedPtr sub2_;
+  rclcpp::Subscription<eagleye_msgs::msg::AccXOffset>::SharedPtr sub3_;
+  rclcpp::Subscription<eagleye_msgs::msg::AccXScaleFactor>::SharedPtr sub4_;
+  rclcpp::Subscription<sensor_msgs::msg::Imu>::SharedPtr sub5_;
+  rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr pub_;
+
+  void yawRateOffsetCallback(const eagleye_msgs::msg::YawrateOffset::ConstSharedPtr msg)
+  {
+    yaw_rate_offset_ = *msg;
+  }
+
+  void angularVelocityOffsetStopCallback(const eagleye_msgs::msg::AngularVelocityOffset::ConstSharedPtr msg)
+  {
+    angular_velocity_offset_stop_ = *msg;
+  }
+
+  void accXOffsetCallback(const eagleye_msgs::msg::AccXOffset::ConstSharedPtr msg)
+  {
+    acc_x_offset_ = *msg;
+  }
+
+  void accXScaleFactorCallback(const eagleye_msgs::msg::AccXScaleFactor::ConstSharedPtr msg)
+  {
+    acc_x_scale_factor_ = *msg;
+  }
+
+  void imuCallback(const sensor_msgs::msg::Imu::ConstSharedPtr msg)
+  {
+    imu_ = *msg;
+
+    correction_imu_.header = imu_.header;
+    correction_imu_.orientation = imu_.orientation;
+    correction_imu_.orientation_covariance = imu_.orientation_covariance;
+    correction_imu_.angular_velocity_covariance = imu_.angular_velocity_covariance;
+    correction_imu_.linear_acceleration_covariance = imu_.linear_acceleration_covariance;
+
+    if (acc_x_offset_.status.enabled_status == true && acc_x_scale_factor_.status.enabled_status)
+    {
+      correction_imu_.linear_acceleration.x = imu_.linear_acceleration.x * acc_x_scale_factor_.acc_x_scale_factor + acc_x_offset_.acc_x_offset;
+      correction_imu_.linear_acceleration.y = imu_.linear_acceleration.y;
+      correction_imu_.linear_acceleration.z = imu_.linear_acceleration.z;
+    }
+    else
+    {
+      correction_imu_.linear_acceleration.x = imu_.linear_acceleration.x;
+      correction_imu_.linear_acceleration.y = imu_.linear_acceleration.y;
+      correction_imu_.linear_acceleration.z = imu_.linear_acceleration.z;
+    }
+
+    correction_imu_.angular_velocity.x = imu_.angular_velocity.x + angular_velocity_offset_stop_.angular_velocity_offset.x;
+    correction_imu_.angular_velocity.y = imu_.angular_velocity.y + angular_velocity_offset_stop_.angular_velocity_offset.y;
+    correction_imu_.angular_velocity.z = -1 * (imu_.angular_velocity.z + angular_velocity_offset_stop_.angular_velocity_offset.z);
+
+    pub_->publish(correction_imu_);
+  }
+};
 
 int main(int argc, char** argv)
 {
   rclcpp::init(argc, argv);
-  auto node = rclcpp::Node::make_shared("eagleye_correction_imu");
-
-  auto sub1 = node->create_subscription<eagleye_msgs::msg::YawrateOffset>("yaw_rate_offset_2nd", rclcpp::QoS(10), yaw_rate_offset_callback);  //ros::TransportHints().tcpNoDelay()
-  auto sub2 = node->create_subscription<eagleye_msgs::msg::AngularVelocityOffset>("angular_velocity_offset_stop", rclcpp::QoS(10), angular_velocity_offset_stop_callback);  //ros::TransportHints().tcpNoDelay()
-  auto sub3 = node->create_subscription<eagleye_msgs::msg::AccXOffset>("acc_x_offset", rclcpp::QoS(10), acc_x_offset_callback);  //ros::TransportHints().tcpNoDelay()
-  auto sub4 = node->create_subscription<eagleye_msgs::msg::AccXScaleFactor>("acc_x_scale_factor", rclcpp::QoS(10), acc_x_scale_factor_callback);  //ros::TransportHints().tcpNoDelay()
-  auto sub5 = node->create_subscription<sensor_msgs::msg::Imu>("imu/data_tf_converted", 1000, imu_callback);  //ros::TransportHints().tcpNoDelay()
-  pub = node->create_publisher<sensor_msgs::msg::Imu>("imu/data_corrected", rclcpp::QoS(10));
-
-  rclcpp::spin(node);
-
+  rclcpp::spin(std::make_shared<CorrectionImuNode>());
   return 0;
 }

--- a/eagleye_rt/src/distance_node.cpp
+++ b/eagleye_rt/src/distance_node.cpp
@@ -53,7 +53,7 @@ private:
   geometry_msgs::msg::TwistStamped velocity_;
   eagleye_msgs::msg::StatusStamped velocity_status_;
   eagleye_msgs::msg::Distance distance_;
-  DistanceStatus distance_status_;
+  DistanceStatus distance_status_ = {};
   bool use_can_less_mode_ = false;
 
   rclcpp::Publisher<eagleye_msgs::msg::Distance>::SharedPtr pub_;

--- a/eagleye_rt/src/distance_node.cpp
+++ b/eagleye_rt/src/distance_node.cpp
@@ -28,52 +28,61 @@
  * Author MapIV Sekino
  */
 
-#include "rclcpp/rclcpp.hpp"
 #include "eagleye_coordinate/eagleye_coordinate.hpp"
 #include "eagleye_navigation/eagleye_navigation.hpp"
+#include "rclcpp/rclcpp.hpp"
 
-rclcpp::Publisher<eagleye_msgs::msg::Distance>::SharedPtr _pub;
-static geometry_msgs::msg::TwistStamped _velocity;
-static eagleye_msgs::msg::StatusStamped _velocity_status;
-static eagleye_msgs::msg::Distance _distance;
-
-struct DistanceStatus _distance_status;
-
-static bool _use_can_less_mode;
-
-void velocity_status_callback(const eagleye_msgs::msg::StatusStamped::ConstSharedPtr msg)
+class DistanceNode : public rclcpp::Node
 {
-  _velocity_status = *msg;
-}
-
-void velocity_callback(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg)
-{
-  if(_use_can_less_mode && !_velocity_status.status.enabled_status) return;
-
-  _velocity = *msg;
-  _distance.header = msg->header;
-  _distance.header.frame_id = "base_link";
-  distance_estimate(_velocity, &_distance_status, &_distance);
-
-  if (_distance_status.time_last != 0)
+public:
+  DistanceNode() : Node("eagleye_distance")
   {
-    _pub->publish(_distance);
+    this->declare_parameter("use_can_less_mode", use_can_less_mode_);
+    this->get_parameter("use_can_less_mode", use_can_less_mode_);
+
+    sub_velocity_ = this->create_subscription<geometry_msgs::msg::TwistStamped>(
+      "velocity", rclcpp::QoS(10),
+      std::bind(&DistanceNode::velocityCallback, this, std::placeholders::_1));
+    sub_velocity_status_ = this->create_subscription<eagleye_msgs::msg::StatusStamped>(
+      "velocity_status", rclcpp::QoS(10),
+      std::bind(&DistanceNode::velocityStatusCallback, this, std::placeholders::_1));
+    pub_ = this->create_publisher<eagleye_msgs::msg::Distance>("distance", rclcpp::QoS(10));
   }
-}
+
+private:
+  geometry_msgs::msg::TwistStamped velocity_;
+  eagleye_msgs::msg::StatusStamped velocity_status_;
+  eagleye_msgs::msg::Distance distance_;
+  DistanceStatus distance_status_;
+  bool use_can_less_mode_ = false;
+
+  rclcpp::Publisher<eagleye_msgs::msg::Distance>::SharedPtr pub_;
+  rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr sub_velocity_;
+  rclcpp::Subscription<eagleye_msgs::msg::StatusStamped>::SharedPtr sub_velocity_status_;
+
+  void velocityStatusCallback(const eagleye_msgs::msg::StatusStamped::ConstSharedPtr msg)
+  {
+    velocity_status_ = *msg;
+  }
+
+  void velocityCallback(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg)
+  {
+    if (use_can_less_mode_ && !velocity_status_.status.enabled_status) return;
+
+    velocity_ = *msg;
+    distance_.header = msg->header;
+    distance_.header.frame_id = "base_link";
+    distance_estimate(velocity_, &distance_status_, &distance_);
+
+    if (distance_status_.time_last != 0) {
+      pub_->publish(distance_);
+    }
+  }
+};
 
 int main(int argc, char** argv)
 {
   rclcpp::init(argc, argv);
-  auto node = rclcpp::Node::make_shared("eagleye_distance");
-
-  node->declare_parameter("use_can_less_mode",_use_can_less_mode);
-  node->get_parameter("use_can_less_mode",_use_can_less_mode);
-
-  auto sub1 = node->create_subscription<geometry_msgs::msg::TwistStamped>("velocity", rclcpp::QoS(10), velocity_callback);
-  auto sub2 = node->create_subscription<eagleye_msgs::msg::StatusStamped>("velocity_status", rclcpp::QoS(10), velocity_status_callback);
-  _pub = node->create_publisher<eagleye_msgs::msg::Distance>("distance", rclcpp::QoS(10));
-
-  rclcpp::spin(node);
-
+  rclcpp::spin(std::make_shared<DistanceNode>());
   return 0;
 }

--- a/eagleye_rt/src/enable_additional_rolling_node.cpp
+++ b/eagleye_rt/src/enable_additional_rolling_node.cpp
@@ -30,148 +30,188 @@
 
 #include "eagleye_coordinate/eagleye_coordinate.hpp"
 #include "eagleye_navigation/eagleye_navigation.hpp"
+#include "rclcpp/rclcpp.hpp"
 
-rclcpp::Publisher<eagleye_msgs::msg::AccYOffset>::SharedPtr _pub1;
-rclcpp::Publisher<eagleye_msgs::msg::Rolling>::SharedPtr _pub2;
-
-static eagleye_msgs::msg::VelocityScaleFactor _velocity_scale_factor;
-static geometry_msgs::msg::TwistStamped _velocity;
-static eagleye_msgs::msg::StatusStamped _velocity_status;
-static eagleye_msgs::msg::YawrateOffset _yaw_rate_offset_2nd;
-static eagleye_msgs::msg::YawrateOffset _yaw_rate_offset_stop;
-static eagleye_msgs::msg::Distance _distance;
-static geometry_msgs::msg::PoseStamped _localization_pose;
-static eagleye_msgs::msg::AngularVelocityOffset _angular_velocity_offset_stop;
-static sensor_msgs::msg::Imu _imu;
-
-static eagleye_msgs::msg::Rolling _rolling_angle;
-static eagleye_msgs::msg::AccYOffset _acc_y_offset;
-
-struct EnableAdditionalRollingParameter _rolling_parameter;
-struct EnableAdditionalRollingStatus _rolling_status;
-
-static bool _use_can_less_mode;
-
-void velocity_callback(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg)
+class EnableAdditionalRollingNode : public rclcpp::Node
 {
-  _velocity = *msg;
-}
-
-void velocity_status_callback(const eagleye_msgs::msg::StatusStamped::ConstSharedPtr msg)
-{
-  _velocity_status = *msg;
-}
-
-void velocity_scale_factor_callback(const eagleye_msgs::msg::VelocityScaleFactor::ConstSharedPtr msg)
-{
-  _velocity_scale_factor = *msg;
-}
-
-void distance_callback(const eagleye_msgs::msg::Distance::ConstSharedPtr msg)
-{
-  _distance = *msg;
-}
-
-void yaw_rate_offset_2nd_callback(const eagleye_msgs::msg::YawrateOffset::ConstSharedPtr msg)
-{
-  _yaw_rate_offset_2nd = *msg;
-}
-
-void yaw_rate_offset_stop_callback(const eagleye_msgs::msg::YawrateOffset::ConstSharedPtr msg)
-{
-  _yaw_rate_offset_stop = *msg;
-}
-
-void localization_pose_callback(const geometry_msgs::msg::PoseStamped::ConstSharedPtr msg)
-{
-  _localization_pose = *msg;
-}
-
-void angular_velocity_offset_stop_callback(const eagleye_msgs::msg::AngularVelocityOffset::ConstSharedPtr msg)
-{
-  _angular_velocity_offset_stop = *msg;
-}
-
-void imu_callback(const sensor_msgs::msg::Imu::ConstSharedPtr msg)
-{
-  if(_use_can_less_mode && !_velocity_status.status.enabled_status) return;
-
-  eagleye_msgs::msg::StatusStamped velocity_enable_status;
-  if(_use_can_less_mode)
+public:
+  EnableAdditionalRollingNode() : Node("eagleye_enable_additional_rolling")
   {
-    velocity_enable_status = _velocity_status;
-  }
-  else
-  {
-    velocity_enable_status.header = _velocity_scale_factor.header;
-    velocity_enable_status.status = _velocity_scale_factor.status;
+    std::string subscribe_localization_pose_topic_name;
+
+    std::string yaml_file;
+    this->declare_parameter("yaml_file", yaml_file);
+    this->get_parameter("yaml_file", yaml_file);
+    std::cout << "yaml_file: " << yaml_file << std::endl;
+
+    try {
+      YAML::Node conf = YAML::LoadFile(yaml_file);
+
+      subscribe_localization_pose_topic_name =
+        conf["/**"]["ros__parameters"]["localization_pose_topic"].as<std::string>();
+
+      rolling_parameter_.imu_rate =
+        conf["/**"]["ros__parameters"]["common"]["imu_rate"].as<double>();
+      rolling_parameter_.stop_judgment_threshold =
+        conf["/**"]["ros__parameters"]["common"]["stop_judgment_threshold"].as<double>();
+      rolling_parameter_.update_distance =
+        conf["/**"]["ros__parameters"]["enable_additional_rolling"]["update_distance"]
+          .as<double>();
+      rolling_parameter_.moving_average_time =
+        conf["/**"]["ros__parameters"]["enable_additional_rolling"]["moving_average_time"]
+          .as<double>();
+      rolling_parameter_.sync_judgment_threshold =
+        conf["/**"]["ros__parameters"]["enable_additional_rolling"]["sync_judgment_threshold"]
+          .as<double>();
+      rolling_parameter_.sync_search_period =
+        conf["/**"]["ros__parameters"]["enable_additional_rolling"]["sync_search_period"]
+          .as<double>();
+
+      std::cout << "subscribe_localization_pose_topic_name "
+                << subscribe_localization_pose_topic_name << std::endl;
+      std::cout << "imu_rate " << rolling_parameter_.imu_rate << std::endl;
+      std::cout << "stop_judgment_threshold " << rolling_parameter_.stop_judgment_threshold
+                << std::endl;
+      std::cout << "update_distance " << rolling_parameter_.update_distance << std::endl;
+      std::cout << "moving_average_time " << rolling_parameter_.moving_average_time << std::endl;
+      std::cout << "sync_judgment_threshold " << rolling_parameter_.sync_judgment_threshold
+                << std::endl;
+      std::cout << "sync_search_period " << rolling_parameter_.sync_search_period << std::endl;
+    } catch (YAML::Exception& e) {
+      std::cerr << "\033[1;31menable_additional_rolling Node YAML Error: " << e.msg << "\033[0m"
+                << std::endl;
+      exit(3);
+    }
+
+    sub_velocity_scale_factor_ =
+      this->create_subscription<eagleye_msgs::msg::VelocityScaleFactor>(
+        "velocity_scale_factor", 1000,
+        std::bind(
+          &EnableAdditionalRollingNode::velocityScaleFactorCallback, this,
+          std::placeholders::_1));
+    sub_yaw_rate_offset_2nd_ = this->create_subscription<eagleye_msgs::msg::YawrateOffset>(
+      "yaw_rate_offset_2nd", 1000,
+      std::bind(
+        &EnableAdditionalRollingNode::yawRateOffset2ndCallback, this, std::placeholders::_1));
+    sub_yaw_rate_offset_stop_ = this->create_subscription<eagleye_msgs::msg::YawrateOffset>(
+      "yaw_rate_offset_stop", 1000,
+      std::bind(
+        &EnableAdditionalRollingNode::yawRateOffsetStopCallback, this, std::placeholders::_1));
+    sub_distance_ = this->create_subscription<eagleye_msgs::msg::Distance>(
+      "distance", 1000,
+      std::bind(&EnableAdditionalRollingNode::distanceCallback, this, std::placeholders::_1));
+    sub_localization_pose_ = this->create_subscription<geometry_msgs::msg::PoseStamped>(
+      subscribe_localization_pose_topic_name, 1000,
+      std::bind(
+        &EnableAdditionalRollingNode::localizationPoseCallback, this, std::placeholders::_1));
+    sub_angular_velocity_offset_stop_ =
+      this->create_subscription<eagleye_msgs::msg::AngularVelocityOffset>(
+        "angular_velocity_offset_stop", 1000,
+        std::bind(
+          &EnableAdditionalRollingNode::angularVelocityOffsetStopCallback, this,
+          std::placeholders::_1));
+    sub_imu_ = this->create_subscription<sensor_msgs::msg::Imu>(
+      "imu/data_tf_converted", 1000,
+      std::bind(&EnableAdditionalRollingNode::imuCallback, this, std::placeholders::_1));
+
+    pub_acc_y_offset_ = this->create_publisher<eagleye_msgs::msg::AccYOffset>(
+      "acc_y_offset_additional_rolling", 1000);
+    pub_rolling_ =
+      this->create_publisher<eagleye_msgs::msg::Rolling>("enable_additional_rolling", 1000);
   }
 
-  _imu = *msg;
-  _acc_y_offset.header = msg->header;
-  _acc_y_offset.header.frame_id = "imu";
-  _rolling_angle.header = msg->header;
-  _rolling_angle.header.frame_id = "base_link";
-  enable_additional_rolling_estimate(_velocity, velocity_enable_status, _yaw_rate_offset_2nd, _yaw_rate_offset_stop, _distance, _imu,
-    _localization_pose, _angular_velocity_offset_stop, _rolling_parameter, &_rolling_status, &_rolling_angle, &_acc_y_offset);
-  _pub1->publish(_acc_y_offset);
-  _pub2->publish(_rolling_angle);
-}
+private:
+  eagleye_msgs::msg::VelocityScaleFactor velocity_scale_factor_;
+  geometry_msgs::msg::TwistStamped velocity_;
+  eagleye_msgs::msg::StatusStamped velocity_status_;
+  eagleye_msgs::msg::YawrateOffset yaw_rate_offset_2nd_;
+  eagleye_msgs::msg::YawrateOffset yaw_rate_offset_stop_;
+  eagleye_msgs::msg::Distance distance_;
+  geometry_msgs::msg::PoseStamped localization_pose_;
+  eagleye_msgs::msg::AngularVelocityOffset angular_velocity_offset_stop_;
+  sensor_msgs::msg::Imu imu_;
+
+  eagleye_msgs::msg::Rolling rolling_angle_;
+  eagleye_msgs::msg::AccYOffset acc_y_offset_;
+
+  EnableAdditionalRollingParameter rolling_parameter_;
+  EnableAdditionalRollingStatus rolling_status_;
+
+  bool use_can_less_mode_ = false;
+
+  rclcpp::Publisher<eagleye_msgs::msg::AccYOffset>::SharedPtr pub_acc_y_offset_;
+  rclcpp::Publisher<eagleye_msgs::msg::Rolling>::SharedPtr pub_rolling_;
+  rclcpp::Subscription<eagleye_msgs::msg::VelocityScaleFactor>::SharedPtr
+    sub_velocity_scale_factor_;
+  rclcpp::Subscription<eagleye_msgs::msg::YawrateOffset>::SharedPtr sub_yaw_rate_offset_2nd_;
+  rclcpp::Subscription<eagleye_msgs::msg::YawrateOffset>::SharedPtr sub_yaw_rate_offset_stop_;
+  rclcpp::Subscription<eagleye_msgs::msg::Distance>::SharedPtr sub_distance_;
+  rclcpp::Subscription<geometry_msgs::msg::PoseStamped>::SharedPtr sub_localization_pose_;
+  rclcpp::Subscription<eagleye_msgs::msg::AngularVelocityOffset>::SharedPtr
+    sub_angular_velocity_offset_stop_;
+  rclcpp::Subscription<sensor_msgs::msg::Imu>::SharedPtr sub_imu_;
+
+  void velocityScaleFactorCallback(
+    const eagleye_msgs::msg::VelocityScaleFactor::ConstSharedPtr msg)
+  {
+    velocity_scale_factor_ = *msg;
+  }
+
+  void yawRateOffset2ndCallback(const eagleye_msgs::msg::YawrateOffset::ConstSharedPtr msg)
+  {
+    yaw_rate_offset_2nd_ = *msg;
+  }
+
+  void yawRateOffsetStopCallback(const eagleye_msgs::msg::YawrateOffset::ConstSharedPtr msg)
+  {
+    yaw_rate_offset_stop_ = *msg;
+  }
+
+  void distanceCallback(const eagleye_msgs::msg::Distance::ConstSharedPtr msg)
+  {
+    distance_ = *msg;
+  }
+
+  void localizationPoseCallback(const geometry_msgs::msg::PoseStamped::ConstSharedPtr msg)
+  {
+    localization_pose_ = *msg;
+  }
+
+  void angularVelocityOffsetStopCallback(
+    const eagleye_msgs::msg::AngularVelocityOffset::ConstSharedPtr msg)
+  {
+    angular_velocity_offset_stop_ = *msg;
+  }
+
+  void imuCallback(const sensor_msgs::msg::Imu::ConstSharedPtr msg)
+  {
+    if (use_can_less_mode_ && !velocity_status_.status.enabled_status) return;
+
+    eagleye_msgs::msg::StatusStamped velocity_enable_status;
+    if (use_can_less_mode_) {
+      velocity_enable_status = velocity_status_;
+    } else {
+      velocity_enable_status.header = velocity_scale_factor_.header;
+      velocity_enable_status.status = velocity_scale_factor_.status;
+    }
+
+    imu_ = *msg;
+    acc_y_offset_.header = msg->header;
+    acc_y_offset_.header.frame_id = "imu";
+    rolling_angle_.header = msg->header;
+    rolling_angle_.header.frame_id = "base_link";
+    enable_additional_rolling_estimate(
+      velocity_, velocity_enable_status, yaw_rate_offset_2nd_, yaw_rate_offset_stop_, distance_,
+      imu_, localization_pose_, angular_velocity_offset_stop_, rolling_parameter_,
+      &rolling_status_, &rolling_angle_, &acc_y_offset_);
+    pub_acc_y_offset_->publish(acc_y_offset_);
+    pub_rolling_->publish(rolling_angle_);
+  }
+};
 
 int main(int argc, char** argv)
 {
   rclcpp::init(argc, argv);
-  auto node = rclcpp::Node::make_shared("eagleye_enable_additional_rolling");
-
-  std::string subscribe_localization_pose_topic_name;
-
-  std::string yaml_file;
-  node->declare_parameter("yaml_file",yaml_file);
-  node->get_parameter("yaml_file",yaml_file);
-  std::cout << "yaml_file: " << yaml_file << std::endl;
-
-  try
-  {
-    YAML::Node conf = YAML::LoadFile(yaml_file);
-
-    subscribe_localization_pose_topic_name = conf["/**"]["ros__parameters"]["localization_pose_topic"].as<std::string>();
-
-    _rolling_parameter.imu_rate = conf["/**"]["ros__parameters"]["common"]["imu_rate"].as<double>();
-    _rolling_parameter.stop_judgment_threshold = conf["/**"]["ros__parameters"]["common"]["stop_judgment_threshold"].as<double>();
-
-    _rolling_parameter.update_distance = conf["/**"]["ros__parameters"]["enable_additional_rolling"]["update_distance"].as<double>();
-    _rolling_parameter.moving_average_time = conf["/**"]["ros__parameters"]["enable_additional_rolling"]["moving_average_time"].as<double>();
-    _rolling_parameter.sync_judgment_threshold = conf["/**"]["ros__parameters"]["enable_additional_rolling"]["sync_judgment_threshold"].as<double>();
-    _rolling_parameter.sync_search_period = conf["/**"]["ros__parameters"]["enable_additional_rolling"]["sync_search_period"].as<double>();
-
-    std::cout<< "subscribe_localization_pose_topic_name " << subscribe_localization_pose_topic_name << std::endl;
-
-    std::cout << "imu_rate " << _rolling_parameter.imu_rate << std::endl;
-    std::cout << "stop_judgment_threshold " << _rolling_parameter.stop_judgment_threshold << std::endl;
-
-    std::cout << "update_distance " << _rolling_parameter.update_distance << std::endl;
-    std::cout << "moving_average_time " << _rolling_parameter.moving_average_time << std::endl;
-    std::cout << "sync_judgment_threshold " << _rolling_parameter.sync_judgment_threshold << std::endl;
-    std::cout << "sync_search_period " << _rolling_parameter.sync_search_period << std::endl;
-  }
-  catch (YAML::Exception& e)
-  {
-    std::cerr << "\033[1;31menable_additional_rolling Node YAML Error: " << e.msg << "\033[0m" << std::endl;
-    exit(3);
-  }
-
-  auto sub1 = node->create_subscription<eagleye_msgs::msg::VelocityScaleFactor>("velocity_scale_factor", 1000, velocity_scale_factor_callback);
-  auto sub2 = node->create_subscription<eagleye_msgs::msg::YawrateOffset>("yaw_rate_offset_2nd", 1000, yaw_rate_offset_2nd_callback);
-  auto sub3 = node->create_subscription<eagleye_msgs::msg::YawrateOffset>("yaw_rate_offset_stop", 1000, yaw_rate_offset_stop_callback);
-  auto sub4 = node->create_subscription<eagleye_msgs::msg::Distance>("distance", 1000, distance_callback);
-  auto sub5 = node->create_subscription<geometry_msgs::msg::PoseStamped>(subscribe_localization_pose_topic_name, 1000, localization_pose_callback);
-  auto sub6 = node->create_subscription<eagleye_msgs::msg::AngularVelocityOffset>("angular_velocity_offset_stop", 1000, angular_velocity_offset_stop_callback);
-  auto sub7 = node->create_subscription<sensor_msgs::msg::Imu>("imu/data_tf_converted", 1000, imu_callback);
-
-  _pub1 = node->create_publisher<eagleye_msgs::msg::AccYOffset>("acc_y_offset_additional_rolling", 1000);
-  _pub2 = node->create_publisher<eagleye_msgs::msg::Rolling>("enable_additional_rolling", 1000);
-
-  rclcpp::spin(node);
-
+  rclcpp::spin(std::make_shared<EnableAdditionalRollingNode>());
   return 0;
 }

--- a/eagleye_rt/src/enable_additional_rolling_node.cpp
+++ b/eagleye_rt/src/enable_additional_rolling_node.cpp
@@ -135,7 +135,7 @@ private:
   eagleye_msgs::msg::AccYOffset acc_y_offset_;
 
   EnableAdditionalRollingParameter rolling_parameter_;
-  EnableAdditionalRollingStatus rolling_status_;
+  EnableAdditionalRollingStatus rolling_status_ = {};
 
   bool use_can_less_mode_ = false;
 

--- a/eagleye_rt/src/heading_interpolate_node.cpp
+++ b/eagleye_rt/src/heading_interpolate_node.cpp
@@ -128,7 +128,7 @@ private:
   eagleye_msgs::msg::SlipAngle slip_angle_;
   eagleye_msgs::msg::Heading heading_interpolate_;
   HeadingInterpolateParameter heading_interpolate_parameter_;
-  HeadingInterpolateStatus heading_interpolate_status_;
+  HeadingInterpolateStatus heading_interpolate_status_ = {};
   bool use_can_less_mode_ = false;
 
   rclcpp::Publisher<eagleye_msgs::msg::Heading>::SharedPtr pub_;

--- a/eagleye_rt/src/heading_interpolate_node.cpp
+++ b/eagleye_rt/src/heading_interpolate_node.cpp
@@ -28,144 +28,165 @@
  * Author MapIV Sekino
  */
 
-#include "rclcpp/rclcpp.hpp"
 #include "eagleye_coordinate/eagleye_coordinate.hpp"
 #include "eagleye_navigation/eagleye_navigation.hpp"
+#include "rclcpp/rclcpp.hpp"
 
-static sensor_msgs::msg::Imu imu;
-static geometry_msgs::msg::TwistStamped velocity;
-static eagleye_msgs::msg::StatusStamped velocity_status;
-static eagleye_msgs::msg::YawrateOffset yaw_rate_offset_stop;
-static eagleye_msgs::msg::YawrateOffset yaw_rate_offset;
-static eagleye_msgs::msg::Heading heading;
-static eagleye_msgs::msg::SlipAngle slip_angle;
-
-rclcpp::Publisher<eagleye_msgs::msg::Heading>::SharedPtr pub;
-static eagleye_msgs::msg::Heading heading_interpolate;
-
-struct HeadingInterpolateParameter heading_interpolate_parameter;
-struct HeadingInterpolateStatus heading_interpolate_status;
-
-static bool _use_can_less_mode;
-
-void velocity_callback(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg)
+class HeadingInterpolateNode : public rclcpp::Node
 {
-  velocity = *msg;
-}
+public:
+  HeadingInterpolateNode(int argc, char** argv) : Node("eagleye_heading_interpolate")
+  {
+    std::string yaml_file;
+    this->declare_parameter("yaml_file", yaml_file);
+    this->get_parameter("yaml_file", yaml_file);
+    std::cout << "yaml_file: " << yaml_file << std::endl;
 
-void velocity_status_callback(const eagleye_msgs::msg::StatusStamped::ConstSharedPtr msg)
-{
-  velocity_status = *msg;
-}
+    try {
+      YAML::Node conf = YAML::LoadFile(yaml_file);
 
-void yaw_rate_offset_stop_callback(const eagleye_msgs::msg::YawrateOffset::ConstSharedPtr msg)
-{
-  yaw_rate_offset_stop = *msg;
-}
+      use_can_less_mode_ = conf["/**"]["ros__parameters"]["use_can_less_mode"].as<bool>();
+      heading_interpolate_parameter_.imu_rate =
+        conf["/**"]["ros__parameters"]["common"]["imu_rate"].as<double>();
+      heading_interpolate_parameter_.stop_judgment_threshold =
+        conf["/**"]["ros__parameters"]["common"]["stop_judgment_threshold"].as<double>();
+      heading_interpolate_parameter_.sync_search_period =
+        conf["/**"]["ros__parameters"]["heading_interpolate"]["sync_search_period"].as<double>();
+      heading_interpolate_parameter_.proc_noise =
+        conf["/**"]["ros__parameters"]["heading_interpolate"]["proc_noise"].as<double>();
 
-void yaw_rate_offset_callback(const eagleye_msgs::msg::YawrateOffset::ConstSharedPtr msg)
-{
-  yaw_rate_offset = *msg;
-}
+      std::cout << "imu_rate " << heading_interpolate_parameter_.imu_rate << std::endl;
+      std::cout << "stop_judgment_threshold "
+                << heading_interpolate_parameter_.stop_judgment_threshold << std::endl;
+      std::cout << "sync_search_period " << heading_interpolate_parameter_.sync_search_period
+                << std::endl;
+      std::cout << "proc_noise " << heading_interpolate_parameter_.proc_noise << std::endl;
+    } catch (YAML::Exception& e) {
+      std::cerr << "\033[1;31mheading_interpolate Node YAML Error: " << e.msg << "\033[0m"
+                << std::endl;
+      exit(3);
+    }
 
-void heading_callback(const eagleye_msgs::msg::Heading::ConstSharedPtr msg)
-{
-  heading = *msg;
-}
+    std::string publish_topic_name = "/publish_topic_name/invalid";
+    std::string subscribe_topic_name_1 = "/subscribe_topic_name/invalid_1";
+    std::string subscribe_topic_name_2 = "/subscribe_topic_name/invalid_2";
 
-void slip_angle_callback(const eagleye_msgs::msg::SlipAngle::ConstSharedPtr msg)
-{
-  slip_angle = *msg;
-}
+    if (argc > 2) {
+      if (strcmp(argv[1], "1st") == 0) {
+        publish_topic_name = "heading_interpolate_1st";
+        subscribe_topic_name_1 = "yaw_rate_offset_stop";
+        subscribe_topic_name_2 = "heading_1st";
+      } else if (strcmp(argv[1], "2nd") == 0) {
+        publish_topic_name = "heading_interpolate_2nd";
+        subscribe_topic_name_1 = "yaw_rate_offset_1st";
+        subscribe_topic_name_2 = "heading_2nd";
+      } else if (strcmp(argv[1], "3rd") == 0) {
+        publish_topic_name = "heading_interpolate_3rd";
+        subscribe_topic_name_1 = "yaw_rate_offset_2nd";
+        subscribe_topic_name_2 = "heading_3rd";
+      } else {
+        RCLCPP_ERROR(this->get_logger(), "Invalid argument");
+        rclcpp::shutdown();
+      }
+    } else {
+      RCLCPP_ERROR(this->get_logger(), "No arguments");
+      rclcpp::shutdown();
+    }
 
-void imu_callback(const sensor_msgs::msg::Imu::ConstSharedPtr msg)
-{
-  if(_use_can_less_mode && !velocity_status.status.enabled_status) return;
+    sub_imu_ = this->create_subscription<sensor_msgs::msg::Imu>(
+      "imu/data_tf_converted", 1000,
+      std::bind(&HeadingInterpolateNode::imuCallback, this, std::placeholders::_1));
+    sub_velocity_ = this->create_subscription<geometry_msgs::msg::TwistStamped>(
+      "velocity", rclcpp::QoS(10),
+      std::bind(&HeadingInterpolateNode::velocityCallback, this, std::placeholders::_1));
+    sub_velocity_status_ = this->create_subscription<eagleye_msgs::msg::StatusStamped>(
+      "velocity_status", rclcpp::QoS(10),
+      std::bind(&HeadingInterpolateNode::velocityStatusCallback, this, std::placeholders::_1));
+    sub_yaw_rate_offset_stop_ = this->create_subscription<eagleye_msgs::msg::YawrateOffset>(
+      "yaw_rate_offset_stop", rclcpp::QoS(10),
+      std::bind(
+        &HeadingInterpolateNode::yawRateOffsetStopCallback, this, std::placeholders::_1));
+    sub_yaw_rate_offset_ = this->create_subscription<eagleye_msgs::msg::YawrateOffset>(
+      subscribe_topic_name_1, 1000,
+      std::bind(&HeadingInterpolateNode::yawRateOffsetCallback, this, std::placeholders::_1));
+    sub_heading_ = this->create_subscription<eagleye_msgs::msg::Heading>(
+      subscribe_topic_name_2, 1000,
+      std::bind(&HeadingInterpolateNode::headingCallback, this, std::placeholders::_1));
+    sub_slip_angle_ = this->create_subscription<eagleye_msgs::msg::SlipAngle>(
+      "slip_angle", rclcpp::QoS(10),
+      std::bind(&HeadingInterpolateNode::slipAngleCallback, this, std::placeholders::_1));
+    pub_ = this->create_publisher<eagleye_msgs::msg::Heading>(publish_topic_name, rclcpp::QoS(10));
+  }
 
-  imu = *msg;
-  heading_interpolate.header = msg->header;
-  heading_interpolate.header.frame_id = "base_link";
-  heading_interpolate_estimate(imu,velocity,yaw_rate_offset_stop,yaw_rate_offset,heading,slip_angle,heading_interpolate_parameter,
-    &heading_interpolate_status,&heading_interpolate);
-  pub->publish(heading_interpolate);
-}
+private:
+  sensor_msgs::msg::Imu imu_;
+  geometry_msgs::msg::TwistStamped velocity_;
+  eagleye_msgs::msg::StatusStamped velocity_status_;
+  eagleye_msgs::msg::YawrateOffset yaw_rate_offset_stop_;
+  eagleye_msgs::msg::YawrateOffset yaw_rate_offset_;
+  eagleye_msgs::msg::Heading heading_;
+  eagleye_msgs::msg::SlipAngle slip_angle_;
+  eagleye_msgs::msg::Heading heading_interpolate_;
+  HeadingInterpolateParameter heading_interpolate_parameter_;
+  HeadingInterpolateStatus heading_interpolate_status_;
+  bool use_can_less_mode_ = false;
+
+  rclcpp::Publisher<eagleye_msgs::msg::Heading>::SharedPtr pub_;
+  rclcpp::Subscription<sensor_msgs::msg::Imu>::SharedPtr sub_imu_;
+  rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr sub_velocity_;
+  rclcpp::Subscription<eagleye_msgs::msg::StatusStamped>::SharedPtr sub_velocity_status_;
+  rclcpp::Subscription<eagleye_msgs::msg::YawrateOffset>::SharedPtr sub_yaw_rate_offset_stop_;
+  rclcpp::Subscription<eagleye_msgs::msg::YawrateOffset>::SharedPtr sub_yaw_rate_offset_;
+  rclcpp::Subscription<eagleye_msgs::msg::Heading>::SharedPtr sub_heading_;
+  rclcpp::Subscription<eagleye_msgs::msg::SlipAngle>::SharedPtr sub_slip_angle_;
+
+  void velocityCallback(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg)
+  {
+    velocity_ = *msg;
+  }
+
+  void velocityStatusCallback(const eagleye_msgs::msg::StatusStamped::ConstSharedPtr msg)
+  {
+    velocity_status_ = *msg;
+  }
+
+  void yawRateOffsetStopCallback(const eagleye_msgs::msg::YawrateOffset::ConstSharedPtr msg)
+  {
+    yaw_rate_offset_stop_ = *msg;
+  }
+
+  void yawRateOffsetCallback(const eagleye_msgs::msg::YawrateOffset::ConstSharedPtr msg)
+  {
+    yaw_rate_offset_ = *msg;
+  }
+
+  void headingCallback(const eagleye_msgs::msg::Heading::ConstSharedPtr msg)
+  {
+    heading_ = *msg;
+  }
+
+  void slipAngleCallback(const eagleye_msgs::msg::SlipAngle::ConstSharedPtr msg)
+  {
+    slip_angle_ = *msg;
+  }
+
+  void imuCallback(const sensor_msgs::msg::Imu::ConstSharedPtr msg)
+  {
+    if (use_can_less_mode_ && !velocity_status_.status.enabled_status) return;
+
+    imu_ = *msg;
+    heading_interpolate_.header = msg->header;
+    heading_interpolate_.header.frame_id = "base_link";
+    heading_interpolate_estimate(
+      imu_, velocity_, yaw_rate_offset_stop_, yaw_rate_offset_, heading_, slip_angle_,
+      heading_interpolate_parameter_, &heading_interpolate_status_, &heading_interpolate_);
+    pub_->publish(heading_interpolate_);
+  }
+};
 
 int main(int argc, char** argv)
 {
   rclcpp::init(argc, argv);
-  auto node = rclcpp::Node::make_shared("eagleye_heading_interpolate");
-
-  std::string yaml_file;
-  node->declare_parameter("yaml_file",yaml_file);
-  node->get_parameter("yaml_file",yaml_file);
-  std::cout << "yaml_file: " << yaml_file << std::endl;
-
-  try
-  {
-    YAML::Node conf = YAML::LoadFile(yaml_file);
-
-    heading_interpolate_parameter.imu_rate = conf["/**"]["ros__parameters"]["common"]["imu_rate"].as<double>();
-    heading_interpolate_parameter.stop_judgment_threshold = conf["/**"]["ros__parameters"]["common"]["stop_judgment_threshold"].as<double>();
-    heading_interpolate_parameter.sync_search_period = conf["/**"]["ros__parameters"]["heading_interpolate"]["sync_search_period"].as<double>();
-    heading_interpolate_parameter.proc_noise = conf["/**"]["ros__parameters"]["heading_interpolate"]["proc_noise"].as<double>();
-
-    std::cout << "imu_rate " << heading_interpolate_parameter.imu_rate << std::endl;
-    std::cout << "stop_judgment_threshold " << heading_interpolate_parameter.stop_judgment_threshold << std::endl;
-    std::cout << "sync_search_period " << heading_interpolate_parameter.sync_search_period << std::endl;
-    std::cout << "proc_noise " << heading_interpolate_parameter.proc_noise << std::endl;
-  }
-  catch (YAML::Exception& e)
-  {
-    std::cerr << "\033[1;31mheading_interpolate Node YAML Error: " << e.msg << "\033[0m" << std::endl;
-    exit(3);
-  }
-
-  std::string publish_topic_name = "/publish_topic_name/invalid";
-  std::string subscribe_topic_name_1 = "/subscribe_topic_name/invalid_1";
-  std::string subscribe_topic_name_2 = "/subscribe_topic_name/invalid_2";
-
-  if (argc > 2)
-  {
-    if (strcmp(argv[1], "1st") == 0)
-    {
-      publish_topic_name = "heading_interpolate_1st";
-      subscribe_topic_name_1 = "yaw_rate_offset_stop";
-      subscribe_topic_name_2 = "heading_1st";
-    }
-    else if (strcmp(argv[1], "2nd") == 0)
-    {
-      publish_topic_name = "heading_interpolate_2nd";
-      subscribe_topic_name_1 = "yaw_rate_offset_1st";
-      subscribe_topic_name_2 = "heading_2nd";
-    }
-    else if (strcmp(argv[1], "3rd") == 0)
-    {
-      publish_topic_name = "heading_interpolate_3rd";
-      subscribe_topic_name_1 = "yaw_rate_offset_2nd";
-      subscribe_topic_name_2 = "heading_3rd";
-    }
-    else
-    {
-      RCLCPP_ERROR(node->get_logger(),"Invalid argument");
-      rclcpp::shutdown();
-    }
-  }
-  else
-  {
-    RCLCPP_ERROR(node->get_logger(),"No arguments");
-    rclcpp::shutdown();
-  }
-
-  auto sub1 = node->create_subscription<sensor_msgs::msg::Imu>("imu/data_tf_converted", 1000, imu_callback);
-  auto sub2 = node->create_subscription<geometry_msgs::msg::TwistStamped>("velocity", rclcpp::QoS(10), velocity_callback);
-  auto sub3 = node->create_subscription<eagleye_msgs::msg::StatusStamped>("velocity_status", rclcpp::QoS(10), velocity_status_callback);
-  auto sub4 = node->create_subscription<eagleye_msgs::msg::YawrateOffset>("yaw_rate_offset_stop", rclcpp::QoS(10), yaw_rate_offset_stop_callback);
-  auto sub5 = node->create_subscription<eagleye_msgs::msg::YawrateOffset>(subscribe_topic_name_1, 1000, yaw_rate_offset_callback);
-  auto sub6 = node->create_subscription<eagleye_msgs::msg::Heading>(subscribe_topic_name_2, 1000, heading_callback);
-  auto sub7 = node->create_subscription<eagleye_msgs::msg::SlipAngle>("slip_angle", rclcpp::QoS(10), slip_angle_callback);
-  pub = node->create_publisher<eagleye_msgs::msg::Heading>(publish_topic_name, rclcpp::QoS(10));
-
-  rclcpp::spin(node);
-
+  rclcpp::spin(std::make_shared<HeadingInterpolateNode>(argc, argv));
   return 0;
 }

--- a/eagleye_rt/src/heading_node.cpp
+++ b/eagleye_rt/src/heading_node.cpp
@@ -186,7 +186,7 @@ private:
   eagleye_msgs::msg::Heading heading_interpolate_;
   eagleye_msgs::msg::Heading heading_;
   HeadingParameter heading_parameter_;
-  HeadingStatus heading_status_;
+  HeadingStatus heading_status_ = {};
   std::string use_gnss_mode_;
   bool use_can_less_mode_ = false;
   bool use_multi_antenna_mode_ = false;

--- a/eagleye_rt/src/heading_node.cpp
+++ b/eagleye_rt/src/heading_node.cpp
@@ -28,259 +28,287 @@
  * Author MapIV Sekino
  */
 
-#include "rclcpp/rclcpp.hpp"
 #include "eagleye_coordinate/eagleye_coordinate.hpp"
 #include "eagleye_navigation/eagleye_navigation.hpp"
+#include "rclcpp/rclcpp.hpp"
 
-static rtklib_msgs::msg::RtklibNav rtklib_nav;
-static nmea_msgs::msg::Gprmc nmea_rmc;
-static eagleye_msgs::msg::Heading multi_antenna_heading;
-static sensor_msgs::msg::Imu imu;
-static geometry_msgs::msg::TwistStamped velocity;
-static eagleye_msgs::msg::StatusStamped velocity_status;
-static eagleye_msgs::msg::YawrateOffset yaw_rate_offset_stop;
-static eagleye_msgs::msg::YawrateOffset yaw_rate_offset;
-static eagleye_msgs::msg::SlipAngle slip_angle;
-static eagleye_msgs::msg::Heading heading_interpolate;
-
-rclcpp::Publisher<eagleye_msgs::msg::Heading>::SharedPtr pub;
-static eagleye_msgs::msg::Heading heading;
-
-struct HeadingParameter heading_parameter;
-struct HeadingStatus heading_status;
-
-std::string use_gnss_mode;
-static bool use_can_less_mode;
-static bool use_multi_antenna_mode;
-
-bool is_first_correction_velocity = false;
-
-bool skip_static_initialization = false;
-double yaw_rate_offset_stop_in_skip_mode = 0.0;
-
-std::string node_name = "eagleye_heading";
-
-void rtklib_nav_callback(const rtklib_msgs::msg::RtklibNav::ConstSharedPtr msg)
+class HeadingNode : public rclcpp::Node
 {
-  rtklib_nav = *msg;
-}
-
-void velocity_callback(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg)
-{
-  velocity = *msg;
-  // To avoid unnecessary buffering when it's just sitting there right after start-up, we're making it so it doesn't buffer.
-  // Multi-antenna mode is an exception.
-  if (is_first_correction_velocity == false && msg->twist.linear.x > heading_parameter.moving_judgment_threshold)
+public:
+  HeadingNode(int argc, char** argv) : Node("eagleye_heading")
   {
-    is_first_correction_velocity = true;
-  }
-}
+    std::string subscribe_rtklib_nav_topic_name = "gnss/rtklib_nav";
+    std::string subscribe_rmc_topic_name = "gnss/rmc";
 
-void pose_callback(const geometry_msgs::msg::PoseStamped::ConstSharedPtr msg)
-{
-  tf2::Quaternion orientation;
-  tf2::fromMsg(msg->pose.orientation, orientation);
-  double roll, pitch, yaw;
-  tf2::Matrix3x3(orientation).getRPY(roll, pitch, yaw);
-  double heading = - yaw + (90* M_PI / 180);
+    std::string yaml_file;
+    this->declare_parameter("yaml_file", yaml_file);
+    this->get_parameter("yaml_file", yaml_file);
+    this->declare_parameter("use_multi_antenna_mode", use_multi_antenna_mode_);
+    this->get_parameter("use_multi_antenna_mode", use_multi_antenna_mode_);
+    std::cout << "yaml_file: " << yaml_file << std::endl;
+    std::cout << "use_multi_antenna_mode: " << use_multi_antenna_mode_ << std::endl;
 
-  multi_antenna_heading.header = msg->header;
-  multi_antenna_heading.heading_angle = heading;
-}
+    try {
+      YAML::Node conf = YAML::LoadFile(yaml_file);
 
-void velocity_status_callback(const eagleye_msgs::msg::StatusStamped::ConstSharedPtr msg)
-{
-  velocity_status = *msg;
-}
+      use_gnss_mode_ = conf["/**"]["ros__parameters"]["use_gnss_mode"].as<std::string>();
+      heading_parameter_.imu_rate =
+        conf["/**"]["ros__parameters"]["common"]["imu_rate"].as<double>();
+      heading_parameter_.gnss_rate =
+        conf["/**"]["ros__parameters"]["common"]["gnss_rate"].as<double>();
+      heading_parameter_.stop_judgment_threshold =
+        conf["/**"]["ros__parameters"]["common"]["stop_judgment_threshold"].as<double>();
+      heading_parameter_.moving_judgment_threshold =
+        conf["/**"]["ros__parameters"]["common"]["moving_judgment_threshold"].as<double>();
+      heading_parameter_.estimated_minimum_interval =
+        conf["/**"]["ros__parameters"]["heading"]["estimated_minimum_interval"].as<double>();
+      heading_parameter_.estimated_maximum_interval =
+        conf["/**"]["ros__parameters"]["heading"]["estimated_maximum_interval"].as<double>();
+      heading_parameter_.gnss_receiving_threshold =
+        conf["/**"]["ros__parameters"]["heading"]["gnss_receiving_threshold"].as<double>();
+      heading_parameter_.outlier_threshold =
+        conf["/**"]["ros__parameters"]["heading"]["outlier_threshold"].as<double>();
+      heading_parameter_.outlier_ratio_threshold =
+        conf["/**"]["ros__parameters"]["heading"]["outlier_ratio_threshold"].as<double>();
+      heading_parameter_.curve_judgment_threshold =
+        conf["/**"]["ros__parameters"]["heading"]["curve_judgment_threshold"].as<double>();
+      heading_parameter_.init_STD =
+        conf["/**"]["ros__parameters"]["heading"]["init_STD"].as<double>();
+      skip_static_initialization_ =
+        conf["/**"]["ros__parameters"]["heading"]["skip_static_initialization"].as<bool>();
+      yaw_rate_offset_stop_in_skip_mode_ =
+        conf["/**"]["ros__parameters"]["heading"]["yaw_rate_offset_stop_in_skip_mode"].as<double>();
 
-void yaw_rate_offset_stop_callback(const eagleye_msgs::msg::YawrateOffset::ConstSharedPtr msg)
-{
-  yaw_rate_offset_stop = *msg;
-}
-
-void yaw_rate_offset_callback(const eagleye_msgs::msg::YawrateOffset::ConstSharedPtr msg)
-{
-  yaw_rate_offset = *msg;
-}
-
-void slip_angle_callback(const eagleye_msgs::msg::SlipAngle::ConstSharedPtr msg)
-{
-  slip_angle = *msg;
-}
-
-void heading_interpolate_callback(const eagleye_msgs::msg::Heading::ConstSharedPtr msg)
-{
-  heading_interpolate = *msg;
-}
-
-void rmc_callback(const nmea_msgs::msg::Gprmc::ConstSharedPtr msg)
-{
-  nmea_rmc = *msg;
-}
-
-void imu_callback(const sensor_msgs::msg::Imu::ConstSharedPtr msg)
-{
-  if (!is_first_correction_velocity)
-  {
-    RCLCPP_WARN(rclcpp::get_logger(node_name), "is_first_correction_velocity is false.");
-    return;
-  }
-  if(use_can_less_mode && !velocity_status.status.enabled_status)
-  {
-    RCLCPP_WARN(rclcpp::get_logger(node_name), "velocity_status is not enabled.");
-    return;
-  }
-  if(!yaw_rate_offset_stop.status.enabled_status)
-  {
-    if(skip_static_initialization)
-    {
-      yaw_rate_offset_stop.yaw_rate_offset = yaw_rate_offset_stop_in_skip_mode;
+      std::cout << "use_gnss_mode " << use_gnss_mode_ << std::endl;
+      std::cout << "subscribe_rtklib_nav_topic_name " << subscribe_rtklib_nav_topic_name
+                << std::endl;
+      std::cout << "subscribe_rmc_topic_name " << subscribe_rmc_topic_name << std::endl;
+      std::cout << "imu_rate " << heading_parameter_.imu_rate << std::endl;
+      std::cout << "gnss_rate " << heading_parameter_.gnss_rate << std::endl;
+      std::cout << "stop_judgment_threshold " << heading_parameter_.stop_judgment_threshold
+                << std::endl;
+      std::cout << "moving_judgment_threshold " << heading_parameter_.moving_judgment_threshold
+                << std::endl;
+      std::cout << "estimated_minimum_interval " << heading_parameter_.estimated_minimum_interval
+                << std::endl;
+      std::cout << "estimated_maximum_interval " << heading_parameter_.estimated_maximum_interval
+                << std::endl;
+      std::cout << "gnss_receiving_threshold " << heading_parameter_.gnss_receiving_threshold
+                << std::endl;
+      std::cout << "outlier_threshold " << heading_parameter_.outlier_threshold << std::endl;
+      std::cout << "outlier_ratio_threshold " << heading_parameter_.outlier_ratio_threshold
+                << std::endl;
+      std::cout << "curve_judgment_threshold " << heading_parameter_.curve_judgment_threshold
+                << std::endl;
+      std::cout << "init_STD " << heading_parameter_.init_STD << std::endl;
+      std::cout << "skip_static_initialization " << skip_static_initialization_ << std::endl;
+      std::cout << "yaw_rate_offset_stop_in_skip_mode " << yaw_rate_offset_stop_in_skip_mode_
+                << std::endl;
+    } catch (YAML::Exception& e) {
+      std::cerr << "\033[1;31mheading Node YAML Error: " << e.msg << "\033[0m" << std::endl;
+      exit(3);
     }
-    else
-    {
-      RCLCPP_WARN(rclcpp::get_logger(node_name), "Heading estimation is not started because the stop calibration is not yet completed.");
+
+    std::string publish_topic_name = "/publish_topic_name/invalid";
+    std::string subscribe_topic_name = "/subscribe_topic_name/invalid";
+    std::string subscribe_topic_name2 = "/subscribe_topic_name2/invalid";
+
+    if (argc > 2) {
+      if (strcmp(argv[1], "1st") == 0) {
+        publish_topic_name = "heading_1st";
+        subscribe_topic_name = "yaw_rate_offset_stop";
+        subscribe_topic_name2 = "heading_interpolate_1st";
+      } else if (strcmp(argv[1], "2nd") == 0) {
+        publish_topic_name = "heading_2nd";
+        subscribe_topic_name = "yaw_rate_offset_1st";
+        subscribe_topic_name2 = "heading_interpolate_2nd";
+      } else if (strcmp(argv[1], "3rd") == 0) {
+        publish_topic_name = "heading_3rd";
+        subscribe_topic_name = "yaw_rate_offset_2nd";
+        subscribe_topic_name2 = "heading_interpolate_3rd";
+      } else {
+        RCLCPP_ERROR(this->get_logger(), "Invalid argument");
+        rclcpp::shutdown();
+      }
+    } else {
+      RCLCPP_ERROR(this->get_logger(), "No arguments");
+      rclcpp::shutdown();
+    }
+
+    if (use_multi_antenna_mode_) {
+      is_first_correction_velocity_ = true;
+    }
+
+    sub_imu_ = this->create_subscription<sensor_msgs::msg::Imu>(
+      "imu/data_tf_converted", 1000,
+      std::bind(&HeadingNode::imuCallback, this, std::placeholders::_1));
+    sub_rtklib_nav_ = this->create_subscription<rtklib_msgs::msg::RtklibNav>(
+      subscribe_rtklib_nav_topic_name, 1000,
+      std::bind(&HeadingNode::rtklibNavCallback, this, std::placeholders::_1));
+    sub_rmc_ = this->create_subscription<nmea_msgs::msg::Gprmc>(
+      subscribe_rmc_topic_name, 1000,
+      std::bind(&HeadingNode::rmcCallback, this, std::placeholders::_1));
+    sub_gnss_compass_pose_ = this->create_subscription<geometry_msgs::msg::PoseStamped>(
+      "gnss_compass_pose", 1000,
+      std::bind(&HeadingNode::poseCallback, this, std::placeholders::_1));
+    sub_velocity_ = this->create_subscription<geometry_msgs::msg::TwistStamped>(
+      "velocity", rclcpp::QoS(10),
+      std::bind(&HeadingNode::velocityCallback, this, std::placeholders::_1));
+    sub_velocity_status_ = this->create_subscription<eagleye_msgs::msg::StatusStamped>(
+      "velocity_status", rclcpp::QoS(10),
+      std::bind(&HeadingNode::velocityStatusCallback, this, std::placeholders::_1));
+    sub_yaw_rate_offset_stop_ = this->create_subscription<eagleye_msgs::msg::YawrateOffset>(
+      "yaw_rate_offset_stop", rclcpp::QoS(10),
+      std::bind(&HeadingNode::yawRateOffsetStopCallback, this, std::placeholders::_1));
+    sub_yaw_rate_offset_ = this->create_subscription<eagleye_msgs::msg::YawrateOffset>(
+      subscribe_topic_name, 1000,
+      std::bind(&HeadingNode::yawRateOffsetCallback, this, std::placeholders::_1));
+    sub_slip_angle_ = this->create_subscription<eagleye_msgs::msg::SlipAngle>(
+      "slip_angle", rclcpp::QoS(10),
+      std::bind(&HeadingNode::slipAngleCallback, this, std::placeholders::_1));
+    sub_heading_interpolate_ = this->create_subscription<eagleye_msgs::msg::Heading>(
+      subscribe_topic_name2, 1000,
+      std::bind(&HeadingNode::headingInterpolateCallback, this, std::placeholders::_1));
+    pub_ =
+      this->create_publisher<eagleye_msgs::msg::Heading>(publish_topic_name, rclcpp::QoS(10));
+  }
+
+private:
+  rtklib_msgs::msg::RtklibNav rtklib_nav_;
+  nmea_msgs::msg::Gprmc nmea_rmc_;
+  eagleye_msgs::msg::Heading multi_antenna_heading_;
+  sensor_msgs::msg::Imu imu_;
+  geometry_msgs::msg::TwistStamped velocity_;
+  eagleye_msgs::msg::StatusStamped velocity_status_;
+  eagleye_msgs::msg::YawrateOffset yaw_rate_offset_stop_;
+  eagleye_msgs::msg::YawrateOffset yaw_rate_offset_;
+  eagleye_msgs::msg::SlipAngle slip_angle_;
+  eagleye_msgs::msg::Heading heading_interpolate_;
+  eagleye_msgs::msg::Heading heading_;
+  HeadingParameter heading_parameter_;
+  HeadingStatus heading_status_;
+  std::string use_gnss_mode_;
+  bool use_can_less_mode_ = false;
+  bool use_multi_antenna_mode_ = false;
+  bool is_first_correction_velocity_ = false;
+  bool skip_static_initialization_ = false;
+  double yaw_rate_offset_stop_in_skip_mode_ = 0.0;
+
+  rclcpp::Publisher<eagleye_msgs::msg::Heading>::SharedPtr pub_;
+  rclcpp::Subscription<sensor_msgs::msg::Imu>::SharedPtr sub_imu_;
+  rclcpp::Subscription<rtklib_msgs::msg::RtklibNav>::SharedPtr sub_rtklib_nav_;
+  rclcpp::Subscription<nmea_msgs::msg::Gprmc>::SharedPtr sub_rmc_;
+  rclcpp::Subscription<geometry_msgs::msg::PoseStamped>::SharedPtr sub_gnss_compass_pose_;
+  rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr sub_velocity_;
+  rclcpp::Subscription<eagleye_msgs::msg::StatusStamped>::SharedPtr sub_velocity_status_;
+  rclcpp::Subscription<eagleye_msgs::msg::YawrateOffset>::SharedPtr sub_yaw_rate_offset_stop_;
+  rclcpp::Subscription<eagleye_msgs::msg::YawrateOffset>::SharedPtr sub_yaw_rate_offset_;
+  rclcpp::Subscription<eagleye_msgs::msg::SlipAngle>::SharedPtr sub_slip_angle_;
+  rclcpp::Subscription<eagleye_msgs::msg::Heading>::SharedPtr sub_heading_interpolate_;
+
+  void rtklibNavCallback(const rtklib_msgs::msg::RtklibNav::ConstSharedPtr msg)
+  {
+    rtklib_nav_ = *msg;
+  }
+
+  void velocityCallback(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg)
+  {
+    velocity_ = *msg;
+    if (
+      is_first_correction_velocity_ == false &&
+      msg->twist.linear.x > heading_parameter_.moving_judgment_threshold) {
+      is_first_correction_velocity_ = true;
+    }
+  }
+
+  void poseCallback(const geometry_msgs::msg::PoseStamped::ConstSharedPtr msg)
+  {
+    tf2::Quaternion orientation;
+    tf2::fromMsg(msg->pose.orientation, orientation);
+    double roll, pitch, yaw;
+    tf2::Matrix3x3(orientation).getRPY(roll, pitch, yaw);
+    double heading = -yaw + (90 * M_PI / 180);
+
+    multi_antenna_heading_.header = msg->header;
+    multi_antenna_heading_.heading_angle = heading;
+  }
+
+  void velocityStatusCallback(const eagleye_msgs::msg::StatusStamped::ConstSharedPtr msg)
+  {
+    velocity_status_ = *msg;
+  }
+
+  void yawRateOffsetStopCallback(const eagleye_msgs::msg::YawrateOffset::ConstSharedPtr msg)
+  {
+    yaw_rate_offset_stop_ = *msg;
+  }
+
+  void yawRateOffsetCallback(const eagleye_msgs::msg::YawrateOffset::ConstSharedPtr msg)
+  {
+    yaw_rate_offset_ = *msg;
+  }
+
+  void slipAngleCallback(const eagleye_msgs::msg::SlipAngle::ConstSharedPtr msg)
+  {
+    slip_angle_ = *msg;
+  }
+
+  void headingInterpolateCallback(const eagleye_msgs::msg::Heading::ConstSharedPtr msg)
+  {
+    heading_interpolate_ = *msg;
+  }
+
+  void rmcCallback(const nmea_msgs::msg::Gprmc::ConstSharedPtr msg) { nmea_rmc_ = *msg; }
+
+  void imuCallback(const sensor_msgs::msg::Imu::ConstSharedPtr msg)
+  {
+    if (!is_first_correction_velocity_) {
+      RCLCPP_WARN(this->get_logger(), "is_first_correction_velocity is false.");
       return;
     }
-  }
+    if (use_can_less_mode_ && !velocity_status_.status.enabled_status) {
+      RCLCPP_WARN(this->get_logger(), "velocity_status is not enabled.");
+      return;
+    }
+    if (!yaw_rate_offset_stop_.status.enabled_status) {
+      if (skip_static_initialization_) {
+        yaw_rate_offset_stop_.yaw_rate_offset = yaw_rate_offset_stop_in_skip_mode_;
+      } else {
+        RCLCPP_WARN(
+          this->get_logger(),
+          "Heading estimation is not started because the stop calibration is not yet completed.");
+        return;
+      }
+    }
 
-  imu = *msg;
-  heading.header = msg->header;
-  heading.header.frame_id = "base_link";
-  bool use_rtklib_mode = use_gnss_mode == "rtklib" || use_gnss_mode == "RTKLIB";
-  bool use_nmea_mode = use_gnss_mode == "nmea" || use_gnss_mode == "NMEA";
-  if (use_rtklib_mode && !use_multi_antenna_mode) // use RTKLIB mode
-    heading_estimate(rtklib_nav,imu,velocity,yaw_rate_offset_stop,yaw_rate_offset,slip_angle,heading_interpolate,heading_parameter,&heading_status,&heading);
-  else if (use_nmea_mode && !use_multi_antenna_mode) // use NMEA mode
-    heading_estimate(nmea_rmc,imu,velocity,yaw_rate_offset_stop,yaw_rate_offset,slip_angle,heading_interpolate,heading_parameter,&heading_status,&heading);
-  else if (use_multi_antenna_mode)
-    heading_estimate(multi_antenna_heading, imu, velocity, yaw_rate_offset_stop, yaw_rate_offset, slip_angle,
-      heading_interpolate, heading_parameter, &heading_status, &heading);
+    imu_ = *msg;
+    heading_.header = msg->header;
+    heading_.header.frame_id = "base_link";
+    bool use_rtklib_mode = use_gnss_mode_ == "rtklib" || use_gnss_mode_ == "RTKLIB";
+    bool use_nmea_mode = use_gnss_mode_ == "nmea" || use_gnss_mode_ == "NMEA";
+    if (use_rtklib_mode && !use_multi_antenna_mode_)
+      heading_estimate(
+        rtklib_nav_, imu_, velocity_, yaw_rate_offset_stop_, yaw_rate_offset_, slip_angle_,
+        heading_interpolate_, heading_parameter_, &heading_status_, &heading_);
+    else if (use_nmea_mode && !use_multi_antenna_mode_)
+      heading_estimate(
+        nmea_rmc_, imu_, velocity_, yaw_rate_offset_stop_, yaw_rate_offset_, slip_angle_,
+        heading_interpolate_, heading_parameter_, &heading_status_, &heading_);
+    else if (use_multi_antenna_mode_)
+      heading_estimate(
+        multi_antenna_heading_, imu_, velocity_, yaw_rate_offset_stop_, yaw_rate_offset_,
+        slip_angle_, heading_interpolate_, heading_parameter_, &heading_status_, &heading_);
 
-  if (heading.status.estimate_status == true || use_multi_antenna_mode)
-  {
-    pub->publish(heading);
+    if (heading_.status.estimate_status == true || use_multi_antenna_mode_) {
+      pub_->publish(heading_);
+    }
+    heading_.status.estimate_status = false;
   }
-  heading.status.estimate_status = false;
-}
+};
 
 int main(int argc, char** argv)
 {
   rclcpp::init(argc, argv);
-  auto node = rclcpp::Node::make_shared(node_name);
-
-  std::string subscribe_rtklib_nav_topic_name = "gnss/rtklib_nav";
-  std::string subscribe_rmc_topic_name = "gnss/rmc";
-
-  std::string yaml_file;
-  node->declare_parameter("yaml_file",yaml_file);
-  node->get_parameter("yaml_file",yaml_file);
-  node->declare_parameter("use_multi_antenna_mode",use_multi_antenna_mode);
-  node->get_parameter("use_multi_antenna_mode",use_multi_antenna_mode);
-  std::cout << "yaml_file: " << yaml_file << std::endl;
-  std::cout << "use_multi_antenna_mode: " << use_multi_antenna_mode << std::endl;
-
-  try
-  {
-    YAML::Node conf = YAML::LoadFile(yaml_file);
-
-    use_gnss_mode = conf["/**"]["ros__parameters"]["use_gnss_mode"].as<std::string>();
-
-    heading_parameter.imu_rate = conf["/**"]["ros__parameters"]["common"]["imu_rate"].as<double>();
-    heading_parameter.gnss_rate = conf["/**"]["ros__parameters"]["common"]["gnss_rate"].as<double>();
-    heading_parameter.stop_judgment_threshold = conf["/**"]["ros__parameters"]["common"]["stop_judgment_threshold"].as<double>();
-    heading_parameter.moving_judgment_threshold = conf["/**"]["ros__parameters"]["common"]["moving_judgment_threshold"].as<double>();
-    heading_parameter.estimated_minimum_interval = conf["/**"]["ros__parameters"]["heading"]["estimated_minimum_interval"].as<double>();
-    heading_parameter.estimated_maximum_interval = conf["/**"]["ros__parameters"]["heading"]["estimated_maximum_interval"].as<double>();
-    heading_parameter.gnss_receiving_threshold = conf["/**"]["ros__parameters"]["heading"]["gnss_receiving_threshold"].as<double>();
-    heading_parameter.outlier_threshold = conf["/**"]["ros__parameters"]["heading"]["outlier_threshold"].as<double>();
-    heading_parameter.outlier_ratio_threshold = conf["/**"]["ros__parameters"]["heading"]["outlier_ratio_threshold"].as<double>();
-    heading_parameter.curve_judgment_threshold = conf["/**"]["ros__parameters"]["heading"]["curve_judgment_threshold"].as<double>();
-    heading_parameter.init_STD = conf["/**"]["ros__parameters"]["heading"]["init_STD"].as<double>();
-    skip_static_initialization = conf["/**"]["ros__parameters"]["heading"]["skip_static_initialization"].as<bool>();
-    yaw_rate_offset_stop_in_skip_mode = conf["/**"]["ros__parameters"]["heading"]["yaw_rate_offset_stop_in_skip_mode"].as<double>();
-
-    std::cout<< "use_gnss_mode " << use_gnss_mode << std::endl;
-
-    std::cout<< "subscribe_rtklib_nav_topic_name " << subscribe_rtklib_nav_topic_name << std::endl;
-    std::cout<< "subscribe_rmc_topic_name " << subscribe_rmc_topic_name << std::endl;
-
-    std::cout << "imu_rate " << heading_parameter.imu_rate << std::endl;
-    std::cout << "gnss_rate " << heading_parameter.gnss_rate << std::endl;
-    std::cout << "stop_judgment_threshold " << heading_parameter.stop_judgment_threshold << std::endl;
-    std::cout << "moving_judgment_threshold " << heading_parameter.moving_judgment_threshold << std::endl;
-
-    std::cout << "estimated_minimum_interval " << heading_parameter.estimated_minimum_interval << std::endl;
-    std::cout << "estimated_maximum_interval " << heading_parameter.estimated_maximum_interval << std::endl;
-    std::cout << "gnss_receiving_threshold " << heading_parameter.gnss_receiving_threshold << std::endl;
-    std::cout << "outlier_threshold " << heading_parameter.outlier_threshold << std::endl;
-    std::cout << "outlier_ratio_threshold " << heading_parameter.outlier_ratio_threshold << std::endl;
-    std::cout << "curve_judgment_threshold " << heading_parameter.curve_judgment_threshold << std::endl;
-    std::cout << "init_STD " << heading_parameter.init_STD << std::endl;
-    std::cout << "skip_static_initialization " << skip_static_initialization << std::endl;
-    std::cout << "yaw_rate_offset_stop_in_skip_mode " << yaw_rate_offset_stop_in_skip_mode << std::endl;
-  }
-  catch (YAML::Exception& e)
-  {
-    std::cerr << "\033[1;31mheading Node YAML Error: " << e.msg << "\033[0m" << std::endl;
-    exit(3);
-  }
-
-  std::string publish_topic_name = "/publish_topic_name/invalid";
-  std::string subscribe_topic_name = "/subscribe_topic_name/invalid";
-  std::string subscribe_topic_name2 = "/subscribe_topic_name2/invalid";
-
-  if (argc > 2)
-  {
-    if (strcmp(argv[1], "1st") == 0)
-    {
-      publish_topic_name = "heading_1st";
-      subscribe_topic_name = "yaw_rate_offset_stop";
-      subscribe_topic_name2 = "heading_interpolate_1st";
-    }
-    else if (strcmp(argv[1], "2nd") == 0)
-    {
-      publish_topic_name = "heading_2nd";
-      subscribe_topic_name = "yaw_rate_offset_1st";
-      subscribe_topic_name2 = "heading_interpolate_2nd";
-    }
-    else if (strcmp(argv[1], "3rd") == 0)
-    {
-      publish_topic_name = "heading_3rd";
-      subscribe_topic_name = "yaw_rate_offset_2nd";
-      subscribe_topic_name2 = "heading_interpolate_3rd";
-    }
-    else
-    {
-      RCLCPP_ERROR(node->get_logger(),"Invalid argument");
-      rclcpp::shutdown();
-    }
-  }
-  else
-  {
-    RCLCPP_ERROR(node->get_logger(),"No arguments");
-    rclcpp::shutdown();
-  }
-
-  if(use_multi_antenna_mode)
-  {
-    // When using multi-antenna mode, set is_first_correction_velocity to true even when stationary for the first time.
-    is_first_correction_velocity = true;
-  }
-
-  auto sub1 = node->create_subscription<sensor_msgs::msg::Imu>("imu/data_tf_converted", 1000, imu_callback);
-  auto sub2 = node->create_subscription<rtklib_msgs::msg::RtklibNav>(subscribe_rtklib_nav_topic_name, 1000, rtklib_nav_callback);
-  auto sub3 = node->create_subscription<nmea_msgs::msg::Gprmc>(subscribe_rmc_topic_name, 1000, rmc_callback);
-  auto sub4 = node->create_subscription<geometry_msgs::msg::PoseStamped>("gnss_compass_pose", 1000, pose_callback);
-  auto sub5 = node->create_subscription<geometry_msgs::msg::TwistStamped>("velocity", rclcpp::QoS(10), velocity_callback);
-  auto sub6 = node->create_subscription<eagleye_msgs::msg::StatusStamped>("velocity_status", rclcpp::QoS(10), velocity_status_callback);
-  auto sub7 = node->create_subscription<eagleye_msgs::msg::YawrateOffset>("yaw_rate_offset_stop", rclcpp::QoS(10), yaw_rate_offset_stop_callback);
-  auto sub8 = node->create_subscription<eagleye_msgs::msg::YawrateOffset>(subscribe_topic_name, 1000, yaw_rate_offset_callback);
-  auto sub9 = node->create_subscription<eagleye_msgs::msg::SlipAngle>("slip_angle", rclcpp::QoS(10), slip_angle_callback);
-  auto sub10 = node->create_subscription<eagleye_msgs::msg::Heading>(subscribe_topic_name2 , 1000, heading_interpolate_callback);
-  pub = node->create_publisher<eagleye_msgs::msg::Heading>(publish_topic_name, rclcpp::QoS(10));
-
-  rclcpp::spin(node);
-
-
+  rclcpp::spin(std::make_shared<HeadingNode>(argc, argv));
   return 0;
 }

--- a/eagleye_rt/src/height_node.cpp
+++ b/eagleye_rt/src/height_node.cpp
@@ -28,146 +28,169 @@
  * Author MapIV  Takanose
  */
 
- #include "rclcpp/rclcpp.hpp"
- #include "eagleye_coordinate/eagleye_coordinate.hpp"
- #include "eagleye_navigation/eagleye_navigation.hpp"
+#include "eagleye_coordinate/eagleye_coordinate.hpp"
+#include "eagleye_navigation/eagleye_navigation.hpp"
+#include "rclcpp/rclcpp.hpp"
 
- static sensor_msgs::msg::Imu imu;
- static nmea_msgs::msg::Gpgga gga;
- static geometry_msgs::msg::TwistStamped velocity;
- static eagleye_msgs::msg::StatusStamped velocity_status;
- static eagleye_msgs::msg::Distance distance;
-
- rclcpp::Publisher<eagleye_msgs::msg::Height>::SharedPtr pub1;
- rclcpp::Publisher<eagleye_msgs::msg::Pitching>::SharedPtr pub2;
- rclcpp::Publisher<eagleye_msgs::msg::AccXOffset>::SharedPtr pub3;
- rclcpp::Publisher<eagleye_msgs::msg::AccXScaleFactor>::SharedPtr pub4;
- rclcpp::Publisher<nmea_msgs::msg::Gpgga>::SharedPtr pub5;
- static eagleye_msgs::msg::Height height;
- static eagleye_msgs::msg::Pitching pitching;
- static eagleye_msgs::msg::AccXOffset acc_x_offset;
- static eagleye_msgs::msg::AccXScaleFactor acc_x_scale_factor;
-
- struct HeightParameter height_parameter;
- struct HeightStatus height_status;
-
- static bool use_can_less_mode;
-
-void gga_callback(const nmea_msgs::msg::Gpgga::ConstSharedPtr msg)
+class HeightNode : public rclcpp::Node
 {
-  gga = *msg;
-}
-
-void velocity_callback(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg)
-{
-  velocity = *msg;
-}
-
-void velocity_status_callback(const eagleye_msgs::msg::StatusStamped::ConstSharedPtr msg)
-{
-  velocity_status = *msg;
-}
-
-void distance_callback(const eagleye_msgs::msg::Distance::ConstSharedPtr msg)
-{
-  distance = *msg;
-}
-
-void imu_callback(const sensor_msgs::msg::Imu::ConstSharedPtr msg)
-{
-  if(use_can_less_mode && !velocity_status.status.enabled_status) return;
-
-  imu = *msg;
-  height.header = msg->header;
-  height.header.frame_id = "base_link";
-  pitching.header = msg->header;
-  pitching.header.frame_id = "base_link";
-  acc_x_offset.header = msg->header;
-  acc_x_scale_factor.header = msg->header;
-  pitching_estimate(imu,gga,velocity,distance,height_parameter,&height_status,&height,&pitching,&acc_x_offset,&acc_x_scale_factor);
-  pub1->publish(height);
-  pub2->publish(pitching);
-  pub3->publish(acc_x_offset);
-  pub4->publish(acc_x_scale_factor);
-
-  if (height_status.flag_reliability == true)
+public:
+  HeightNode() : Node("eagleye_height")
   {
-    pub5->publish(gga);
+    std::string subscribe_gga_topic_name = "gnss/gga";
+
+    std::string yaml_file;
+    this->declare_parameter("yaml_file", yaml_file);
+    this->get_parameter("yaml_file", yaml_file);
+    std::cout << "yaml_file: " << yaml_file << std::endl;
+
+    try {
+      YAML::Node conf = YAML::LoadFile(yaml_file);
+
+      use_can_less_mode_ = conf["/**"]["ros__parameters"]["use_can_less_mode"].as<bool>();
+      height_parameter_.imu_rate =
+        conf["/**"]["ros__parameters"]["common"]["imu_rate"].as<double>();
+      height_parameter_.gnss_rate =
+        conf["/**"]["ros__parameters"]["common"]["gnss_rate"].as<double>();
+      height_parameter_.moving_judgment_threshold =
+        conf["/**"]["ros__parameters"]["common"]["moving_judgment_threshold"].as<double>();
+      height_parameter_.estimated_minimum_interval =
+        conf["/**"]["ros__parameters"]["height"]["estimated_minimum_interval"].as<double>();
+      height_parameter_.estimated_maximum_interval =
+        conf["/**"]["ros__parameters"]["height"]["estimated_maximum_interval"].as<double>();
+      height_parameter_.update_distance =
+        conf["/**"]["ros__parameters"]["height"]["update_distance"].as<double>();
+      height_parameter_.gnss_receiving_threshold =
+        conf["/**"]["ros__parameters"]["height"]["gnss_receiving_threshold"].as<double>();
+      height_parameter_.outlier_threshold =
+        conf["/**"]["ros__parameters"]["height"]["outlier_threshold"].as<double>();
+      height_parameter_.outlier_ratio_threshold =
+        conf["/**"]["ros__parameters"]["height"]["outlier_ratio_threshold"].as<double>();
+      height_parameter_.moving_average_time =
+        conf["/**"]["ros__parameters"]["height"]["moving_average_time"].as<double>();
+
+      std::cout << "imu_rate " << height_parameter_.imu_rate << std::endl;
+      std::cout << "gnss_rate " << height_parameter_.gnss_rate << std::endl;
+      std::cout << "moving_judgment_threshold " << height_parameter_.moving_judgment_threshold
+                << std::endl;
+      std::cout << "estimated_minimum_interval " << height_parameter_.estimated_minimum_interval
+                << std::endl;
+      std::cout << "estimated_maximum_interval " << height_parameter_.estimated_maximum_interval
+                << std::endl;
+      std::cout << "update_distance " << height_parameter_.update_distance << std::endl;
+      std::cout << "gnss_receiving_threshold " << height_parameter_.gnss_receiving_threshold
+                << std::endl;
+      std::cout << "outlier_threshold " << height_parameter_.outlier_threshold << std::endl;
+      std::cout << "outlier_ratio_threshold " << height_parameter_.outlier_ratio_threshold
+                << std::endl;
+      std::cout << "moving_average_time " << height_parameter_.moving_average_time << std::endl;
+    } catch (YAML::Exception& e) {
+      std::cerr << "\033[1;31mheight Node YAML Error: " << e.msg << "\033[0m" << std::endl;
+      exit(3);
+    }
+
+    sub_imu_ = this->create_subscription<sensor_msgs::msg::Imu>(
+      "imu/data_tf_converted", 1000,
+      std::bind(&HeightNode::imuCallback, this, std::placeholders::_1));
+    sub_gga_ = this->create_subscription<nmea_msgs::msg::Gpgga>(
+      subscribe_gga_topic_name, 1000,
+      std::bind(&HeightNode::ggaCallback, this, std::placeholders::_1));
+    sub_velocity_ = this->create_subscription<geometry_msgs::msg::TwistStamped>(
+      "velocity", rclcpp::QoS(10),
+      std::bind(&HeightNode::velocityCallback, this, std::placeholders::_1));
+    sub_velocity_status_ = this->create_subscription<eagleye_msgs::msg::StatusStamped>(
+      "velocity_status", rclcpp::QoS(10),
+      std::bind(&HeightNode::velocityStatusCallback, this, std::placeholders::_1));
+    sub_distance_ = this->create_subscription<eagleye_msgs::msg::Distance>(
+      "distance", rclcpp::QoS(10),
+      std::bind(&HeightNode::distanceCallback, this, std::placeholders::_1));
+
+    pub_height_ = this->create_publisher<eagleye_msgs::msg::Height>("height", 1000);
+    pub_pitching_ = this->create_publisher<eagleye_msgs::msg::Pitching>("pitching", 1000);
+    pub_acc_x_offset_ =
+      this->create_publisher<eagleye_msgs::msg::AccXOffset>("acc_x_offset", 1000);
+    pub_acc_x_scale_factor_ =
+      this->create_publisher<eagleye_msgs::msg::AccXScaleFactor>("acc_x_scale_factor", 1000);
+    pub_gga_ =
+      this->create_publisher<nmea_msgs::msg::Gpgga>("navsat/reliability_gga", 1000);
   }
 
-  height_status.flag_reliability = false;
-  height.status.estimate_status = false;
-  pitching.status.estimate_status = false;
-  acc_x_offset.status.estimate_status = false;
-  acc_x_scale_factor.status.estimate_status = false;
-}
+private:
+  sensor_msgs::msg::Imu imu_;
+  nmea_msgs::msg::Gpgga gga_;
+  geometry_msgs::msg::TwistStamped velocity_;
+  eagleye_msgs::msg::StatusStamped velocity_status_;
+  eagleye_msgs::msg::Distance distance_;
+  eagleye_msgs::msg::Height height_;
+  eagleye_msgs::msg::Pitching pitching_;
+  eagleye_msgs::msg::AccXOffset acc_x_offset_;
+  eagleye_msgs::msg::AccXScaleFactor acc_x_scale_factor_;
+  HeightParameter height_parameter_;
+  HeightStatus height_status_;
+  bool use_can_less_mode_ = false;
+
+  rclcpp::Publisher<eagleye_msgs::msg::Height>::SharedPtr pub_height_;
+  rclcpp::Publisher<eagleye_msgs::msg::Pitching>::SharedPtr pub_pitching_;
+  rclcpp::Publisher<eagleye_msgs::msg::AccXOffset>::SharedPtr pub_acc_x_offset_;
+  rclcpp::Publisher<eagleye_msgs::msg::AccXScaleFactor>::SharedPtr pub_acc_x_scale_factor_;
+  rclcpp::Publisher<nmea_msgs::msg::Gpgga>::SharedPtr pub_gga_;
+  rclcpp::Subscription<sensor_msgs::msg::Imu>::SharedPtr sub_imu_;
+  rclcpp::Subscription<nmea_msgs::msg::Gpgga>::SharedPtr sub_gga_;
+  rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr sub_velocity_;
+  rclcpp::Subscription<eagleye_msgs::msg::StatusStamped>::SharedPtr sub_velocity_status_;
+  rclcpp::Subscription<eagleye_msgs::msg::Distance>::SharedPtr sub_distance_;
+
+  void ggaCallback(const nmea_msgs::msg::Gpgga::ConstSharedPtr msg) { gga_ = *msg; }
+
+  void velocityCallback(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg)
+  {
+    velocity_ = *msg;
+  }
+
+  void velocityStatusCallback(const eagleye_msgs::msg::StatusStamped::ConstSharedPtr msg)
+  {
+    velocity_status_ = *msg;
+  }
+
+  void distanceCallback(const eagleye_msgs::msg::Distance::ConstSharedPtr msg)
+  {
+    distance_ = *msg;
+  }
+
+  void imuCallback(const sensor_msgs::msg::Imu::ConstSharedPtr msg)
+  {
+    if (use_can_less_mode_ && !velocity_status_.status.enabled_status) return;
+
+    imu_ = *msg;
+    height_.header = msg->header;
+    height_.header.frame_id = "base_link";
+    pitching_.header = msg->header;
+    pitching_.header.frame_id = "base_link";
+    acc_x_offset_.header = msg->header;
+    acc_x_scale_factor_.header = msg->header;
+    pitching_estimate(
+      imu_, gga_, velocity_, distance_, height_parameter_, &height_status_, &height_, &pitching_,
+      &acc_x_offset_, &acc_x_scale_factor_);
+    pub_height_->publish(height_);
+    pub_pitching_->publish(pitching_);
+    pub_acc_x_offset_->publish(acc_x_offset_);
+    pub_acc_x_scale_factor_->publish(acc_x_scale_factor_);
+
+    if (height_status_.flag_reliability == true) {
+      pub_gga_->publish(gga_);
+    }
+
+    height_status_.flag_reliability = false;
+    height_.status.estimate_status = false;
+    pitching_.status.estimate_status = false;
+    acc_x_offset_.status.estimate_status = false;
+    acc_x_scale_factor_.status.estimate_status = false;
+  }
+};
 
 int main(int argc, char** argv)
 {
   rclcpp::init(argc, argv);
-  auto node = rclcpp::Node::make_shared("eagleye_height");
-
-  std::string subscribe_gga_topic_name = "gnss/gga";
-
-  std::string yaml_file;
-  node->declare_parameter("yaml_file",yaml_file);
-  node->get_parameter("yaml_file",yaml_file);
-  std::cout << "yaml_file: " << yaml_file << std::endl;
-
-  try
-  {
-    YAML::Node conf = YAML::LoadFile(yaml_file);
-
-    height_parameter.imu_rate = conf["/**"]["ros__parameters"]["common"]["imu_rate"].as<double>();
-    height_parameter.gnss_rate = conf["/**"]["ros__parameters"]["common"]["gnss_rate"].as<double>();
-    height_parameter.moving_judgment_threshold = conf["/**"]["ros__parameters"]["common"]["moving_judgment_threshold"].as<double>();
-
-    height_parameter.estimated_minimum_interval = conf["/**"]["ros__parameters"]["height"]["estimated_minimum_interval"].as<double>();
-    height_parameter.estimated_maximum_interval = conf["/**"]["ros__parameters"]["height"]["estimated_maximum_interval"].as<double>();
-    height_parameter.update_distance = conf["/**"]["ros__parameters"]["height"]["update_distance"].as<double>();
-    height_parameter.gnss_receiving_threshold = conf["/**"]["ros__parameters"]["height"]["gnss_receiving_threshold"].as<double>();
-    height_parameter.outlier_threshold = conf["/**"]["ros__parameters"]["height"]["outlier_threshold"].as<double>();
-    height_parameter.outlier_ratio_threshold = conf["/**"]["ros__parameters"]["height"]["outlier_ratio_threshold"].as<double>();
-    height_parameter.moving_average_time = conf["/**"]["ros__parameters"]["height"]["moving_average_time"].as<double>();
-
-    std::cout << "imu_rate " << height_parameter.imu_rate << std::endl;
-    std::cout << "gnss_rate " << height_parameter.gnss_rate << std::endl;
-    std::cout << "moving_judgment_threshold " << height_parameter.moving_judgment_threshold << std::endl;
-
-    std::cout << "estimated_minimum_interval " << height_parameter.estimated_minimum_interval << std::endl;
-    std::cout << "estimated_maximum_interval " << height_parameter.estimated_maximum_interval << std::endl;
-    std::cout << "update_distance " << height_parameter.update_distance << std::endl;
-    std::cout << "gnss_receiving_threshold " << height_parameter.gnss_receiving_threshold << std::endl;
-    std::cout << "outlier_threshold " << height_parameter.outlier_threshold << std::endl;
-    std::cout << "outlier_ratio_threshold " << height_parameter.outlier_ratio_threshold << std::endl;
-    std::cout << "moving_average_time " << height_parameter.moving_average_time << std::endl;
-  }
-  catch (YAML::Exception& e)
-  {
-    std::cerr << "\033[1;31mheight Node YAML Error: " << e.msg << "\033[0m" << std::endl;
-    exit(3);
-  }
-
-
-  auto sub1 = node->create_subscription<sensor_msgs::msg::Imu>("imu/data_tf_converted", 1000, imu_callback);
-  auto sub2 = node->create_subscription<nmea_msgs::msg::Gpgga>(subscribe_gga_topic_name, 1000, gga_callback);
-  auto sub3 = node->create_subscription<geometry_msgs::msg::TwistStamped>("velocity", rclcpp::QoS(10), velocity_callback);
-  auto sub4 = node->create_subscription<eagleye_msgs::msg::StatusStamped>("velocity_status", rclcpp::QoS(10), velocity_status_callback);
-  auto sub5 = node->create_subscription<eagleye_msgs::msg::Distance>("distance", rclcpp::QoS(10), distance_callback);
-
-  std::string publish_height_topic_name = "height";
-  std::string publish_pitching_topic_name = "pitching";
-  std::string publish_acc_x_offset_topic_name = "acc_x_offset";
-  std::string publish_acc_x_scale_factor_topic_name = "acc_x_scale_factor";
-  std::string publish_nav_sat_gga_topic_name = "navsat/reliability_gga";
-
-  pub1 = node->create_publisher<eagleye_msgs::msg::Height>(publish_height_topic_name, 1000);
-  pub2 = node->create_publisher<eagleye_msgs::msg::Pitching>(publish_pitching_topic_name, 1000);
-  pub3 = node->create_publisher<eagleye_msgs::msg::AccXOffset>(publish_acc_x_offset_topic_name, 1000);
-  pub4 = node->create_publisher<eagleye_msgs::msg::AccXScaleFactor>(publish_acc_x_scale_factor_topic_name, 1000);
-  pub5 = node->create_publisher<nmea_msgs::msg::Gpgga>(publish_nav_sat_gga_topic_name, 1000);
-
-  rclcpp::spin(node);
-
+  rclcpp::spin(std::make_shared<HeightNode>());
   return 0;
 }

--- a/eagleye_rt/src/height_node.cpp
+++ b/eagleye_rt/src/height_node.cpp
@@ -126,7 +126,7 @@ private:
   eagleye_msgs::msg::AccXOffset acc_x_offset_;
   eagleye_msgs::msg::AccXScaleFactor acc_x_scale_factor_;
   HeightParameter height_parameter_;
-  HeightStatus height_status_;
+  HeightStatus height_status_ = {};
   bool use_can_less_mode_ = false;
 
   rclcpp::Publisher<eagleye_msgs::msg::Height>::SharedPtr pub_height_;

--- a/eagleye_rt/src/monitor_node.cpp
+++ b/eagleye_rt/src/monitor_node.cpp
@@ -28,1175 +28,1474 @@
  * Author MapIV Sekino
  */
 
-#include "rclcpp/rclcpp.hpp"
 #include "eagleye_coordinate/eagleye_coordinate.hpp"
 #include "eagleye_navigation/eagleye_navigation.hpp"
+#include "rclcpp/rclcpp.hpp"
 
-#include <diagnostic_updater/diagnostic_updater.hpp>
 #include <ament_index_cpp/get_package_share_directory.hpp>
+#include <diagnostic_updater/diagnostic_updater.hpp>
 
-static sensor_msgs::msg::Imu _imu;
-static rtklib_msgs::msg::RtklibNav _rtklib_nav;
-static sensor_msgs::msg::NavSatFix _rtklib_fix;
-static nmea_msgs::msg::Gpgga _gga;
-static geometry_msgs::msg::TwistStamped _velocity;
-static geometry_msgs::msg::TwistStamped _correction_velocity;
-static eagleye_msgs::msg::VelocityScaleFactor _velocity_scale_factor;
-static eagleye_msgs::msg::Distance _distance;
-static eagleye_msgs::msg::Heading _heading_1st;
-static eagleye_msgs::msg::Heading _heading_interpolate_1st;
-static eagleye_msgs::msg::Heading _heading_2nd;
-static eagleye_msgs::msg::Heading _heading_interpolate_2nd;
-static eagleye_msgs::msg::Heading _heading_3rd;
-static eagleye_msgs::msg::Heading _heading_interpolate_3rd;
-static eagleye_msgs::msg::YawrateOffset _yaw_rate_offset_stop;
-static eagleye_msgs::msg::YawrateOffset _yaw_rate_offset_1st;
-static eagleye_msgs::msg::YawrateOffset _yaw_rate_offset_2nd;
-static eagleye_msgs::msg::SlipAngle _slip_angle;
-static eagleye_msgs::msg::Height _height;
-static eagleye_msgs::msg::Pitching _pitching;
-static eagleye_msgs::msg::Rolling _rolling;
-static eagleye_msgs::msg::Position _enu_relative_pos;
-static geometry_msgs::msg::Vector3Stamped _enu_vel;
-static eagleye_msgs::msg::Position _enu_absolute_pos;
-static eagleye_msgs::msg::Position _enu_absolute_pos_interpolate;
-static sensor_msgs::msg::NavSatFix _eagleye_fix;
-static geometry_msgs::msg::TwistStamped _eagleye_twist;
-
-static geometry_msgs::msg::TwistStamped::ConstSharedPtr _comparison_velocity_ptr;
-static sensor_msgs::msg::Imu _corrected_imu;
-
-static bool _gga_sub_status;
-static bool _print_status, _log_output_status, _log_header_make = false;
-static std::string _output_log_dir;
-
-static double _imu_time_last;
-static double _rtklib_nav_time_last;
-static double _navsat_gga_time_last;
-static double _velocity_time_last;
-static double _velocity_scale_factor_time_last;
-static double _distance_time_last;
-static double _heading_1st_time_last;
-static double _heading_interpolate_1st_time_last;
-static double _heading_2nd_time_last;
-static double _heading_interpolate_2nd_time_last;
-static double _heading_3rd_time_last;
-static double _heading_interpolate_3rd_time_last;
-static double _yaw_rate_offset_stop_time_last;
-static double _yaw_rate_offset_1st_time_last;
-static double _yaw_rate_offset_2nd_time_last;
-static double _slip_angle_time_last;
-static double _height_time_last;
-static double _pitching_time_last;
-static double _enu_vel_time_last;
-static double _enu_absolute_pos_time_last;
-static double _enu_absolute_pos_interpolate_time_last;
-static double _eagleye_twist_time_last;
-
-bool _use_compare_yaw_rate = false;
-double _update_rate = 10.0;
-double _th_gnss_deadrock_time = 10;
-double _th_diff_rad_per_sec = 0.17453;
-int _num_continuous_abnormal_yaw_rate = 0;
-int _th_num_continuous_abnormal_yaw_rate = 10;
-
-std::shared_ptr<diagnostic_updater::Updater> updater_;
-
-void rtklib_nav_callback(const rtklib_msgs::msg::RtklibNav::ConstSharedPtr msg)
+class MonitorNode : public rclcpp::Node
 {
-  _rtklib_nav = *msg;
-}
-
-void rtklib_fix_callback(const sensor_msgs::msg::NavSatFix::ConstSharedPtr msg)
-{
-  _rtklib_fix = *msg;
-}
-
-void navsatfix_gga_callback(const nmea_msgs::msg::Gpgga::ConstSharedPtr msg)
-{
-  _gga = *msg;
-  _gga_sub_status = true;
-}
-
-void velocity_callback(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg)
-{
-  _velocity = *msg;
-}
-
-void correction_velocity_callback(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg)
-{
-  _correction_velocity = *msg;
-}
-
-void velocity_scale_factor_callback(const eagleye_msgs::msg::VelocityScaleFactor::ConstSharedPtr msg)
-{
-  _velocity_scale_factor = *msg;
-}
-
-void distance_callback(const eagleye_msgs::msg::Distance::ConstSharedPtr msg)
-{
-  _distance = *msg;
-}
-
-void heading_1st_callback(const eagleye_msgs::msg::Heading::ConstSharedPtr msg)
-{
-  _heading_1st = *msg;
-}
-
-void heading_interpolate_1st_callback(const eagleye_msgs::msg::Heading::ConstSharedPtr msg)
-{
-  _heading_interpolate_1st = *msg;
-}
-
-void heading_2nd_callback(const eagleye_msgs::msg::Heading::ConstSharedPtr msg)
-{
-  _heading_2nd = *msg;
-}
-
-void heading_interpolate_2nd_callback(const eagleye_msgs::msg::Heading::ConstSharedPtr msg)
-{
-  _heading_interpolate_2nd = *msg;
-}
-
-void heading_3rd_callback(const eagleye_msgs::msg::Heading::ConstSharedPtr msg)
-{
-  _heading_3rd = *msg;
-}
-
-void heading_interpolate_3rd_callback(const eagleye_msgs::msg::Heading::ConstSharedPtr msg)
-{
-  _heading_interpolate_3rd = *msg;
-}
-
-void yaw_rate_offset_stop_callback(const eagleye_msgs::msg::YawrateOffset::ConstSharedPtr msg)
-{
-  _yaw_rate_offset_stop = *msg;
-}
-
-void yaw_rate_offset_1st_callback(const eagleye_msgs::msg::YawrateOffset::ConstSharedPtr msg)
-{
-  _yaw_rate_offset_1st = *msg;
-}
-
-void yaw_rate_offset_2nd_callback(const eagleye_msgs::msg::YawrateOffset::ConstSharedPtr msg)
-{
-  _yaw_rate_offset_2nd = *msg;
-}
-
-void slip_angle_callback(const eagleye_msgs::msg::SlipAngle::ConstSharedPtr msg)
-{
-  _slip_angle = *msg;
-}
-
-void enu_relative_pos_callback(const eagleye_msgs::msg::Position::ConstSharedPtr msg)
-{
-  _enu_relative_pos = *msg;
-}
-
-void enu_vel_callback(const geometry_msgs::msg::Vector3Stamped::ConstSharedPtr msg)
-{
-  _enu_vel = *msg;
-}
-
-void enu_absolute_pos_callback(const eagleye_msgs::msg::Position::ConstSharedPtr msg)
-{
-  _enu_absolute_pos = *msg;
-}
-
-void height_callback(const eagleye_msgs::msg::Height::ConstSharedPtr msg)
-{
-  _height = *msg;
-}
-
-void pitching_callback(const eagleye_msgs::msg::Pitching::ConstSharedPtr msg)
-{
-  _pitching = *msg;
-}
-
-void rolling_callback(const eagleye_msgs::msg::Rolling::ConstSharedPtr msg)
-{
-  _rolling = *msg;
-}
-
-void enu_absolute_pos_interpolate_callback(const eagleye_msgs::msg::Position::ConstSharedPtr msg)
-{
-  _enu_absolute_pos_interpolate = *msg;
-}
-
-void eagleye_fix_callback(const sensor_msgs::msg::NavSatFix::ConstSharedPtr msg)
-{
-  _eagleye_fix = *msg;
-}
-
-void eagleye_twist_callback(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg)
-{
-  _eagleye_twist = *msg;
-}
-
-void comparison_velocity_callback(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg)
-{
-  _comparison_velocity_ptr = msg;
-}
-
-
-void imu_topic_checker(diagnostic_updater::DiagnosticStatusWrapper & stat)
-{
-  rclcpp::Time ros_clock(_imu.header.stamp);
-  auto imu_time = ros_clock.seconds();
-
-  int8_t level = diagnostic_msgs::msg::DiagnosticStatus::OK;
-  std::string msg = "OK";
-
-  if (_imu_time_last == imu_time) {
-    level = diagnostic_msgs::msg::DiagnosticStatus::STALE;
-    msg = "not subscribed to topic";
-  }
-
-  _imu_time_last = imu_time;
-  stat.summary(level, msg);
-}
-void rtklib_nav_topic_checker(diagnostic_updater::DiagnosticStatusWrapper & stat)
-{
-  rclcpp::Time ros_clock(_rtklib_nav.header.stamp);
-  auto rtklib_nav_time = ros_clock.seconds();
-
-  int8_t level = diagnostic_msgs::msg::DiagnosticStatus::OK;
-  std::string msg = "OK";
-
-  if (_rtklib_nav_time_last - rtklib_nav_time > _th_gnss_deadrock_time) {
-    level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-    msg = "not subscribed or deadlock of more than 10 seconds";
-  }
-
-  _rtklib_nav_time_last = rtklib_nav_time;
-  stat.summary(level, msg);
-}
-void navsat_gga_topic_checker(diagnostic_updater::DiagnosticStatusWrapper & stat)
-{
-  rclcpp::Time ros_clock(_gga.header.stamp);
-  auto navsat_gga_time = ros_clock.seconds();
-
-  int8_t level = diagnostic_msgs::msg::DiagnosticStatus::OK;
-  std::string msg = "OK";
-
-  if (_navsat_gga_time_last - navsat_gga_time > _th_gnss_deadrock_time || !_gga_sub_status) {
-    level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-    msg = "not subscribed to topic";
-  }
-
-  _navsat_gga_time_last = navsat_gga_time;
-  stat.summary(level, msg);
-}
-void velocity_topic_checker(diagnostic_updater::DiagnosticStatusWrapper & stat)
-{
-  rclcpp::Time ros_clock(_velocity.header.stamp);
-  auto velocity_time = ros_clock.seconds();
-
-  int8_t level = diagnostic_msgs::msg::DiagnosticStatus::OK;
-  std::string msg = "OK";
-
-  if (_velocity_time_last == velocity_time) {
-    level = diagnostic_msgs::msg::DiagnosticStatus::STALE;
-    msg = "not subscribed to topic";
-  }
-
-  _velocity_time_last = velocity_time;
-  stat.summary(level, msg);
-}
-void velocity_scale_factor_topic_checker(diagnostic_updater::DiagnosticStatusWrapper & stat)
-{
-  rclcpp::Time ros_clock(_velocity_scale_factor.header.stamp);
-  auto velocity_scale_factor_time = ros_clock.seconds();
-
-  int8_t level = diagnostic_msgs::msg::DiagnosticStatus::OK;
-  std::string msg = "OK";
-
-  if (_velocity_scale_factor_time_last == velocity_scale_factor_time) {
-    level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-    msg = "not subscribed to topic";
-  }
-  else if (!_velocity_scale_factor.status.enabled_status) {
-    level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-    msg = "estimates have not started yet";
-  }
-  else if (_velocity_scale_factor.status.is_abnormal) {
-    level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
-    if (_velocity_scale_factor.status.error_code == eagleye_msgs::msg::Status::NAN_OR_INFINITE)
-    {
-      msg = "Estimated velocity scale factor is NaN or infinete";
-    }
-    else if (_velocity_scale_factor.status.error_code == eagleye_msgs::msg::Status::TOO_LARGE_OR_SMALL)
-    {
-      msg = "Estimated velocity scale factor is too large or too small";
-    }
-    else
-    {
-      msg = "abnormal error of velocity_scale_factor";
-    }
-  }
-
-  _velocity_scale_factor_time_last = velocity_scale_factor_time;
-  stat.summary(level, msg);
-}
-void distance_topic_checker(diagnostic_updater::DiagnosticStatusWrapper & stat)
-{
-  rclcpp::Time ros_clock(_distance.header.stamp);
-  auto distance_time = ros_clock.seconds();
-  
-  int8_t level = diagnostic_msgs::msg::DiagnosticStatus::OK;
-  std::string msg = "OK";
-
-  if (_distance_time_last == distance_time) {
-    level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-    msg = "not subscribed to topic";
-  }
-  else if (!std::isfinite(_distance.distance)) {
-    level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
-    msg = "invalid number";
-  }
-  else if (!_distance.status.enabled_status) {
-    level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-    msg = "estimates have not started yet";
-  }
-
-  _distance_time_last = distance_time;
-  stat.summary(level, msg);
-}
-void heading_1st_topic_checker(diagnostic_updater::DiagnosticStatusWrapper & stat)
-{
-  rclcpp::Time ros_clock(_heading_1st.header.stamp);
-  auto heading_1st_time = ros_clock.seconds();
-  
-  int8_t level = diagnostic_msgs::msg::DiagnosticStatus::OK;
-  std::string msg = "OK";
-
-  if (!std::isfinite(_heading_1st.heading_angle)) {
-    level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
-    msg = "invalid number";
-  }
-  else if (_heading_1st_time_last - heading_1st_time > _th_gnss_deadrock_time) {
-    level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-    msg = "not subscribed or deadlock of more than 10 seconds";
-  }
-  else if (!_heading_1st.status.enabled_status) {
-    level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-    msg = "estimates have not started yet";
-  }
-
-  _heading_1st_time_last = heading_1st_time;
-  stat.summary(level, msg);
-}
-void heading_interpolate_1st_topic_checker(diagnostic_updater::DiagnosticStatusWrapper & stat)
-{
-  rclcpp::Time ros_clock(_heading_interpolate_1st.header.stamp);
-  auto heading_interpolate_1st_time = ros_clock.seconds();
-  
-  int8_t level = diagnostic_msgs::msg::DiagnosticStatus::OK;
-  std::string msg = "OK";
-
-  if (_heading_interpolate_1st_time_last == heading_interpolate_1st_time) {
-    level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-    msg = "not subscribed to topic";
-  }
-  else if (!std::isfinite(_heading_interpolate_1st.heading_angle)) {
-    level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
-    msg = "invalid number";
-  }
-  else if (!_heading_interpolate_1st.status.enabled_status) {
-    level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-    msg = "estimates have not started yet";
-  }
-
-  _heading_interpolate_1st_time_last = heading_interpolate_1st_time;
-  stat.summary(level, msg);
-}
-void heading_2nd_topic_checker(diagnostic_updater::DiagnosticStatusWrapper & stat)
-{
-  rclcpp::Time ros_clock(_heading_2nd.header.stamp);
-  auto heading_2nd_time = ros_clock.seconds();
-
-  int8_t level = diagnostic_msgs::msg::DiagnosticStatus::OK;
-  std::string msg = "OK";
-
-  if (!std::isfinite(_heading_2nd.heading_angle)) {
-    level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
-    msg = "invalid number";
-  }
-  else if (_heading_2nd_time_last - heading_2nd_time > _th_gnss_deadrock_time) {
-    level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-    msg = "not subscribed or deadlock of more than 10 seconds";
-  }
-  else if (!_heading_2nd.status.enabled_status) {
-    level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-    msg = "estimates have not started yet";
-  }
-
-  _heading_2nd_time_last = heading_2nd_time;
-  stat.summary(level, msg);
-}
-void heading_interpolate_2nd_topic_checker(diagnostic_updater::DiagnosticStatusWrapper & stat)
-{
-  rclcpp::Time ros_clock(_heading_interpolate_2nd.header.stamp);
-  auto heading_interpolate_2nd_time = ros_clock.seconds();
-
-  int8_t level = diagnostic_msgs::msg::DiagnosticStatus::OK;
-  std::string msg = "OK";
-
-  if (_heading_interpolate_2nd_time_last == heading_interpolate_2nd_time) {
-    level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-    msg = "not subscribed to topic";
-  }
-  else if (!std::isfinite(_heading_interpolate_2nd.heading_angle)) {
-    level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
-    msg = "invalid number";
-  }
-  else if (!_heading_interpolate_2nd.status.enabled_status) {
-    level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-    msg = "estimates have not started yet";
-  }
-
-  _heading_interpolate_2nd_time_last = heading_interpolate_2nd_time;
-  stat.summary(level, msg);
-}
-void heading_3rd_topic_checker(diagnostic_updater::DiagnosticStatusWrapper & stat)
-{
-  rclcpp::Time ros_clock(_heading_3rd.header.stamp);
-  auto heading_3rd_time = ros_clock.seconds();
-
-  int8_t level = diagnostic_msgs::msg::DiagnosticStatus::OK;
-  std::string msg = "OK";
-
-  if (!std::isfinite(_heading_3rd.heading_angle)) {
-    level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
-    msg = "invalid number";
-  }
-  else if (_heading_3rd_time_last - heading_3rd_time > _th_gnss_deadrock_time) {
-    level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-    msg = "not subscribed or deadlock of more than 10 seconds";
-  }
-  else if (!_heading_3rd.status.enabled_status) {
-    level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-    msg = "estimates have not started yet";
-  }
-
-  _heading_3rd_time_last = heading_3rd_time;
-  stat.summary(level, msg);
-}
-void heading_interpolate_3rd_topic_checker(diagnostic_updater::DiagnosticStatusWrapper & stat)
-{
-  rclcpp::Time ros_clock(_heading_interpolate_3rd.header.stamp);
-  auto heading_interpolate_3rd_time = ros_clock.seconds();
-
-  int8_t level = diagnostic_msgs::msg::DiagnosticStatus::OK;
-  std::string msg = "OK";
-
-  if (_heading_interpolate_3rd_time_last == heading_interpolate_3rd_time) {
-    level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-    msg = "not subscribed to topic";
-  }
-  else if (!std::isfinite(_heading_interpolate_3rd.heading_angle)) {
-    level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
-    msg = "invalid number";
-  }
-  else if (!_heading_interpolate_3rd.status.enabled_status) {
-    level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-    msg = "estimates have not started yet";
-  }
-
-  _heading_interpolate_3rd_time_last = heading_interpolate_3rd_time;
-  stat.summary(level, msg);
-}
-void yaw_rate_offset_stop_topic_checker(diagnostic_updater::DiagnosticStatusWrapper & stat)
-{
-  rclcpp::Time ros_clock(_yaw_rate_offset_stop.header.stamp);
-  auto yaw_rate_offset_stop_time = ros_clock.seconds();
-
-  int8_t level = diagnostic_msgs::msg::DiagnosticStatus::OK;
-  std::string msg = "OK";
-
-  if (_yaw_rate_offset_stop_time_last == yaw_rate_offset_stop_time) {
-    level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-    msg = "not subscribed to topic";
-  }
-  else if (!_yaw_rate_offset_stop.status.enabled_status) {
-    level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-    msg = "estimates have not started yet";
-  }
-  else if (_yaw_rate_offset_stop.status.is_abnormal) {
-    level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
-    if(_yaw_rate_offset_stop.status.error_code == eagleye_msgs::msg::Status::NAN_OR_INFINITE)
-    {
-      msg = "estimate value is NaN or infinete";
-    }
-    else
-    {
-      msg = "abnormal error of yaw_rate_offset_stop";
-    }
-  }
-
-  _yaw_rate_offset_stop_time_last = yaw_rate_offset_stop_time;
-  stat.summary(level, msg);
-}
-void yaw_rate_offset_1st_topic_checker(diagnostic_updater::DiagnosticStatusWrapper & stat)
-{
-  rclcpp::Time ros_clock(_yaw_rate_offset_1st.header.stamp);
-  auto yaw_rate_offset_1st_time = ros_clock.seconds();
-
-  int8_t level = diagnostic_msgs::msg::DiagnosticStatus::OK;
-  std::string msg = "OK";
-
-  if (_yaw_rate_offset_1st_time_last == yaw_rate_offset_1st_time) {
-    level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-    msg = "not subscribed to topic";
-  }
-  else if (!_yaw_rate_offset_1st.status.enabled_status) {
-    level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-    msg = "estimates have not started yet";
-  }
-  else if (_yaw_rate_offset_1st.status.is_abnormal) {
-    level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
-    if(_yaw_rate_offset_1st.status.error_code == eagleye_msgs::msg::Status::NAN_OR_INFINITE)
-    {
-      msg = "estimate value is NaN or infinete";
-    }
-    else
-    {
-      msg = "abnormal error of yaw_rate_offset_1st";
-    }
-  }
-
-  _yaw_rate_offset_1st_time_last = yaw_rate_offset_1st_time;
-  stat.summary(level, msg);
-}
-void yaw_rate_offset_2nd_topic_checker(diagnostic_updater::DiagnosticStatusWrapper & stat)
-{
-  rclcpp::Time ros_clock(_yaw_rate_offset_2nd.header.stamp);
-  auto yaw_rate_offset_2nd_time = ros_clock.seconds();
-
-  int8_t level = diagnostic_msgs::msg::DiagnosticStatus::OK;
-  std::string msg = "OK";
-
-  if (_yaw_rate_offset_2nd_time_last == yaw_rate_offset_2nd_time) {
-    level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-    msg = "not subscribed to topic";
-  }
-  else if (!_yaw_rate_offset_2nd.status.enabled_status) {
-    level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-    msg = "estimates have not started yet";
-  }
-  else if (_yaw_rate_offset_2nd.status.is_abnormal) {
-    level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
-    if(_yaw_rate_offset_2nd.status.error_code == eagleye_msgs::msg::Status::NAN_OR_INFINITE)
-    {
-      msg = "estimate value is NaN or infinete";
-    }
-    else
-    {
-      msg = "abnormal error of yaw_rate_offset_2nd";
-    }
-  }
-
-  _yaw_rate_offset_2nd_time_last = yaw_rate_offset_2nd_time;
-  stat.summary(level, msg);
-}
-void slip_angle_topic_checker(diagnostic_updater::DiagnosticStatusWrapper & stat)
-{
-  rclcpp::Time ros_clock(_slip_angle.header.stamp);
-  auto slip_angle_time = ros_clock.seconds();
-
-  int8_t level = diagnostic_msgs::msg::DiagnosticStatus::OK;
-  std::string msg = "OK";
-
-  if (_slip_angle_time_last == slip_angle_time) {
-    level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-    msg = "not subscribed to topic";
-  }
-  else if (!std::isfinite(_slip_angle.slip_angle)) {
-    level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
-    msg = "invalid number";
-  }
-  else if (_slip_angle.coefficient == 0) {
-    level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-    msg = "/slip_angle/manual_coefficient is not set";
-  }
-  else if (!_slip_angle.status.enabled_status) {
-    level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-    msg = "estimates have not started yet";
-  }
-
-  _slip_angle_time_last = slip_angle_time;
-  stat.summary(level, msg);
-}
-void enu_vel_topic_checker(diagnostic_updater::DiagnosticStatusWrapper & stat)
-{
-  rclcpp::Time ros_clock(_enu_vel.header.stamp);
-  auto enu_vel_time = ros_clock.seconds();
-
-  int8_t level = diagnostic_msgs::msg::DiagnosticStatus::OK;
-  std::string msg = "OK";
-
- if (!std::isfinite(_enu_vel.vector.x)||!std::isfinite(_enu_vel.vector.y)||!std::isfinite(_enu_vel.vector.z)) {
-    level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
-    msg = "invalid number";
-  }
-  else  if (_enu_vel_time_last == enu_vel_time) {
-    level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-    msg = "not subscribed to topic";
-  }
-
-  _enu_vel_time_last = enu_vel_time;
-  stat.summary(level, msg);
-}
-void height_topic_checker(diagnostic_updater::DiagnosticStatusWrapper & stat)
-{
-  rclcpp::Time ros_clock(_height.header.stamp);
-  auto height_time = ros_clock.seconds();
-
-  int8_t level = diagnostic_msgs::msg::DiagnosticStatus::OK;
-  std::string msg = "OK";
-
-  if (_height_time_last == height_time) {
-    level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-    msg = "not subscribed to topic";
-  }
-  else if (!std::isfinite(_height.height)) {
-    level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
-    msg = "invalid number";
-  }
-  else if (!_height.status.enabled_status) {
-    level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-    msg = "estimates have not started yet";
-  }
-
-  _height_time_last = height_time;
-  stat.summary(level, msg);
-}
-void pitching_topic_checker(diagnostic_updater::DiagnosticStatusWrapper & stat)
-{
-  rclcpp::Time ros_clock(_pitching.header.stamp);
-  auto pitching_time = ros_clock.seconds();
-
-  int8_t level = diagnostic_msgs::msg::DiagnosticStatus::OK;
-  std::string msg = "OK";
-
-  if (_pitching_time_last == pitching_time) {
-    level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-    msg = "not subscribed to topic";
-  }
-  else if (!std::isfinite(_pitching.pitching_angle)) {
-    level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
-    msg = "invalid number";
-  }
-  else if (!_pitching.status.enabled_status) {
-    level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-    msg = "estimates have not started yet";
-  }
-
-  _pitching_time_last = pitching_time;
-  stat.summary(level, msg);
-}
-void enu_absolute_pos_topic_checker(diagnostic_updater::DiagnosticStatusWrapper & stat)
-{
-  rclcpp::Time ros_clock(_enu_absolute_pos.header.stamp);
-  auto enu_absolute_pos_time = ros_clock.seconds();
-
-  int8_t level = diagnostic_msgs::msg::DiagnosticStatus::OK;
-  std::string msg = "OK";
-
-  if (!std::isfinite(_enu_absolute_pos.enu_pos.x)||!std::isfinite(_enu_absolute_pos.enu_pos.y)||!std::isfinite(_enu_absolute_pos.enu_pos.z)) {
-    level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
-    msg = "invalid number";
-  }
-  else if (_enu_absolute_pos_time_last - enu_absolute_pos_time > _th_gnss_deadrock_time) {
-    level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-    msg = "not subscribed or deadlock of more than 10 seconds";
-  }
-  else if (!_enu_absolute_pos.status.enabled_status) {
-    level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-    msg = "estimates have not started yet";
-  }
-
-  _enu_absolute_pos_time_last = enu_absolute_pos_time;
-  stat.summary(level, msg);
-}
-void enu_absolute_pos_interpolate_topic_checker(diagnostic_updater::DiagnosticStatusWrapper & stat)
-{
-  rclcpp::Time ros_clock(_enu_absolute_pos_interpolate.header.stamp);
-  auto enu_absolute_pos_interpolate_time = ros_clock.seconds();
-
-  int8_t level = diagnostic_msgs::msg::DiagnosticStatus::OK;
-  std::string msg = "OK";
-
-  if (!std::isfinite(_enu_absolute_pos_interpolate.enu_pos.x)||!std::isfinite(_enu_absolute_pos_interpolate.enu_pos.y)||!std::isfinite(_enu_absolute_pos_interpolate.enu_pos.z)) {
-    level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
-    msg = "invalid number";
-  }
-  else if (_enu_absolute_pos_interpolate_time_last == enu_absolute_pos_interpolate_time) {
-    level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-    msg = "not subscribed or deadlock of more than 10 seconds";
-  }
-  else if (!_enu_absolute_pos_interpolate.status.enabled_status) {
-    level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-    msg = "estimates have not started yet";
-  }
-
-  _enu_absolute_pos_interpolate_time_last = enu_absolute_pos_interpolate_time;
-  stat.summary(level, msg);
-}
-void twist_topic_checker(diagnostic_updater::DiagnosticStatusWrapper & stat)
-{
-  rclcpp::Time ros_clock(_eagleye_twist.header.stamp);
-  auto eagleye_twist_time = ros_clock.seconds();
-
-  int8_t level = diagnostic_msgs::msg::DiagnosticStatus::OK;
-  std::string msg = "OK";
-
-  if (_eagleye_twist_time_last == eagleye_twist_time) {
-    level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
-    msg = "not subscribed or deadlock of more than 10 seconds";
-  }
-  else if (!std::isfinite(_eagleye_twist.twist.linear.x)||!std::isfinite(_eagleye_twist.twist.linear.y)||!std::isfinite(_eagleye_twist.twist.linear.z)
-      ||!std::isfinite(_eagleye_twist.twist.angular.x)||!std::isfinite(_eagleye_twist.twist.angular.y)||!std::isfinite(_eagleye_twist.twist.angular.z)) {
-    level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
-    msg = "invalid number";
-  }
-
-  _eagleye_twist_time_last = eagleye_twist_time;
-  stat.summary(level, msg);
-}
-
-void imu_comparison_checker(diagnostic_updater::DiagnosticStatusWrapper & stat)
-{
-  if(_comparison_velocity_ptr == nullptr)
+public:
+  MonitorNode() : Node("eagleye_monitor")
   {
-    return;
+    std::string subscribe_twist_topic_name = "vehicle/twist";
+    std::string subscribe_rtklib_nav_topic_name = "gnss/rtklib_nav";
+    std::string subscribe_gga_topic_name = "gnss/gga";
+    std::string comparison_twist_topic_name = "/calculated_twist";
+
+    this->declare_parameter("rtklib_nav_topic", subscribe_rtklib_nav_topic_name);
+    this->declare_parameter("gga_topic", subscribe_gga_topic_name);
+    this->declare_parameter("monitor.comparison_twist_topic", comparison_twist_topic_name);
+    this->declare_parameter("monitor.print_status", print_status_);
+    this->declare_parameter("monitor.log_output_status", log_output_status_);
+    this->declare_parameter("monitor.use_compare_yaw_rate", use_compare_yaw_rate_);
+    this->declare_parameter("monitor.th_diff_rad_per_sec", th_diff_rad_per_sec_);
+    this->declare_parameter(
+      "monitor.th_num_continuous_abnormal_yaw_rate", th_num_continuous_abnormal_yaw_rate_);
+
+    this->get_parameter("rtklib_nav_topic", subscribe_rtklib_nav_topic_name);
+    this->get_parameter("gga_topic", subscribe_gga_topic_name);
+    this->get_parameter("monitor.comparison_twist_topic", comparison_twist_topic_name);
+    this->get_parameter("monitor.print_status", print_status_);
+    this->get_parameter("monitor.log_output_status", log_output_status_);
+    this->get_parameter("monitor.use_compare_yaw_rate", use_compare_yaw_rate_);
+    this->get_parameter("monitor.th_diff_rad_per_sec", th_diff_rad_per_sec_);
+    this->get_parameter(
+      "monitor.th_num_continuous_abnormal_yaw_rate", th_num_continuous_abnormal_yaw_rate_);
+
+    std::cout << "subscribe_rtklib_nav_topic_name " << subscribe_rtklib_nav_topic_name
+              << std::endl;
+    std::cout << "subscribe_gga_topic_name " << subscribe_gga_topic_name << std::endl;
+    std::cout << "print_status " << print_status_ << std::endl;
+    std::cout << "log_output_status " << log_output_status_ << std::endl;
+    std::cout << "use_compare_yaw_rate " << use_compare_yaw_rate_ << std::endl;
+    if (use_compare_yaw_rate_) {
+      std::cout << "comparison_twist_topic_name " << comparison_twist_topic_name << std::endl;
+      std::cout << "th_diff_rad_per_sec " << th_diff_rad_per_sec_ << std::endl;
+      std::cout << "th_num_continuous_abnormal_yaw_rate "
+                << th_num_continuous_abnormal_yaw_rate_ << std::endl;
+    }
+
+    double update_time = 1.0 / update_rate_;
+    updater_ = std::make_shared<diagnostic_updater::Updater>(this, update_time);
+
+    updater_->setHardwareID("eagleye_topic_checker");
+    updater_->add(
+      "eagleye_input_imu",
+      std::bind(&MonitorNode::imuTopicChecker, this, std::placeholders::_1));
+    updater_->add(
+      "eagleye_input_rtklib_nav",
+      std::bind(&MonitorNode::rtklibNavTopicChecker, this, std::placeholders::_1));
+    updater_->add(
+      "eagleye_input_navsat_gga",
+      std::bind(&MonitorNode::navsatGgaTopicChecker, this, std::placeholders::_1));
+    updater_->add(
+      "eagleye_input_velocity",
+      std::bind(&MonitorNode::velocityTopicChecker, this, std::placeholders::_1));
+    updater_->add(
+      "eagleye_velocity_scale_factor",
+      std::bind(&MonitorNode::velocityScaleFactorTopicChecker, this, std::placeholders::_1));
+    updater_->add(
+      "eagleye_distance",
+      std::bind(&MonitorNode::distanceTopicChecker, this, std::placeholders::_1));
+    updater_->add(
+      "eagleye_heading_1st",
+      std::bind(&MonitorNode::heading1stTopicChecker, this, std::placeholders::_1));
+    updater_->add(
+      "eagleye_heading_interpolate_1st",
+      std::bind(
+        &MonitorNode::headingInterpolate1stTopicChecker, this, std::placeholders::_1));
+    updater_->add(
+      "eagleye_heading_2nd",
+      std::bind(&MonitorNode::heading2ndTopicChecker, this, std::placeholders::_1));
+    updater_->add(
+      "eagleye_heading_interpolate_2nd",
+      std::bind(
+        &MonitorNode::headingInterpolate2ndTopicChecker, this, std::placeholders::_1));
+    updater_->add(
+      "eagleye_heading_3rd",
+      std::bind(&MonitorNode::heading3rdTopicChecker, this, std::placeholders::_1));
+    updater_->add(
+      "eagleye_heading_interpolate_3rd",
+      std::bind(
+        &MonitorNode::headingInterpolate3rdTopicChecker, this, std::placeholders::_1));
+    updater_->add(
+      "eagleye_yaw_rate_offset_stop",
+      std::bind(&MonitorNode::yawRateOffsetStopTopicChecker, this, std::placeholders::_1));
+    updater_->add(
+      "eagleye_yaw_rate_offset_1st",
+      std::bind(&MonitorNode::yawRateOffset1stTopicChecker, this, std::placeholders::_1));
+    updater_->add(
+      "eagleye_yaw_rate_offset_2nd",
+      std::bind(&MonitorNode::yawRateOffset2ndTopicChecker, this, std::placeholders::_1));
+    updater_->add(
+      "eagleye_slip_angle",
+      std::bind(&MonitorNode::slipAngleTopicChecker, this, std::placeholders::_1));
+    updater_->add(
+      "eagleye_enu_vel",
+      std::bind(&MonitorNode::enuVelTopicChecker, this, std::placeholders::_1));
+    updater_->add(
+      "eagleye_height",
+      std::bind(&MonitorNode::heightTopicChecker, this, std::placeholders::_1));
+    updater_->add(
+      "eagleye_pitching",
+      std::bind(&MonitorNode::pitchingTopicChecker, this, std::placeholders::_1));
+    updater_->add(
+      "eagleye_enu_absolute_pos",
+      std::bind(&MonitorNode::enuAbsolutePosTopicChecker, this, std::placeholders::_1));
+    updater_->add(
+      "eagleye_enu_absolute_pos_interpolate",
+      std::bind(
+        &MonitorNode::enuAbsolutePosInterpolateTopicChecker, this, std::placeholders::_1));
+    updater_->add(
+      "eagleye_twist",
+      std::bind(&MonitorNode::twistTopicChecker, this, std::placeholders::_1));
+    if (use_compare_yaw_rate_) {
+      updater_->add(
+        "eagleye_imu_comparison",
+        std::bind(&MonitorNode::imuComparisonChecker, this, std::placeholders::_1));
+    }
+
+    time_t time_;
+    time_ = time(NULL);
+    std::stringstream time_ss;
+    time_ss << time_;
+    std::string time_str = time_ss.str();
+    output_log_dir_ = ament_index_cpp::get_package_share_directory("eagleye_rt") +
+                      "/log/eagleye_log_" + time_str + ".csv";
+    if (log_output_status_) std::cout << output_log_dir_ << std::endl;
+
+    sub_imu_ = this->create_subscription<sensor_msgs::msg::Imu>(
+      "imu/data_tf_converted", 1000,
+      std::bind(&MonitorNode::imuCallback, this, std::placeholders::_1));
+    sub_rtklib_nav_ = this->create_subscription<rtklib_msgs::msg::RtklibNav>(
+      subscribe_rtklib_nav_topic_name, 1000,
+      std::bind(&MonitorNode::rtklibNavCallback, this, std::placeholders::_1));
+    sub_rtklib_fix_ = this->create_subscription<sensor_msgs::msg::NavSatFix>(
+      "rtklib/fix", rclcpp::QoS(10),
+      std::bind(&MonitorNode::rtklibFixCallback, this, std::placeholders::_1));
+    sub_gga_ = this->create_subscription<nmea_msgs::msg::Gpgga>(
+      subscribe_gga_topic_name, 1000,
+      std::bind(&MonitorNode::navsatfixGgaCallback, this, std::placeholders::_1));
+    sub_velocity_ = this->create_subscription<geometry_msgs::msg::TwistStamped>(
+      subscribe_twist_topic_name, 1000,
+      std::bind(&MonitorNode::velocityCallback, this, std::placeholders::_1));
+    sub_velocity_scale_factor_ =
+      this->create_subscription<eagleye_msgs::msg::VelocityScaleFactor>(
+        "velocity_scale_factor", rclcpp::QoS(10),
+        std::bind(&MonitorNode::velocityScaleFactorCallback, this, std::placeholders::_1));
+    sub_distance_ = this->create_subscription<eagleye_msgs::msg::Distance>(
+      "distance", rclcpp::QoS(10),
+      std::bind(&MonitorNode::distanceCallback, this, std::placeholders::_1));
+    sub_heading_1st_ = this->create_subscription<eagleye_msgs::msg::Heading>(
+      "heading_1st", rclcpp::QoS(10),
+      std::bind(&MonitorNode::heading1stCallback, this, std::placeholders::_1));
+    sub_heading_interpolate_1st_ = this->create_subscription<eagleye_msgs::msg::Heading>(
+      "heading_interpolate_1st", rclcpp::QoS(10),
+      std::bind(&MonitorNode::headingInterpolate1stCallback, this, std::placeholders::_1));
+    sub_heading_2nd_ = this->create_subscription<eagleye_msgs::msg::Heading>(
+      "heading_2nd", rclcpp::QoS(10),
+      std::bind(&MonitorNode::heading2ndCallback, this, std::placeholders::_1));
+    sub_heading_interpolate_2nd_ = this->create_subscription<eagleye_msgs::msg::Heading>(
+      "heading_interpolate_2nd", rclcpp::QoS(10),
+      std::bind(&MonitorNode::headingInterpolate2ndCallback, this, std::placeholders::_1));
+    sub_heading_3rd_ = this->create_subscription<eagleye_msgs::msg::Heading>(
+      "heading_3rd", rclcpp::QoS(10),
+      std::bind(&MonitorNode::heading3rdCallback, this, std::placeholders::_1));
+    sub_heading_interpolate_3rd_ = this->create_subscription<eagleye_msgs::msg::Heading>(
+      "heading_interpolate_3rd", rclcpp::QoS(10),
+      std::bind(&MonitorNode::headingInterpolate3rdCallback, this, std::placeholders::_1));
+    sub_yaw_rate_offset_stop_ = this->create_subscription<eagleye_msgs::msg::YawrateOffset>(
+      "yaw_rate_offset_stop", rclcpp::QoS(10),
+      std::bind(&MonitorNode::yawRateOffsetStopCallback, this, std::placeholders::_1));
+    sub_yaw_rate_offset_1st_ = this->create_subscription<eagleye_msgs::msg::YawrateOffset>(
+      "yaw_rate_offset_1st", rclcpp::QoS(10),
+      std::bind(&MonitorNode::yawRateOffset1stCallback, this, std::placeholders::_1));
+    sub_yaw_rate_offset_2nd_ = this->create_subscription<eagleye_msgs::msg::YawrateOffset>(
+      "yaw_rate_offset_2nd", rclcpp::QoS(10),
+      std::bind(&MonitorNode::yawRateOffset2ndCallback, this, std::placeholders::_1));
+    sub_slip_angle_ = this->create_subscription<eagleye_msgs::msg::SlipAngle>(
+      "slip_angle", rclcpp::QoS(10),
+      std::bind(&MonitorNode::slipAngleCallback, this, std::placeholders::_1));
+    sub_enu_relative_pos_ = this->create_subscription<eagleye_msgs::msg::Position>(
+      "enu_relative_pos", rclcpp::QoS(10),
+      std::bind(&MonitorNode::enuRelativePosCallback, this, std::placeholders::_1));
+    sub_enu_vel_ = this->create_subscription<geometry_msgs::msg::Vector3Stamped>(
+      "enu_vel", rclcpp::QoS(10),
+      std::bind(&MonitorNode::enuVelCallback, this, std::placeholders::_1));
+    sub_height_ = this->create_subscription<eagleye_msgs::msg::Height>(
+      "height", rclcpp::QoS(10),
+      std::bind(&MonitorNode::heightCallback, this, std::placeholders::_1));
+    sub_pitching_ = this->create_subscription<eagleye_msgs::msg::Pitching>(
+      "pitching", rclcpp::QoS(10),
+      std::bind(&MonitorNode::pitchingCallback, this, std::placeholders::_1));
+    sub_enu_absolute_pos_ = this->create_subscription<eagleye_msgs::msg::Position>(
+      "enu_absolute_pos", rclcpp::QoS(10),
+      std::bind(&MonitorNode::enuAbsolutePosCallback, this, std::placeholders::_1));
+    sub_enu_absolute_pos_interpolate_ = this->create_subscription<eagleye_msgs::msg::Position>(
+      "enu_absolute_pos_interpolate", rclcpp::QoS(10),
+      std::bind(
+        &MonitorNode::enuAbsolutePosInterpolateCallback, this, std::placeholders::_1));
+    sub_eagleye_fix_ = this->create_subscription<sensor_msgs::msg::NavSatFix>(
+      "fix", rclcpp::QoS(10),
+      std::bind(&MonitorNode::eagleyeFixCallback, this, std::placeholders::_1));
+    sub_eagleye_twist_ = this->create_subscription<geometry_msgs::msg::TwistStamped>(
+      "twist", rclcpp::QoS(10),
+      std::bind(&MonitorNode::eagleyeTwistCallback, this, std::placeholders::_1));
+    sub_rolling_ = this->create_subscription<eagleye_msgs::msg::Rolling>(
+      "rolling", rclcpp::QoS(10),
+      std::bind(&MonitorNode::rollingCallback, this, std::placeholders::_1));
+    sub_comparison_velocity_ = this->create_subscription<geometry_msgs::msg::TwistStamped>(
+      comparison_twist_topic_name, 1000,
+      std::bind(&MonitorNode::comparisonVelocityCallback, this, std::placeholders::_1));
+    sub_correction_velocity_ = this->create_subscription<geometry_msgs::msg::TwistStamped>(
+      "velocity", 1000,
+      std::bind(&MonitorNode::correctionVelocityCallback, this, std::placeholders::_1));
   }
 
-  int8_t level = diagnostic_msgs::msg::DiagnosticStatus::OK;
-  std::string msg = "OK";
+private:
+  sensor_msgs::msg::Imu imu_;
+  rtklib_msgs::msg::RtklibNav rtklib_nav_;
+  sensor_msgs::msg::NavSatFix rtklib_fix_;
+  nmea_msgs::msg::Gpgga gga_;
+  geometry_msgs::msg::TwistStamped velocity_;
+  geometry_msgs::msg::TwistStamped correction_velocity_;
+  eagleye_msgs::msg::VelocityScaleFactor velocity_scale_factor_;
+  eagleye_msgs::msg::Distance distance_;
+  eagleye_msgs::msg::Heading heading_1st_;
+  eagleye_msgs::msg::Heading heading_interpolate_1st_;
+  eagleye_msgs::msg::Heading heading_2nd_;
+  eagleye_msgs::msg::Heading heading_interpolate_2nd_;
+  eagleye_msgs::msg::Heading heading_3rd_;
+  eagleye_msgs::msg::Heading heading_interpolate_3rd_;
+  eagleye_msgs::msg::YawrateOffset yaw_rate_offset_stop_;
+  eagleye_msgs::msg::YawrateOffset yaw_rate_offset_1st_;
+  eagleye_msgs::msg::YawrateOffset yaw_rate_offset_2nd_;
+  eagleye_msgs::msg::SlipAngle slip_angle_;
+  eagleye_msgs::msg::Height height_;
+  eagleye_msgs::msg::Pitching pitching_;
+  eagleye_msgs::msg::Rolling rolling_;
+  eagleye_msgs::msg::Position enu_relative_pos_;
+  geometry_msgs::msg::Vector3Stamped enu_vel_;
+  eagleye_msgs::msg::Position enu_absolute_pos_;
+  eagleye_msgs::msg::Position enu_absolute_pos_interpolate_;
+  sensor_msgs::msg::NavSatFix eagleye_fix_;
+  geometry_msgs::msg::TwistStamped eagleye_twist_;
 
-  if(_use_compare_yaw_rate && _th_diff_rad_per_sec <
-    std::abs(_corrected_imu.angular_velocity.z - _comparison_velocity_ptr->twist.angular.z))
+  geometry_msgs::msg::TwistStamped::ConstSharedPtr comparison_velocity_ptr_;
+  sensor_msgs::msg::Imu corrected_imu_;
+
+  bool gga_sub_status_ = false;
+  bool print_status_ = false;
+  bool log_output_status_ = false;
+  bool log_header_make_ = false;
+  std::string output_log_dir_;
+
+  double imu_time_last_ = 0;
+  double rtklib_nav_time_last_ = 0;
+  double navsat_gga_time_last_ = 0;
+  double velocity_time_last_ = 0;
+  double velocity_scale_factor_time_last_ = 0;
+  double distance_time_last_ = 0;
+  double heading_1st_time_last_ = 0;
+  double heading_interpolate_1st_time_last_ = 0;
+  double heading_2nd_time_last_ = 0;
+  double heading_interpolate_2nd_time_last_ = 0;
+  double heading_3rd_time_last_ = 0;
+  double heading_interpolate_3rd_time_last_ = 0;
+  double yaw_rate_offset_stop_time_last_ = 0;
+  double yaw_rate_offset_1st_time_last_ = 0;
+  double yaw_rate_offset_2nd_time_last_ = 0;
+  double slip_angle_time_last_ = 0;
+  double height_time_last_ = 0;
+  double pitching_time_last_ = 0;
+  double enu_vel_time_last_ = 0;
+  double enu_absolute_pos_time_last_ = 0;
+  double enu_absolute_pos_interpolate_time_last_ = 0;
+  double eagleye_twist_time_last_ = 0;
+
+  bool use_compare_yaw_rate_ = false;
+  double update_rate_ = 10.0;
+  double th_gnss_deadrock_time_ = 10;
+  double th_diff_rad_per_sec_ = 0.17453;
+  int num_continuous_abnormal_yaw_rate_ = 0;
+  int th_num_continuous_abnormal_yaw_rate_ = 10;
+
+  std::shared_ptr<diagnostic_updater::Updater> updater_;
+
+  rclcpp::Subscription<sensor_msgs::msg::Imu>::SharedPtr sub_imu_;
+  rclcpp::Subscription<rtklib_msgs::msg::RtklibNav>::SharedPtr sub_rtklib_nav_;
+  rclcpp::Subscription<sensor_msgs::msg::NavSatFix>::SharedPtr sub_rtklib_fix_;
+  rclcpp::Subscription<nmea_msgs::msg::Gpgga>::SharedPtr sub_gga_;
+  rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr sub_velocity_;
+  rclcpp::Subscription<eagleye_msgs::msg::VelocityScaleFactor>::SharedPtr
+    sub_velocity_scale_factor_;
+  rclcpp::Subscription<eagleye_msgs::msg::Distance>::SharedPtr sub_distance_;
+  rclcpp::Subscription<eagleye_msgs::msg::Heading>::SharedPtr sub_heading_1st_;
+  rclcpp::Subscription<eagleye_msgs::msg::Heading>::SharedPtr sub_heading_interpolate_1st_;
+  rclcpp::Subscription<eagleye_msgs::msg::Heading>::SharedPtr sub_heading_2nd_;
+  rclcpp::Subscription<eagleye_msgs::msg::Heading>::SharedPtr sub_heading_interpolate_2nd_;
+  rclcpp::Subscription<eagleye_msgs::msg::Heading>::SharedPtr sub_heading_3rd_;
+  rclcpp::Subscription<eagleye_msgs::msg::Heading>::SharedPtr sub_heading_interpolate_3rd_;
+  rclcpp::Subscription<eagleye_msgs::msg::YawrateOffset>::SharedPtr sub_yaw_rate_offset_stop_;
+  rclcpp::Subscription<eagleye_msgs::msg::YawrateOffset>::SharedPtr sub_yaw_rate_offset_1st_;
+  rclcpp::Subscription<eagleye_msgs::msg::YawrateOffset>::SharedPtr sub_yaw_rate_offset_2nd_;
+  rclcpp::Subscription<eagleye_msgs::msg::SlipAngle>::SharedPtr sub_slip_angle_;
+  rclcpp::Subscription<eagleye_msgs::msg::Position>::SharedPtr sub_enu_relative_pos_;
+  rclcpp::Subscription<geometry_msgs::msg::Vector3Stamped>::SharedPtr sub_enu_vel_;
+  rclcpp::Subscription<eagleye_msgs::msg::Height>::SharedPtr sub_height_;
+  rclcpp::Subscription<eagleye_msgs::msg::Pitching>::SharedPtr sub_pitching_;
+  rclcpp::Subscription<eagleye_msgs::msg::Position>::SharedPtr sub_enu_absolute_pos_;
+  rclcpp::Subscription<eagleye_msgs::msg::Position>::SharedPtr
+    sub_enu_absolute_pos_interpolate_;
+  rclcpp::Subscription<sensor_msgs::msg::NavSatFix>::SharedPtr sub_eagleye_fix_;
+  rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr sub_eagleye_twist_;
+  rclcpp::Subscription<eagleye_msgs::msg::Rolling>::SharedPtr sub_rolling_;
+  rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr sub_comparison_velocity_;
+  rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr sub_correction_velocity_;
+
+  void rtklibNavCallback(const rtklib_msgs::msg::RtklibNav::ConstSharedPtr msg)
   {
-    _num_continuous_abnormal_yaw_rate++;
+    rtklib_nav_ = *msg;
   }
-  else
+
+  void rtklibFixCallback(const sensor_msgs::msg::NavSatFix::ConstSharedPtr msg)
   {
-    _num_continuous_abnormal_yaw_rate = 0;
+    rtklib_fix_ = *msg;
   }
 
-  if (_num_continuous_abnormal_yaw_rate > _th_num_continuous_abnormal_yaw_rate) {
-    level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
-    msg = "IMU Yaw Rate too large or too small compared to reference twist";
-  }
-  stat.summary(level, msg);
-}
-
-void printStatus(void)
-{
-  std::cout << std::endl;
-  std::cout<<"\033[1;33m Eagleye status \033[m"<<std::endl;
-  std::cout << std::endl;
-  std::cout << std::fixed;
-
-  std::cout << "--- \033[1;34m imu(input)\033[m ------------------------------"<< std::endl;
-  std::cout<<"\033[1m linear_acceleration \033[mx "<<std::setprecision(6)<<_imu.linear_acceleration.x<<" [m/s^2]"<<std::endl;
-  std::cout<<"\033[1m linear acceleration \033[my "<<std::setprecision(6)<<_imu.linear_acceleration.y<<" [m/s^2]"<<std::endl;
-  std::cout<<"\033[1m linear acceleration \033[mz "<<std::setprecision(6)<<_imu.linear_acceleration.z<<" [m/s^2]"<<std::endl;
-  std::cout<<"\033[1m angular velocity \033[mx "<<std::setprecision(6)<<_imu.angular_velocity.x<<" [rad/s]"<<std::endl;
-  std::cout<<"\033[1m angular velocity \033[my "<<std::setprecision(6)<<_imu.angular_velocity.y<<" [rad/s]"<<std::endl;
-  std::cout<<"\033[1m angular velocity \033[mz "<<std::setprecision(6)<<_imu.angular_velocity.z<<" [rad/s]"<<std::endl;
-  std::cout << std::endl;
-
-  std::cout << "--- \033[1;34m velocity(input)\033[m -------------------------"<< std::endl;
-  std::cout<<"\033[1m velocity \033[m"<<std::setprecision(4)<<_velocity.twist.linear.x * 3.6<<" [km/h]"<<std::endl;
-  std::cout << std::endl;
-
-  std::cout << "--- \033[1;34m rtklib(input)\033[m ---------------------------"<< std::endl;
-  std::cout<<"\033[1m time of week  \033[m"<<_rtklib_nav.tow<<" [ms]"<<std::endl;
-  std::cout<<"\033[1m latitude  \033[m"<<std::setprecision(8)<<_rtklib_nav.status.latitude<<" [deg]"<<std::endl;
-  std::cout<<"\033[1m longitude  \033[m"<<std::setprecision(8)<<_rtklib_nav.status.longitude<<" [deg]"<<std::endl;
-  std::cout<<"\033[1m altitude  \033[m"<<std::setprecision(4)<<_rtklib_nav.status.altitude<<" [m]"<<std::endl;
-  std::cout << std::endl;
-
-  std::cout << "--- \033[1;34m gga(input)\033[m ------------------------------"<< std::endl;
-
-  if (_gga_sub_status)
+  void navsatfixGgaCallback(const nmea_msgs::msg::Gpgga::ConstSharedPtr msg)
   {
-    std::cout<< "\033[1m rtk status \033[m "<<int(_gga.gps_qual)<<std::endl;
-    std::cout<< "\033[1m rtk status \033[m "<<(int(_gga.gps_qual)!=4 ? "\033[1;31mNo Fix\033[m" : "\033[1;32mFix\033[m")<<std::endl;
-    std::cout<<"\033[1m latitude  \033[m"<<std::setprecision(8)<<_gga.lat<<" [deg]"<<std::endl;
-    std::cout<<"\033[1m longitude  \033[m"<<std::setprecision(8)<<_gga.lon<<" [deg]"<<std::endl;
-    std::cout<<"\033[1m altitude  \033[m"<<std::setprecision(4)<<_gga.alt + _gga.undulation<<" [m]"<<std::endl;
+    gga_ = *msg;
+    gga_sub_status_ = true;
+  }
+
+  void velocityCallback(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg)
+  {
+    velocity_ = *msg;
+  }
+
+  void correctionVelocityCallback(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg)
+  {
+    correction_velocity_ = *msg;
+  }
+
+  void velocityScaleFactorCallback(
+    const eagleye_msgs::msg::VelocityScaleFactor::ConstSharedPtr msg)
+  {
+    velocity_scale_factor_ = *msg;
+  }
+
+  void distanceCallback(const eagleye_msgs::msg::Distance::ConstSharedPtr msg)
+  {
+    distance_ = *msg;
+  }
+
+  void heading1stCallback(const eagleye_msgs::msg::Heading::ConstSharedPtr msg)
+  {
+    heading_1st_ = *msg;
+  }
+
+  void headingInterpolate1stCallback(const eagleye_msgs::msg::Heading::ConstSharedPtr msg)
+  {
+    heading_interpolate_1st_ = *msg;
+  }
+
+  void heading2ndCallback(const eagleye_msgs::msg::Heading::ConstSharedPtr msg)
+  {
+    heading_2nd_ = *msg;
+  }
+
+  void headingInterpolate2ndCallback(const eagleye_msgs::msg::Heading::ConstSharedPtr msg)
+  {
+    heading_interpolate_2nd_ = *msg;
+  }
+
+  void heading3rdCallback(const eagleye_msgs::msg::Heading::ConstSharedPtr msg)
+  {
+    heading_3rd_ = *msg;
+  }
+
+  void headingInterpolate3rdCallback(const eagleye_msgs::msg::Heading::ConstSharedPtr msg)
+  {
+    heading_interpolate_3rd_ = *msg;
+  }
+
+  void yawRateOffsetStopCallback(const eagleye_msgs::msg::YawrateOffset::ConstSharedPtr msg)
+  {
+    yaw_rate_offset_stop_ = *msg;
+  }
+
+  void yawRateOffset1stCallback(const eagleye_msgs::msg::YawrateOffset::ConstSharedPtr msg)
+  {
+    yaw_rate_offset_1st_ = *msg;
+  }
+
+  void yawRateOffset2ndCallback(const eagleye_msgs::msg::YawrateOffset::ConstSharedPtr msg)
+  {
+    yaw_rate_offset_2nd_ = *msg;
+  }
+
+  void slipAngleCallback(const eagleye_msgs::msg::SlipAngle::ConstSharedPtr msg)
+  {
+    slip_angle_ = *msg;
+  }
+
+  void enuRelativePosCallback(const eagleye_msgs::msg::Position::ConstSharedPtr msg)
+  {
+    enu_relative_pos_ = *msg;
+  }
+
+  void enuVelCallback(const geometry_msgs::msg::Vector3Stamped::ConstSharedPtr msg)
+  {
+    enu_vel_ = *msg;
+  }
+
+  void enuAbsolutePosCallback(const eagleye_msgs::msg::Position::ConstSharedPtr msg)
+  {
+    enu_absolute_pos_ = *msg;
+  }
+
+  void heightCallback(const eagleye_msgs::msg::Height::ConstSharedPtr msg)
+  {
+    height_ = *msg;
+  }
+
+  void pitchingCallback(const eagleye_msgs::msg::Pitching::ConstSharedPtr msg)
+  {
+    pitching_ = *msg;
+  }
+
+  void rollingCallback(const eagleye_msgs::msg::Rolling::ConstSharedPtr msg)
+  {
+    rolling_ = *msg;
+  }
+
+  void enuAbsolutePosInterpolateCallback(
+    const eagleye_msgs::msg::Position::ConstSharedPtr msg)
+  {
+    enu_absolute_pos_interpolate_ = *msg;
+  }
+
+  void eagleyeFixCallback(const sensor_msgs::msg::NavSatFix::ConstSharedPtr msg)
+  {
+    eagleye_fix_ = *msg;
+  }
+
+  void eagleyeTwistCallback(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg)
+  {
+    eagleye_twist_ = *msg;
+  }
+
+  void comparisonVelocityCallback(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg)
+  {
+    comparison_velocity_ptr_ = msg;
+  }
+
+  void imuTopicChecker(diagnostic_updater::DiagnosticStatusWrapper& stat)
+  {
+    rclcpp::Time ros_clock(imu_.header.stamp);
+    auto imu_time = ros_clock.seconds();
+
+    int8_t level = diagnostic_msgs::msg::DiagnosticStatus::OK;
+    std::string msg = "OK";
+
+    if (imu_time_last_ == imu_time) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::STALE;
+      msg = "not subscribed to topic";
+    }
+
+    imu_time_last_ = imu_time;
+    stat.summary(level, msg);
+  }
+
+  void rtklibNavTopicChecker(diagnostic_updater::DiagnosticStatusWrapper& stat)
+  {
+    rclcpp::Time ros_clock(rtklib_nav_.header.stamp);
+    auto rtklib_nav_time = ros_clock.seconds();
+
+    int8_t level = diagnostic_msgs::msg::DiagnosticStatus::OK;
+    std::string msg = "OK";
+
+    if (rtklib_nav_time_last_ - rtklib_nav_time > th_gnss_deadrock_time_) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+      msg = "not subscribed or deadlock of more than 10 seconds";
+    }
+
+    rtklib_nav_time_last_ = rtklib_nav_time;
+    stat.summary(level, msg);
+  }
+
+  void navsatGgaTopicChecker(diagnostic_updater::DiagnosticStatusWrapper& stat)
+  {
+    rclcpp::Time ros_clock(gga_.header.stamp);
+    auto navsat_gga_time = ros_clock.seconds();
+
+    int8_t level = diagnostic_msgs::msg::DiagnosticStatus::OK;
+    std::string msg = "OK";
+
+    if (
+      navsat_gga_time_last_ - navsat_gga_time > th_gnss_deadrock_time_ || !gga_sub_status_) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+      msg = "not subscribed to topic";
+    }
+
+    navsat_gga_time_last_ = navsat_gga_time;
+    stat.summary(level, msg);
+  }
+
+  void velocityTopicChecker(diagnostic_updater::DiagnosticStatusWrapper& stat)
+  {
+    rclcpp::Time ros_clock(velocity_.header.stamp);
+    auto velocity_time = ros_clock.seconds();
+
+    int8_t level = diagnostic_msgs::msg::DiagnosticStatus::OK;
+    std::string msg = "OK";
+
+    if (velocity_time_last_ == velocity_time) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::STALE;
+      msg = "not subscribed to topic";
+    }
+
+    velocity_time_last_ = velocity_time;
+    stat.summary(level, msg);
+  }
+
+  void velocityScaleFactorTopicChecker(diagnostic_updater::DiagnosticStatusWrapper& stat)
+  {
+    rclcpp::Time ros_clock(velocity_scale_factor_.header.stamp);
+    auto velocity_scale_factor_time = ros_clock.seconds();
+
+    int8_t level = diagnostic_msgs::msg::DiagnosticStatus::OK;
+    std::string msg = "OK";
+
+    if (velocity_scale_factor_time_last_ == velocity_scale_factor_time) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+      msg = "not subscribed to topic";
+    } else if (!velocity_scale_factor_.status.enabled_status) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+      msg = "estimates have not started yet";
+    } else if (velocity_scale_factor_.status.is_abnormal) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
+      if (
+        velocity_scale_factor_.status.error_code ==
+        eagleye_msgs::msg::Status::NAN_OR_INFINITE) {
+        msg = "Estimated velocity scale factor is NaN or infinete";
+      } else if (
+        velocity_scale_factor_.status.error_code ==
+        eagleye_msgs::msg::Status::TOO_LARGE_OR_SMALL) {
+        msg = "Estimated velocity scale factor is too large or too small";
+      } else {
+        msg = "abnormal error of velocity_scale_factor";
+      }
+    }
+
+    velocity_scale_factor_time_last_ = velocity_scale_factor_time;
+    stat.summary(level, msg);
+  }
+
+  void distanceTopicChecker(diagnostic_updater::DiagnosticStatusWrapper& stat)
+  {
+    rclcpp::Time ros_clock(distance_.header.stamp);
+    auto distance_time = ros_clock.seconds();
+
+    int8_t level = diagnostic_msgs::msg::DiagnosticStatus::OK;
+    std::string msg = "OK";
+
+    if (distance_time_last_ == distance_time) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+      msg = "not subscribed to topic";
+    } else if (!std::isfinite(distance_.distance)) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
+      msg = "invalid number";
+    } else if (!distance_.status.enabled_status) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+      msg = "estimates have not started yet";
+    }
+
+    distance_time_last_ = distance_time;
+    stat.summary(level, msg);
+  }
+
+  void heading1stTopicChecker(diagnostic_updater::DiagnosticStatusWrapper& stat)
+  {
+    rclcpp::Time ros_clock(heading_1st_.header.stamp);
+    auto heading_1st_time = ros_clock.seconds();
+
+    int8_t level = diagnostic_msgs::msg::DiagnosticStatus::OK;
+    std::string msg = "OK";
+
+    if (!std::isfinite(heading_1st_.heading_angle)) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
+      msg = "invalid number";
+    } else if (heading_1st_time_last_ - heading_1st_time > th_gnss_deadrock_time_) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+      msg = "not subscribed or deadlock of more than 10 seconds";
+    } else if (!heading_1st_.status.enabled_status) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+      msg = "estimates have not started yet";
+    }
+
+    heading_1st_time_last_ = heading_1st_time;
+    stat.summary(level, msg);
+  }
+
+  void headingInterpolate1stTopicChecker(diagnostic_updater::DiagnosticStatusWrapper& stat)
+  {
+    rclcpp::Time ros_clock(heading_interpolate_1st_.header.stamp);
+    auto heading_interpolate_1st_time = ros_clock.seconds();
+
+    int8_t level = diagnostic_msgs::msg::DiagnosticStatus::OK;
+    std::string msg = "OK";
+
+    if (heading_interpolate_1st_time_last_ == heading_interpolate_1st_time) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+      msg = "not subscribed to topic";
+    } else if (!std::isfinite(heading_interpolate_1st_.heading_angle)) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
+      msg = "invalid number";
+    } else if (!heading_interpolate_1st_.status.enabled_status) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+      msg = "estimates have not started yet";
+    }
+
+    heading_interpolate_1st_time_last_ = heading_interpolate_1st_time;
+    stat.summary(level, msg);
+  }
+
+  void heading2ndTopicChecker(diagnostic_updater::DiagnosticStatusWrapper& stat)
+  {
+    rclcpp::Time ros_clock(heading_2nd_.header.stamp);
+    auto heading_2nd_time = ros_clock.seconds();
+
+    int8_t level = diagnostic_msgs::msg::DiagnosticStatus::OK;
+    std::string msg = "OK";
+
+    if (!std::isfinite(heading_2nd_.heading_angle)) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
+      msg = "invalid number";
+    } else if (heading_2nd_time_last_ - heading_2nd_time > th_gnss_deadrock_time_) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+      msg = "not subscribed or deadlock of more than 10 seconds";
+    } else if (!heading_2nd_.status.enabled_status) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+      msg = "estimates have not started yet";
+    }
+
+    heading_2nd_time_last_ = heading_2nd_time;
+    stat.summary(level, msg);
+  }
+
+  void headingInterpolate2ndTopicChecker(diagnostic_updater::DiagnosticStatusWrapper& stat)
+  {
+    rclcpp::Time ros_clock(heading_interpolate_2nd_.header.stamp);
+    auto heading_interpolate_2nd_time = ros_clock.seconds();
+
+    int8_t level = diagnostic_msgs::msg::DiagnosticStatus::OK;
+    std::string msg = "OK";
+
+    if (heading_interpolate_2nd_time_last_ == heading_interpolate_2nd_time) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+      msg = "not subscribed to topic";
+    } else if (!std::isfinite(heading_interpolate_2nd_.heading_angle)) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
+      msg = "invalid number";
+    } else if (!heading_interpolate_2nd_.status.enabled_status) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+      msg = "estimates have not started yet";
+    }
+
+    heading_interpolate_2nd_time_last_ = heading_interpolate_2nd_time;
+    stat.summary(level, msg);
+  }
+
+  void heading3rdTopicChecker(diagnostic_updater::DiagnosticStatusWrapper& stat)
+  {
+    rclcpp::Time ros_clock(heading_3rd_.header.stamp);
+    auto heading_3rd_time = ros_clock.seconds();
+
+    int8_t level = diagnostic_msgs::msg::DiagnosticStatus::OK;
+    std::string msg = "OK";
+
+    if (!std::isfinite(heading_3rd_.heading_angle)) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
+      msg = "invalid number";
+    } else if (heading_3rd_time_last_ - heading_3rd_time > th_gnss_deadrock_time_) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+      msg = "not subscribed or deadlock of more than 10 seconds";
+    } else if (!heading_3rd_.status.enabled_status) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+      msg = "estimates have not started yet";
+    }
+
+    heading_3rd_time_last_ = heading_3rd_time;
+    stat.summary(level, msg);
+  }
+
+  void headingInterpolate3rdTopicChecker(diagnostic_updater::DiagnosticStatusWrapper& stat)
+  {
+    rclcpp::Time ros_clock(heading_interpolate_3rd_.header.stamp);
+    auto heading_interpolate_3rd_time = ros_clock.seconds();
+
+    int8_t level = diagnostic_msgs::msg::DiagnosticStatus::OK;
+    std::string msg = "OK";
+
+    if (heading_interpolate_3rd_time_last_ == heading_interpolate_3rd_time) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+      msg = "not subscribed to topic";
+    } else if (!std::isfinite(heading_interpolate_3rd_.heading_angle)) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
+      msg = "invalid number";
+    } else if (!heading_interpolate_3rd_.status.enabled_status) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+      msg = "estimates have not started yet";
+    }
+
+    heading_interpolate_3rd_time_last_ = heading_interpolate_3rd_time;
+    stat.summary(level, msg);
+  }
+
+  void yawRateOffsetStopTopicChecker(diagnostic_updater::DiagnosticStatusWrapper& stat)
+  {
+    rclcpp::Time ros_clock(yaw_rate_offset_stop_.header.stamp);
+    auto yaw_rate_offset_stop_time = ros_clock.seconds();
+
+    int8_t level = diagnostic_msgs::msg::DiagnosticStatus::OK;
+    std::string msg = "OK";
+
+    if (yaw_rate_offset_stop_time_last_ == yaw_rate_offset_stop_time) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+      msg = "not subscribed to topic";
+    } else if (!yaw_rate_offset_stop_.status.enabled_status) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+      msg = "estimates have not started yet";
+    } else if (yaw_rate_offset_stop_.status.is_abnormal) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
+      if (yaw_rate_offset_stop_.status.error_code ==
+          eagleye_msgs::msg::Status::NAN_OR_INFINITE) {
+        msg = "estimate value is NaN or infinete";
+      } else {
+        msg = "abnormal error of yaw_rate_offset_stop";
+      }
+    }
+
+    yaw_rate_offset_stop_time_last_ = yaw_rate_offset_stop_time;
+    stat.summary(level, msg);
+  }
+
+  void yawRateOffset1stTopicChecker(diagnostic_updater::DiagnosticStatusWrapper& stat)
+  {
+    rclcpp::Time ros_clock(yaw_rate_offset_1st_.header.stamp);
+    auto yaw_rate_offset_1st_time = ros_clock.seconds();
+
+    int8_t level = diagnostic_msgs::msg::DiagnosticStatus::OK;
+    std::string msg = "OK";
+
+    if (yaw_rate_offset_1st_time_last_ == yaw_rate_offset_1st_time) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+      msg = "not subscribed to topic";
+    } else if (!yaw_rate_offset_1st_.status.enabled_status) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+      msg = "estimates have not started yet";
+    } else if (yaw_rate_offset_1st_.status.is_abnormal) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
+      if (yaw_rate_offset_1st_.status.error_code ==
+          eagleye_msgs::msg::Status::NAN_OR_INFINITE) {
+        msg = "estimate value is NaN or infinete";
+      } else {
+        msg = "abnormal error of yaw_rate_offset_1st";
+      }
+    }
+
+    yaw_rate_offset_1st_time_last_ = yaw_rate_offset_1st_time;
+    stat.summary(level, msg);
+  }
+
+  void yawRateOffset2ndTopicChecker(diagnostic_updater::DiagnosticStatusWrapper& stat)
+  {
+    rclcpp::Time ros_clock(yaw_rate_offset_2nd_.header.stamp);
+    auto yaw_rate_offset_2nd_time = ros_clock.seconds();
+
+    int8_t level = diagnostic_msgs::msg::DiagnosticStatus::OK;
+    std::string msg = "OK";
+
+    if (yaw_rate_offset_2nd_time_last_ == yaw_rate_offset_2nd_time) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+      msg = "not subscribed to topic";
+    } else if (!yaw_rate_offset_2nd_.status.enabled_status) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+      msg = "estimates have not started yet";
+    } else if (yaw_rate_offset_2nd_.status.is_abnormal) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
+      if (yaw_rate_offset_2nd_.status.error_code ==
+          eagleye_msgs::msg::Status::NAN_OR_INFINITE) {
+        msg = "estimate value is NaN or infinete";
+      } else {
+        msg = "abnormal error of yaw_rate_offset_2nd";
+      }
+    }
+
+    yaw_rate_offset_2nd_time_last_ = yaw_rate_offset_2nd_time;
+    stat.summary(level, msg);
+  }
+
+  void slipAngleTopicChecker(diagnostic_updater::DiagnosticStatusWrapper& stat)
+  {
+    rclcpp::Time ros_clock(slip_angle_.header.stamp);
+    auto slip_angle_time = ros_clock.seconds();
+
+    int8_t level = diagnostic_msgs::msg::DiagnosticStatus::OK;
+    std::string msg = "OK";
+
+    if (slip_angle_time_last_ == slip_angle_time) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+      msg = "not subscribed to topic";
+    } else if (!std::isfinite(slip_angle_.slip_angle)) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
+      msg = "invalid number";
+    } else if (slip_angle_.coefficient == 0) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+      msg = "/slip_angle/manual_coefficient is not set";
+    } else if (!slip_angle_.status.enabled_status) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+      msg = "estimates have not started yet";
+    }
+
+    slip_angle_time_last_ = slip_angle_time;
+    stat.summary(level, msg);
+  }
+
+  void enuVelTopicChecker(diagnostic_updater::DiagnosticStatusWrapper& stat)
+  {
+    rclcpp::Time ros_clock(enu_vel_.header.stamp);
+    auto enu_vel_time = ros_clock.seconds();
+
+    int8_t level = diagnostic_msgs::msg::DiagnosticStatus::OK;
+    std::string msg = "OK";
+
+    if (
+      !std::isfinite(enu_vel_.vector.x) || !std::isfinite(enu_vel_.vector.y) ||
+      !std::isfinite(enu_vel_.vector.z)) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
+      msg = "invalid number";
+    } else if (enu_vel_time_last_ == enu_vel_time) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+      msg = "not subscribed to topic";
+    }
+
+    enu_vel_time_last_ = enu_vel_time;
+    stat.summary(level, msg);
+  }
+
+  void heightTopicChecker(diagnostic_updater::DiagnosticStatusWrapper& stat)
+  {
+    rclcpp::Time ros_clock(height_.header.stamp);
+    auto height_time = ros_clock.seconds();
+
+    int8_t level = diagnostic_msgs::msg::DiagnosticStatus::OK;
+    std::string msg = "OK";
+
+    if (height_time_last_ == height_time) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+      msg = "not subscribed to topic";
+    } else if (!std::isfinite(height_.height)) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
+      msg = "invalid number";
+    } else if (!height_.status.enabled_status) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+      msg = "estimates have not started yet";
+    }
+
+    height_time_last_ = height_time;
+    stat.summary(level, msg);
+  }
+
+  void pitchingTopicChecker(diagnostic_updater::DiagnosticStatusWrapper& stat)
+  {
+    rclcpp::Time ros_clock(pitching_.header.stamp);
+    auto pitching_time = ros_clock.seconds();
+
+    int8_t level = diagnostic_msgs::msg::DiagnosticStatus::OK;
+    std::string msg = "OK";
+
+    if (pitching_time_last_ == pitching_time) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+      msg = "not subscribed to topic";
+    } else if (!std::isfinite(pitching_.pitching_angle)) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
+      msg = "invalid number";
+    } else if (!pitching_.status.enabled_status) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+      msg = "estimates have not started yet";
+    }
+
+    pitching_time_last_ = pitching_time;
+    stat.summary(level, msg);
+  }
+
+  void enuAbsolutePosTopicChecker(diagnostic_updater::DiagnosticStatusWrapper& stat)
+  {
+    rclcpp::Time ros_clock(enu_absolute_pos_.header.stamp);
+    auto enu_absolute_pos_time = ros_clock.seconds();
+
+    int8_t level = diagnostic_msgs::msg::DiagnosticStatus::OK;
+    std::string msg = "OK";
+
+    if (
+      !std::isfinite(enu_absolute_pos_.enu_pos.x) ||
+      !std::isfinite(enu_absolute_pos_.enu_pos.y) ||
+      !std::isfinite(enu_absolute_pos_.enu_pos.z)) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
+      msg = "invalid number";
+    } else if (enu_absolute_pos_time_last_ - enu_absolute_pos_time > th_gnss_deadrock_time_) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+      msg = "not subscribed or deadlock of more than 10 seconds";
+    } else if (!enu_absolute_pos_.status.enabled_status) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+      msg = "estimates have not started yet";
+    }
+
+    enu_absolute_pos_time_last_ = enu_absolute_pos_time;
+    stat.summary(level, msg);
+  }
+
+  void enuAbsolutePosInterpolateTopicChecker(
+    diagnostic_updater::DiagnosticStatusWrapper& stat)
+  {
+    rclcpp::Time ros_clock(enu_absolute_pos_interpolate_.header.stamp);
+    auto enu_absolute_pos_interpolate_time = ros_clock.seconds();
+
+    int8_t level = diagnostic_msgs::msg::DiagnosticStatus::OK;
+    std::string msg = "OK";
+
+    if (
+      !std::isfinite(enu_absolute_pos_interpolate_.enu_pos.x) ||
+      !std::isfinite(enu_absolute_pos_interpolate_.enu_pos.y) ||
+      !std::isfinite(enu_absolute_pos_interpolate_.enu_pos.z)) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
+      msg = "invalid number";
+    } else if (
+      enu_absolute_pos_interpolate_time_last_ == enu_absolute_pos_interpolate_time) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+      msg = "not subscribed or deadlock of more than 10 seconds";
+    } else if (!enu_absolute_pos_interpolate_.status.enabled_status) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+      msg = "estimates have not started yet";
+    }
+
+    enu_absolute_pos_interpolate_time_last_ = enu_absolute_pos_interpolate_time;
+    stat.summary(level, msg);
+  }
+
+  void twistTopicChecker(diagnostic_updater::DiagnosticStatusWrapper& stat)
+  {
+    rclcpp::Time ros_clock(eagleye_twist_.header.stamp);
+    auto eagleye_twist_time = ros_clock.seconds();
+
+    int8_t level = diagnostic_msgs::msg::DiagnosticStatus::OK;
+    std::string msg = "OK";
+
+    if (eagleye_twist_time_last_ == eagleye_twist_time) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
+      msg = "not subscribed or deadlock of more than 10 seconds";
+    } else if (
+      !std::isfinite(eagleye_twist_.twist.linear.x) ||
+      !std::isfinite(eagleye_twist_.twist.linear.y) ||
+      !std::isfinite(eagleye_twist_.twist.linear.z) ||
+      !std::isfinite(eagleye_twist_.twist.angular.x) ||
+      !std::isfinite(eagleye_twist_.twist.angular.y) ||
+      !std::isfinite(eagleye_twist_.twist.angular.z)) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
+      msg = "invalid number";
+    }
+
+    eagleye_twist_time_last_ = eagleye_twist_time;
+    stat.summary(level, msg);
+  }
+
+  void imuComparisonChecker(diagnostic_updater::DiagnosticStatusWrapper& stat)
+  {
+    if (comparison_velocity_ptr_ == nullptr) {
+      return;
+    }
+
+    int8_t level = diagnostic_msgs::msg::DiagnosticStatus::OK;
+    std::string msg = "OK";
+
+    if (
+      use_compare_yaw_rate_ &&
+      th_diff_rad_per_sec_ <
+        std::abs(
+          corrected_imu_.angular_velocity.z -
+          comparison_velocity_ptr_->twist.angular.z)) {
+      num_continuous_abnormal_yaw_rate_++;
+    } else {
+      num_continuous_abnormal_yaw_rate_ = 0;
+    }
+
+    if (num_continuous_abnormal_yaw_rate_ > th_num_continuous_abnormal_yaw_rate_) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
+      msg = "IMU Yaw Rate too large or too small compared to reference twist";
+    }
+    stat.summary(level, msg);
+  }
+
+  void printStatus()
+  {
+    std::cout << std::endl;
+    std::cout << "\033[1;33m Eagleye status \033[m" << std::endl;
+    std::cout << std::endl;
+    std::cout << std::fixed;
+
+    std::cout << "--- \033[1;34m imu(input)\033[m ------------------------------" << std::endl;
+    std::cout << "\033[1m linear_acceleration \033[mx " << std::setprecision(6)
+              << imu_.linear_acceleration.x << " [m/s^2]" << std::endl;
+    std::cout << "\033[1m linear acceleration \033[my " << std::setprecision(6)
+              << imu_.linear_acceleration.y << " [m/s^2]" << std::endl;
+    std::cout << "\033[1m linear acceleration \033[mz " << std::setprecision(6)
+              << imu_.linear_acceleration.z << " [m/s^2]" << std::endl;
+    std::cout << "\033[1m angular velocity \033[mx " << std::setprecision(6)
+              << imu_.angular_velocity.x << " [rad/s]" << std::endl;
+    std::cout << "\033[1m angular velocity \033[my " << std::setprecision(6)
+              << imu_.angular_velocity.y << " [rad/s]" << std::endl;
+    std::cout << "\033[1m angular velocity \033[mz " << std::setprecision(6)
+              << imu_.angular_velocity.z << " [rad/s]" << std::endl;
+    std::cout << std::endl;
+
+    std::cout << "--- \033[1;34m velocity(input)\033[m -------------------------" << std::endl;
+    std::cout << "\033[1m velocity \033[m" << std::setprecision(4)
+              << velocity_.twist.linear.x * 3.6 << " [km/h]" << std::endl;
+    std::cout << std::endl;
+
+    std::cout << "--- \033[1;34m rtklib(input)\033[m ---------------------------" << std::endl;
+    std::cout << "\033[1m time of week  \033[m" << rtklib_nav_.tow << " [ms]" << std::endl;
+    std::cout << "\033[1m latitude  \033[m" << std::setprecision(8)
+              << rtklib_nav_.status.latitude << " [deg]" << std::endl;
+    std::cout << "\033[1m longitude  \033[m" << std::setprecision(8)
+              << rtklib_nav_.status.longitude << " [deg]" << std::endl;
+    std::cout << "\033[1m altitude  \033[m" << std::setprecision(4)
+              << rtklib_nav_.status.altitude << " [m]" << std::endl;
+    std::cout << std::endl;
+
+    std::cout << "--- \033[1;34m gga(input)\033[m ------------------------------" << std::endl;
+
+    if (gga_sub_status_) {
+      std::cout << "\033[1m rtk status \033[m " << int(gga_.gps_qual) << std::endl;
+      std::cout << "\033[1m rtk status \033[m "
+                << (int(gga_.gps_qual) != 4 ? "\033[1;31mNo Fix\033[m" : "\033[1;32mFix\033[m")
+                << std::endl;
+      std::cout << "\033[1m latitude  \033[m" << std::setprecision(8) << gga_.lat << " [deg]"
+                << std::endl;
+      std::cout << "\033[1m longitude  \033[m" << std::setprecision(8) << gga_.lon << " [deg]"
+                << std::endl;
+      std::cout << "\033[1m altitude  \033[m" << std::setprecision(4)
+                << gga_.alt + gga_.undulation << " [m]" << std::endl;
+      std::cout << std::endl;
+    } else {
+      std::cout << std::endl;
+      std::cout << "\033[1;31m no subscription \033[m" << std::endl;
+      std::cout << std::endl;
+    }
+
+    std::cout << "--- \033[1;34m velocity SF\033[m -----------------------------" << std::endl;
+    std::cout << "\033[1m scale factor \033[m " << std::setprecision(4)
+              << velocity_scale_factor_.scale_factor << std::endl;
+    std::cout << "\033[1m status enable \033[m "
+              << (velocity_scale_factor_.status.enabled_status ? "\033[1;32mTrue\033[m"
+                                                               : "\033[1;31mFalse\033[m")
+              << std::endl;
+    std::cout << std::endl;
+
+    std::cout << "--- \033[1;34m yaw_rate offset stop\033[m ---------------------" << std::endl;
+    std::cout << "\033[1m yaw_rate offset \033[m " << std::setprecision(6)
+              << yaw_rate_offset_stop_.yaw_rate_offset << " [rad/s]" << std::endl;
+    std::cout << "\033[1m status enable \033[m "
+              << (yaw_rate_offset_stop_.status.enabled_status ? "\033[1;32mTrue\033[m"
+                                                              : "\033[1;31mFalse\033[m")
+              << std::endl;
+    std::cout << std::endl;
+
+    std::cout << "--- \033[1;34m yaw_rate offset\033[m --------------------------" << std::endl;
+    std::cout << "\033[1m yaw_rate offset \033[m " << std::setprecision(6)
+              << yaw_rate_offset_2nd_.yaw_rate_offset << " [rad/s]" << std::endl;
+    std::cout << "\033[1m status enable \033[m "
+              << (yaw_rate_offset_2nd_.status.enabled_status ? "\033[1;32mTrue\033[m"
+                                                             : "\033[1;31mFalse\033[m")
+              << std::endl;
+    std::cout << std::endl;
+
+    std::cout << "--- \033[1;34m slip angle\033[m ------------------------------" << std::endl;
+    std::cout << "\033[1m coefficient \033[m " << std::setprecision(6)
+              << slip_angle_.coefficient << std::endl;
+    std::cout << "\033[1m slip angle \033[m " << std::setprecision(6)
+              << slip_angle_.slip_angle << " [rad]" << std::endl;
+    std::cout << "\033[1m status enable \033[m "
+              << (slip_angle_.status.enabled_status ? "\033[1;32mTrue\033[m"
+                                                    : "\033[1;31mFalse\033[m")
+              << std::endl;
+    std::cout << std::endl;
+
+    std::cout << "--- \033[1;34m heading\033[m ---------------------------------" << std::endl;
+    std::cout << "\033[1m heading \033[m " << std::setprecision(6)
+              << heading_interpolate_3rd_.heading_angle << " [rad/s]" << std::endl;
+    std::cout << "\033[1m status enable \033[m "
+              << (heading_interpolate_3rd_.status.enabled_status ? "\033[1;32mTrue\033[m"
+                                                                  : "\033[1;31mFalse\033[m")
+              << std::endl;
+    std::cout << std::endl;
+
+    std::cout << "--- \033[1;34m pitching\033[m --------------------------------" << std::endl;
+    std::cout << "\033[1m pitching \033[m " << std::setprecision(6)
+              << pitching_.pitching_angle << " [rad]" << std::endl;
+    std::cout << "\033[1m status enable \033[m "
+              << (pitching_.status.enabled_status ? "\033[1;32mTrue\033[m"
+                                                  : "\033[1;31mFalse\033[m")
+              << std::endl;
+    std::cout << std::endl;
+
+    std::cout << "--- \033[1;34m height\033[m ----------------------------------" << std::endl;
+    std::cout << "\033[1m height \033[m " << std::setprecision(4) << height_.height << " [m]"
+              << std::endl;
+    std::cout << "\033[1m status enable \033[m "
+              << (height_.status.enabled_status ? "\033[1;32mTrue\033[m"
+                                                : "\033[1;31mFalse\033[m")
+              << std::endl;
+    std::cout << std::endl;
+
+    std::cout << "--- \033[1;34m position\033[m --------------------------------" << std::endl;
+    std::cout << "\033[1m latitude  \033[m" << std::setprecision(8) << eagleye_fix_.latitude
+              << " [deg]" << std::endl;
+    std::cout << "\033[1m longitude  \033[m" << std::setprecision(8) << eagleye_fix_.longitude
+              << " [deg]" << std::endl;
+    std::cout << "\033[1m altitude  \033[m" << std::setprecision(4) << eagleye_fix_.altitude
+              << " [m]" << std::endl;
+    std::cout << "\033[1m status enable \033[m "
+              << (enu_absolute_pos_interpolate_.status.enabled_status ? "\033[1;32mTrue\033[m"
+                                                                      : "\033[1;31mFalse\033[m")
+              << std::endl;
     std::cout << std::endl;
   }
-  else
+
+  void outputLog()
   {
-    std::cout << std::endl;
-    std::cout<<"\033[1;31m no subscription \033[m"<<std::endl;
-    std::cout << std::endl;
+    if (!log_header_make_) {
+      std::ofstream output_log_file(
+        output_log_dir_, std::ios_base::trunc | std::ios_base::out);
+      std::cout << "Output file = eagleye_log.csv" << std::endl;
+      output_log_file
+        << "timestamp,imu.angular_velocity.x,imu.angular_velocity.y,imu.angular_velocity.z,"
+           "imu.linear_acceleration.x,imu.linear_acceleration.y,imu.linear_acceleration.z"
+        << ",rtklib_nav.tow,rtklib_nav.ecef_pos.x,rtklib_nav.ecef_pos.y,rtklib_nav.ecef_pos.z,"
+           "rtklib_nav.ecef_vel.x,rtklib_nav.ecef_vel.y,rtklib_nav.ecef_vel.z,rtklib_nav.status."
+           "status.status,rtklib_nav.status.status.service,rtklib_nav.status.latitude,rtklib_nav."
+           "status.longitude,rtklib_nav.status.altitude"
+        << ",velocity.twist.linear.x,velocity.twist.linear.y,velocity.twist.linear.z,velocity."
+           "twist.angular.x,velocity.twist.angular.y,velocity.twist.angular.z"
+        << ",velocity_scale_factor.scale_factor,correction_velocity.twist.linear.x,correction_"
+           "velocity.twist.linear.y,correction_velocity.twist.linear.z,correction_velocity.twist."
+           "angular.x,correction_velocity.twist.angular.y,correction_velocity.twist.angular.z,"
+           "velocity_scale_factor.status.enabled_status,velocity_scale_factor.status.estimate_"
+           "status"
+        << ",distance.distance,distance.status.enabled_status,distance.status.estimate_status"
+        << ",heading_1st.heading_angle,heading_1st.status.enabled_status,heading_1st.status."
+           "estimate_status"
+        << ",heading_interpolate_1st.heading_angle,heading_interpolate_1st.status.enabled_status,"
+           "heading_interpolate_1st.status.estimate_status"
+        << ",heading_2nd.heading_angle,heading_2nd.status.enabled_status,heading_2nd.status."
+           "estimate_status"
+        << ",heading_interpolate_2nd.heading_angle,heading_interpolate_2nd.status.enabled_status,"
+           "heading_interpolate_2nd.status.estimate_status"
+        << ",heading_3rd.heading_angle,heading_3rd.status.enabled_status,heading_3rd.status."
+           "estimate_status"
+        << ",heading_interpolate_3rd.heading_angle,heading_interpolate_3rd.status.enabled_status,"
+           "heading_interpolate_3rd.status.estimate_status"
+        << ",yaw_rate_offset_stop.yaw_rate_offset,yaw_rate_offset_stop.status.enabled_status,"
+           "yaw_rate_offset_stop.status.estimate_status"
+        << ",yaw_rate_offset_1st.yaw_rate_offset,yaw_rate_offset_1st.status.enabled_status,"
+           "yaw_rate_offset_1st.status.estimate_status"
+        << ",yaw_rate_offset_2nd.yaw_rate_offset,yaw_rate_offset_2nd.status.enabled_status,"
+           "yaw_rate_offset_2nd.status.estimate_status"
+        << ",slip_angle.coefficient,slip_angle.slip_angle,slip_angle.status.enabled_status,"
+           "slip_angle.status.estimate_status"
+        << ",enu_vel.vector.x,enu_vel.vector.y,enu_vel.vector.z"
+        << ",enu_absolute_pos.enu_pos.x,enu_absolute_pos.enu_pos.y,enu_absolute_pos.enu_pos.z,"
+           "enu_absolute_pos.ecef_base_pos.x,enu_absolute_pos.ecef_base_pos.y,enu_absolute_pos."
+           "ecef_base_pos.z,enu_absolute_pos.status.enabled_status,enu_absolute_pos.status."
+           "estimate_status"
+        << ",enu_absolute_pos_interpolate.enu_pos.x,enu_absolute_pos_interpolate.enu_pos.y,"
+           "enu_absolute_pos_interpolate.enu_pos.z,enu_absolute_pos_interpolate.ecef_base_pos.x,"
+           "enu_absolute_pos_interpolate.ecef_base_pos.y,enu_absolute_pos_interpolate.ecef_base_"
+           "pos.z,enu_absolute_pos_interpolate.status.enabled_status,enu_absolute_pos_interpolate."
+           "status.estimate_status"
+        << ",height.height,height.status.enabled_status,height.status.estimate_status"
+        << ",pitching.pitching_angle,pitching.status.enabled_status,pitching.status.estimate_status"
+        << ",acc_x_offset.acc_x_offset,acc_x_offset.status.enabled_status,acc_x_offset.status."
+           "estimate_status"
+        << ",acc_x_scale_factor.acc_x_scale_factor,acc_x_scale_factor.status.enabled_status,"
+           "acc_x_scale_factor.status.estimate_status"
+        << ",rolling.rolling_angle,rolling.status.enabled_status,rolling.status.estimate_status"
+        << ",gga_timestamp"
+        << ",gga_llh.latitude,gga_llh.longitude,gga_llh.altitude"
+        << ",gga_llh.gps_qual"
+        << ",eagleye_pp_llh.latitude,eagleye_pp_llh.longitude,eagleye_pp_llh.altitude"
+        << ",eagleye_pp_llh.orientation_covariance[0],eagleye_pp_llh.orientation_covariance[1],"
+           "eagleye_pp_llh.orientation_covariance[2],eagleye_pp_llh.orientation_covariance[3],"
+           "eagleye_pp_llh.orientation_covariance[4],eagleye_pp_llh.orientation_covariance[5],"
+           "eagleye_pp_llh.orientation_covariance[6],eagleye_pp_llh.orientation_covariance[7],"
+           "eagleye_pp_llh.orientation_covariance[8]"
+        << ",eagleye_pp_llh.status"
+        << ",eagleye_pp_llh.height_status"
+        << ",enu_relative_pos.enu_pos.x,enu_relative_pos.enu_pos.y,enu_relative_pos.enu_pos.z"
+        << ",enu_relative_pos.status.enabled_status"
+        << std::endl;
+      log_header_make_ = true;
+    } else {
+      std::ofstream output_log_file(output_log_dir_, std::ios_base::app);
+      rclcpp::Time imu_clock(imu_.header.stamp);
+      long double nano_sec = imu_clock.nanoseconds();
+      long double sec_digits = std::pow(10, 9);
+      long double imu_time = nano_sec / sec_digits;
+      output_log_file << std::fixed << std::setprecision(9) << imu_time << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << imu_.angular_velocity.x << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << imu_.angular_velocity.y << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << imu_.angular_velocity.z << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << imu_.linear_acceleration.x << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << imu_.linear_acceleration.y << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << imu_.linear_acceleration.z << ",";
+      output_log_file << std::setprecision(std::numeric_limits<int>::max_digits10)
+                      << rtklib_nav_.tow << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << rtklib_nav_.ecef_pos.x << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << rtklib_nav_.ecef_pos.y << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << rtklib_nav_.ecef_pos.z << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << rtklib_nav_.ecef_vel.x << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << rtklib_nav_.ecef_vel.y << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << rtklib_nav_.ecef_vel.z << ",";
+      output_log_file << std::setprecision(std::numeric_limits<int>::max_digits10)
+                      << int(rtklib_nav_.status.status.status) << ",";
+      output_log_file << std::setprecision(std::numeric_limits<int>::max_digits10)
+                      << rtklib_nav_.status.status.service << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << rtklib_nav_.status.latitude << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << rtklib_nav_.status.longitude << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << rtklib_nav_.status.altitude << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << velocity_.twist.linear.x << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << velocity_.twist.linear.y << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << velocity_.twist.linear.z << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << velocity_.twist.angular.x << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << velocity_.twist.angular.y << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << velocity_.twist.angular.z << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << velocity_scale_factor_.scale_factor << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << correction_velocity_.twist.linear.x << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << correction_velocity_.twist.linear.y << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << correction_velocity_.twist.linear.z << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << correction_velocity_.twist.angular.x << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << correction_velocity_.twist.angular.y << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << correction_velocity_.twist.angular.z << ",";
+      output_log_file << (velocity_scale_factor_.status.enabled_status ? "1" : "0") << ",";
+      output_log_file << (velocity_scale_factor_.status.estimate_status ? "1" : "0") << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << distance_.distance << ",";
+      output_log_file << (distance_.status.enabled_status ? "1" : "0") << ",";
+      output_log_file << (distance_.status.estimate_status ? "1" : "0") << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << heading_1st_.heading_angle << ",";
+      output_log_file << (heading_1st_.status.enabled_status ? "1" : "0") << ",";
+      output_log_file << (heading_1st_.status.estimate_status ? "1" : "0") << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << heading_interpolate_1st_.heading_angle << ",";
+      output_log_file << (heading_interpolate_1st_.status.enabled_status ? "1" : "0") << ",";
+      output_log_file << (heading_interpolate_1st_.status.estimate_status ? "1" : "0") << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << heading_2nd_.heading_angle << ",";
+      output_log_file << (heading_2nd_.status.enabled_status ? "1" : "0") << ",";
+      output_log_file << (heading_2nd_.status.estimate_status ? "1" : "0") << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << heading_interpolate_2nd_.heading_angle << ",";
+      output_log_file << (heading_interpolate_2nd_.status.enabled_status ? "1" : "0") << ",";
+      output_log_file << (heading_interpolate_2nd_.status.estimate_status ? "1" : "0") << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << heading_3rd_.heading_angle << ",";
+      output_log_file << (heading_3rd_.status.enabled_status ? "1" : "0") << ",";
+      output_log_file << (heading_3rd_.status.estimate_status ? "1" : "0") << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << heading_interpolate_3rd_.heading_angle << ",";
+      output_log_file << (heading_interpolate_3rd_.status.enabled_status ? "1" : "0") << ",";
+      output_log_file << (heading_interpolate_3rd_.status.estimate_status ? "1" : "0") << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << yaw_rate_offset_stop_.yaw_rate_offset << ",";
+      output_log_file << (yaw_rate_offset_stop_.status.enabled_status ? "1" : "0") << ",";
+      output_log_file << (yaw_rate_offset_stop_.status.estimate_status ? "1" : "0") << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << yaw_rate_offset_1st_.yaw_rate_offset << ",";
+      output_log_file << (yaw_rate_offset_1st_.status.enabled_status ? "1" : "0") << ",";
+      output_log_file << (yaw_rate_offset_1st_.status.estimate_status ? "1" : "0") << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << yaw_rate_offset_2nd_.yaw_rate_offset << ",";
+      output_log_file << (yaw_rate_offset_2nd_.status.enabled_status ? "1" : "0") << ",";
+      output_log_file << (yaw_rate_offset_2nd_.status.estimate_status ? "1" : "0") << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << slip_angle_.coefficient << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << slip_angle_.slip_angle << ",";
+      output_log_file << (slip_angle_.status.enabled_status ? "1" : "0") << ",";
+      output_log_file << (slip_angle_.status.estimate_status ? "1" : "0") << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << enu_vel_.vector.x << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << enu_vel_.vector.y << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << enu_vel_.vector.z << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << enu_absolute_pos_.enu_pos.x << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << enu_absolute_pos_.enu_pos.y << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << enu_absolute_pos_.enu_pos.z << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << enu_absolute_pos_.ecef_base_pos.x << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << enu_absolute_pos_.ecef_base_pos.y << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << enu_absolute_pos_.ecef_base_pos.z << ",";
+      output_log_file << (enu_absolute_pos_.status.enabled_status ? "1" : "0") << ",";
+      output_log_file << (enu_absolute_pos_.status.estimate_status ? "1" : "0") << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << enu_absolute_pos_interpolate_.enu_pos.x << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << enu_absolute_pos_interpolate_.enu_pos.y << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << enu_absolute_pos_interpolate_.enu_pos.z << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << enu_absolute_pos_interpolate_.ecef_base_pos.x << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << enu_absolute_pos_interpolate_.ecef_base_pos.y << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << enu_absolute_pos_interpolate_.ecef_base_pos.z << ",";
+      output_log_file << (enu_absolute_pos_interpolate_.status.enabled_status ? "1" : "0")
+                      << ",";
+      output_log_file << (enu_absolute_pos_interpolate_.status.estimate_status ? "1" : "0")
+                      << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << height_.height << ",";
+      output_log_file << (height_.status.enabled_status ? "1" : "0") << ",";
+      output_log_file << (height_.status.estimate_status ? "1" : "0") << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << pitching_.pitching_angle << ",";
+      output_log_file << (pitching_.status.enabled_status ? "1" : "0") << ",";
+      output_log_file << (pitching_.status.estimate_status ? "1" : "0") << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0
+                      << ",";  // acc_x_offset
+      output_log_file << 0 << ",";  // acc_x_offset.status.enabled_status
+      output_log_file << 0 << ",";  // acc_x_offset.status.estimate_status
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0
+                      << ",";  // acc_x_scale_factor.acc_x_scale_factor
+      output_log_file << 0 << ",";  // acc_x_scale_factor.status.enabled_status
+      output_log_file << 0 << ",";  // acc_x_scale_factor.status.estimate_status
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << rolling_.rolling_angle << ",";
+      output_log_file << (rolling_.status.enabled_status ? "1" : "0") << ",";
+      output_log_file << (rolling_.status.estimate_status ? "1" : "0") << ",";
+      rclcpp::Time gga_clock(gga_.header.stamp);
+      double gga_time = gga_clock.seconds();
+      output_log_file << std::setprecision(std::numeric_limits<int>::max_digits10) << gga_time
+                      << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << gga_.lat
+                      << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << gga_.lon
+                      << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << gga_.alt + gga_.undulation << ",";
+      output_log_file << std::setprecision(std::numeric_limits<int>::max_digits10)
+                      << int(gga_.gps_qual) << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << eagleye_fix_.latitude << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << eagleye_fix_.longitude << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << eagleye_fix_.altitude << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0
+                      << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0
+                      << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0
+                      << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0
+                      << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0
+                      << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0
+                      << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0
+                      << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0
+                      << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0
+                      << ",";
+      output_log_file << std::setprecision(std::numeric_limits<int>::max_digits10) << 0 << ",";
+      output_log_file << std::setprecision(std::numeric_limits<int>::max_digits10) << 0 << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << enu_relative_pos_.enu_pos.x << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << enu_relative_pos_.enu_pos.y << ",";
+      output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10)
+                      << enu_relative_pos_.enu_pos.z << ",";
+      output_log_file << (enu_relative_pos_.status.enabled_status ? "1" : "0");
+      output_log_file << "\n";
+    }
   }
 
-
-  std::cout << "--- \033[1;34m velocity SF\033[m -----------------------------"<< std::endl;
-  std::cout<<"\033[1m scale factor \033[m "<<std::setprecision(4)<<_velocity_scale_factor.scale_factor<<std::endl;
-  std::cout<< "\033[1m status enable \033[m "<<(_velocity_scale_factor.status.enabled_status ? "\033[1;32mTrue\033[m" : "\033[1;31mFalse\033[m")<<std::endl;
-
-  std::cout << std::endl;
-
-  std::cout << "--- \033[1;34m yaw_rate offset stop\033[m ---------------------"<< std::endl;
-  std::cout<<"\033[1m yaw_rate offset \033[m "<<std::setprecision(6)<<_yaw_rate_offset_stop.yaw_rate_offset<<" [rad/s]"<<std::endl;
-  std::cout<< "\033[1m status enable \033[m "<<(_yaw_rate_offset_stop.status.enabled_status ? "\033[1;32mTrue\033[m" : "\033[1;31mFalse\033[m")<<std::endl;
-  std::cout << std::endl;
-
-  std::cout << "--- \033[1;34m yaw_rate offset\033[m --------------------------"<< std::endl;
-  std::cout<<"\033[1m yaw_rate offset \033[m "<<std::setprecision(6)<<_yaw_rate_offset_2nd.yaw_rate_offset<<" [rad/s]"<<std::endl;
-  std::cout<< "\033[1m status enable \033[m "<<(_yaw_rate_offset_2nd.status.enabled_status ? "\033[1;32mTrue\033[m" : "\033[1;31mFalse\033[m")<<std::endl;
-  std::cout << std::endl;
-
-  std::cout << "--- \033[1;34m slip angle\033[m ------------------------------"<< std::endl;
-  std::cout<<"\033[1m coefficient \033[m "<<std::setprecision(6)<<_slip_angle.coefficient<<std::endl;
-  std::cout<<"\033[1m slip angle \033[m "<<std::setprecision(6)<<_slip_angle.slip_angle<<" [rad]"<<std::endl;
-  std::cout<< "\033[1m status enable \033[m "<<(_slip_angle.status.enabled_status ? "\033[1;32mTrue\033[m" : "\033[1;31mFalse\033[m")<<std::endl;
-  std::cout << std::endl;
-
-  std::cout << "--- \033[1;34m heading\033[m ---------------------------------"<< std::endl;
-  std::cout<<"\033[1m heading \033[m "<<std::setprecision(6)<<_heading_interpolate_3rd.heading_angle<<" [rad/s]"<<std::endl;
-  std::cout<< "\033[1m status enable \033[m "<<(_heading_interpolate_3rd.status.enabled_status ? "\033[1;32mTrue\033[m" : "\033[1;31mFalse\033[m")<<std::endl;
-  std::cout << std::endl;
-
-  std::cout << "--- \033[1;34m pitching\033[m --------------------------------"<< std::endl;
-  std::cout<<"\033[1m pitching \033[m "<<std::setprecision(6)<<_pitching.pitching_angle<<" [rad]"<<std::endl;
-  std::cout<< "\033[1m status enable \033[m "<<(_pitching.status.enabled_status ? "\033[1;32mTrue\033[m" : "\033[1;31mFalse\033[m")<<std::endl;
-  std::cout << std::endl;
-
-  std::cout << "--- \033[1;34m height\033[m ----------------------------------"<< std::endl;
-  std::cout<<"\033[1m height \033[m "<<std::setprecision(4)<<_height.height<<" [m]"<<std::endl;
-  std::cout<< "\033[1m status enable \033[m "<<(_height.status.enabled_status ? "\033[1;32mTrue\033[m" : "\033[1;31mFalse\033[m")<<std::endl;
-  std::cout << std::endl;
-
-  std::cout << "--- \033[1;34m position\033[m --------------------------------"<< std::endl;
-  std::cout<<"\033[1m latitude  \033[m"<<std::setprecision(8)<<_eagleye_fix.latitude<<" [deg]"<<std::endl;
-  std::cout<<"\033[1m longitude  \033[m"<<std::setprecision(8)<<_eagleye_fix.longitude<<" [deg]"<<std::endl;
-  std::cout<<"\033[1m altitude  \033[m"<<std::setprecision(4)<<_eagleye_fix.altitude<<" [m]"<<std::endl;
-  std::cout<< "\033[1m status enable \033[m "<<(_enu_absolute_pos_interpolate.status.enabled_status ? "\033[1;32mTrue\033[m" : "\033[1;31mFalse\033[m")<<std::endl;
-  std::cout << std::endl;
-}
-
-void outputLog(void)
-{
-  if(!_log_header_make)
+  void imuCallback(const sensor_msgs::msg::Imu::ConstSharedPtr msg)
   {
-  std::ofstream output_log_file(_output_log_dir, std::ios_base::trunc | std::ios_base::out);
-  std::cout << "Output file = eagleye_log.csv" << std::endl;
-  output_log_file << "timestamp,imu.angular_velocity.x,imu.angular_velocity.y,imu.angular_velocity.z,imu.linear_acceleration.x,imu.linear_acceleration.y,imu.linear_acceleration.z\
-,rtklib_nav.tow,rtklib_nav.ecef_pos.x,rtklib_nav.ecef_pos.y,rtklib_nav.ecef_pos.z,rtklib_nav.ecef_vel.x,rtklib_nav.ecef_vel.y,rtklib_nav.ecef_vel.z,rtklib_nav.status.status.status,rtklib_nav.status.status.service,rtklib_nav.status.latitude,rtklib_nav.status.longitude,rtklib_nav.status.altitude\
-,velocity.twist.linear.x,velocity.twist.linear.y,velocity.twist.linear.z,velocity.twist.angular.x,velocity.twist.angular.y,velocity.twist.angular.z\
-,velocity_scale_factor.scale_factor,correction_velocity.twist.linear.x,correction_velocity.twist.linear.y,correction_velocity.twist.linear.z,correction_velocity.twist.angular.x,correction_velocity.twist.angular.y,correction_velocity.twist.angular.z,velocity_scale_factor.status.enabled_status,velocity_scale_factor.status.estimate_status\
-,distance.distance,distance.status.enabled_status,distance.status.estimate_status\
-,heading_1st.heading_angle,heading_1st.status.enabled_status,heading_1st.status.estimate_status\
-,heading_interpolate_1st.heading_angle,heading_interpolate_1st.status.enabled_status,heading_interpolate_1st.status.estimate_status\
-,heading_2nd.heading_angle,heading_2nd.status.enabled_status,heading_2nd.status.estimate_status\
-,heading_interpolate_2nd.heading_angle,heading_interpolate_2nd.status.enabled_status,heading_interpolate_2nd.status.estimate_status\
-,heading_3rd.heading_angle,heading_3rd.status.enabled_status,heading_3rd.status.estimate_status\
-,heading_interpolate_3rd.heading_angle,heading_interpolate_3rd.status.enabled_status,heading_interpolate_3rd.status.estimate_status\
-,yaw_rate_offset_stop.yaw_rate_offset,yaw_rate_offset_stop.status.enabled_status,yaw_rate_offset_stop.status.estimate_status\
-,yaw_rate_offset_1st.yaw_rate_offset,yaw_rate_offset_1st.status.enabled_status,yaw_rate_offset_1st.status.estimate_status\
-,yaw_rate_offset_2nd.yaw_rate_offset,yaw_rate_offset_2nd.status.enabled_status,yaw_rate_offset_2nd.status.estimate_status\
-,slip_angle.coefficient,slip_angle.slip_angle,slip_angle.status.enabled_status,slip_angle.status.estimate_status\
-,enu_vel.vector.x,enu_vel.vector.y,enu_vel.vector.z\
-,enu_absolute_pos.enu_pos.x,enu_absolute_pos.enu_pos.y,enu_absolute_pos.enu_pos.z,enu_absolute_pos.ecef_base_pos.x,enu_absolute_pos.ecef_base_pos.y,enu_absolute_pos.ecef_base_pos.z,enu_absolute_pos.status.enabled_status,enu_absolute_pos.status.estimate_status\
-,enu_absolute_pos_interpolate.enu_pos.x,enu_absolute_pos_interpolate.enu_pos.y,enu_absolute_pos_interpolate.enu_pos.z,enu_absolute_pos_interpolate.ecef_base_pos.x,enu_absolute_pos_interpolate.ecef_base_pos.y,enu_absolute_pos_interpolate.ecef_base_pos.z,enu_absolute_pos_interpolate.status.enabled_status,enu_absolute_pos_interpolate.status.estimate_status\
-,height.height,height.status.enabled_status,height.status.estimate_status\
-,pitching.pitching_angle,pitching.status.enabled_status,pitching.status.estimate_status\
-,acc_x_offset.acc_x_offset,acc_x_offset.status.enabled_status,acc_x_offset.status.estimate_status\
-,acc_x_scale_factor.acc_x_scale_factor,acc_x_scale_factor.status.enabled_status,acc_x_scale_factor.status.estimate_status\
-,rolling.rolling_angle,rolling.status.enabled_status,rolling.status.estimate_status\
-,gga_timestamp\
-,gga_llh.latitude,gga_llh.longitude,gga_llh.altitude\
-,gga_llh.gps_qual\
-,eagleye_pp_llh.latitude,eagleye_pp_llh.longitude,eagleye_pp_llh.altitude\
-,eagleye_pp_llh.orientation_covariance[0],eagleye_pp_llh.orientation_covariance[1],eagleye_pp_llh.orientation_covariance[2],eagleye_pp_llh.orientation_covariance[3],eagleye_pp_llh.orientation_covariance[4],eagleye_pp_llh.orientation_covariance[5],eagleye_pp_llh.orientation_covariance[6],eagleye_pp_llh.orientation_covariance[7],eagleye_pp_llh.orientation_covariance[8]\
-,eagleye_pp_llh.status\
-,eagleye_pp_llh.height_status\
-,enu_relative_pos.enu_pos.x,enu_relative_pos.enu_pos.y,enu_relative_pos.enu_pos.z\
-,enu_relative_pos.status.enabled_status\
-" << std::endl;
-  _log_header_make = true;
-  }
-  else
-  {
-  std::ofstream output_log_file(_output_log_dir, std::ios_base::app);
-  rclcpp::Time imu_clock(_imu.header.stamp);
-  long double nano_sec = imu_clock.nanoseconds();
-  long double sec_digits = std::pow(10,9);
-  long double imu_time = nano_sec/sec_digits;
-  output_log_file << std::fixed << std::setprecision(9) << imu_time  << ","; // timestamp
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _imu.angular_velocity.x << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _imu.angular_velocity.y << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _imu.angular_velocity.z << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _imu.linear_acceleration.x << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _imu.linear_acceleration.y << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _imu.linear_acceleration.z << ",";
-  output_log_file << std::setprecision(std::numeric_limits<int>::max_digits10) << _rtklib_nav.tow << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _rtklib_nav.ecef_pos.x << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _rtklib_nav.ecef_pos.y << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _rtklib_nav.ecef_pos.z << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _rtklib_nav.ecef_vel.x << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _rtklib_nav.ecef_vel.y << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _rtklib_nav.ecef_vel.z << ",";
-  output_log_file << std::setprecision(std::numeric_limits<int>::max_digits10) << int(_rtklib_nav.status.status.status) << ",";
-  output_log_file << std::setprecision(std::numeric_limits<int>::max_digits10) << _rtklib_nav.status.status.service << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _rtklib_nav.status.latitude << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _rtklib_nav.status.longitude << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _rtklib_nav.status.altitude << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _velocity.twist.linear.x << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _velocity.twist.linear.y << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _velocity.twist.linear.z << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _velocity.twist.angular.x << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _velocity.twist.angular.y << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _velocity.twist.angular.z << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _velocity_scale_factor.scale_factor << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _correction_velocity.twist.linear.x << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _correction_velocity.twist.linear.y << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _correction_velocity.twist.linear.z << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _correction_velocity.twist.angular.x << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _correction_velocity.twist.angular.y << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _correction_velocity.twist.angular.z << ",";
-  output_log_file << (_velocity_scale_factor.status.enabled_status ? "1" : "0") << ",";
-  output_log_file << (_velocity_scale_factor.status.estimate_status ? "1" : "0") << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _distance.distance << ",";
-  output_log_file << (_distance.status.enabled_status ? "1" : "0") << ",";
-  output_log_file << (_distance.status.estimate_status ? "1" : "0") << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _heading_1st.heading_angle << ",";
-  output_log_file << (_heading_1st.status.enabled_status ? "1" : "0") << ",";
-  output_log_file << (_heading_1st.status.estimate_status ? "1" : "0") << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _heading_interpolate_1st.heading_angle << ",";
-  output_log_file << (_heading_interpolate_1st.status.enabled_status ? "1" : "0") << ",";
-  output_log_file << (_heading_interpolate_1st.status.estimate_status ? "1" : "0") << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _heading_2nd.heading_angle << ",";
-  output_log_file << (_heading_2nd.status.enabled_status ? "1" : "0") << ",";
-  output_log_file << (_heading_2nd.status.estimate_status ? "1" : "0") << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _heading_interpolate_2nd.heading_angle << ",";
-  output_log_file << (_heading_interpolate_2nd.status.enabled_status ? "1" : "0") << ",";
-  output_log_file << (_heading_interpolate_2nd.status.estimate_status ? "1" : "0") << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _heading_3rd.heading_angle << ",";
-  output_log_file << (_heading_3rd.status.enabled_status ? "1" : "0") << ",";
-  output_log_file << (_heading_3rd.status.estimate_status ? "1" : "0") << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _heading_interpolate_3rd.heading_angle << ",";
-  output_log_file << (_heading_interpolate_3rd.status.enabled_status ? "1" : "0") << ",";
-  output_log_file << (_heading_interpolate_3rd.status.estimate_status ? "1" : "0") << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _yaw_rate_offset_stop.yaw_rate_offset << ",";
-  output_log_file << (_yaw_rate_offset_stop.status.enabled_status ? "1" : "0") << ",";
-  output_log_file << (_yaw_rate_offset_stop.status.estimate_status ? "1" : "0") << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _yaw_rate_offset_1st.yaw_rate_offset << ",";
-  output_log_file << (_yaw_rate_offset_1st.status.enabled_status ? "1" : "0") << ",";
-  output_log_file << (_yaw_rate_offset_1st.status.estimate_status ? "1" : "0") << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _yaw_rate_offset_2nd.yaw_rate_offset << ",";
-  output_log_file << (_yaw_rate_offset_2nd.status.enabled_status ? "1" : "0") << ",";
-  output_log_file << (_yaw_rate_offset_2nd.status.estimate_status ? "1" : "0") << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _slip_angle.coefficient << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _slip_angle.slip_angle << ",";
-  output_log_file << (_slip_angle.status.enabled_status ? "1" : "0") << ",";
-  output_log_file << (_slip_angle.status.estimate_status ? "1" : "0") << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _enu_vel.vector.x << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _enu_vel.vector.y << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _enu_vel.vector.z << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _enu_absolute_pos.enu_pos.x << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _enu_absolute_pos.enu_pos.y << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _enu_absolute_pos.enu_pos.z << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _enu_absolute_pos.ecef_base_pos.x << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _enu_absolute_pos.ecef_base_pos.y << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _enu_absolute_pos.ecef_base_pos.z << ",";
-  output_log_file << (_enu_absolute_pos.status.enabled_status ? "1" : "0") << ",";
-  output_log_file << (_enu_absolute_pos.status.estimate_status ? "1" : "0") << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _enu_absolute_pos_interpolate.enu_pos.x << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _enu_absolute_pos_interpolate.enu_pos.y << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _enu_absolute_pos_interpolate.enu_pos.z << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _enu_absolute_pos_interpolate.ecef_base_pos.x << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _enu_absolute_pos_interpolate.ecef_base_pos.y << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _enu_absolute_pos_interpolate.ecef_base_pos.z << ",";
-  output_log_file << (_enu_absolute_pos_interpolate.status.enabled_status ? "1" : "0") << ",";
-  output_log_file << (_enu_absolute_pos_interpolate.status.estimate_status ? "1" : "0") << ",";
-  // output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << angular_velocity_offset_stop.rollrate_offset << ",";
-  // output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << angular_velocity_offset_stop.pitch_rate_offset << ",";
-  // output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << angular_velocity_offset_stop.yaw_rate_offset << ",";
-  // output_log_file << (angular_velocity_offset_stop.status.enabled_status ? "1" : "0") << ",";
-  // output_log_file << (angular_velocity_offset_stop.status.estimate_status ? "1" : "0") << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _height.height << ",";
-  output_log_file << (_height.status.enabled_status ? "1" : "0") << ",";
-  output_log_file << (_height.status.estimate_status ? "1" : "0") << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _pitching.pitching_angle << ",";
-  output_log_file << (_pitching.status.enabled_status ? "1" : "0") << ",";
-  output_log_file << (_pitching.status.estimate_status ? "1" : "0") << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // acc_x_offset
-  output_log_file << 0 << ","; // acc_x_offset.status.enabled_status
-  output_log_file << 0 << ","; // acc_x_offset.status.estimate_status
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; // acc_x_scale_factor.acc_x_scale_factor
-  output_log_file << 0 << ","; // acc_x_scale_factor.status.enabled_status
-  output_log_file << 0 << ","; // acc_x_scale_factor.status.estimate_status
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _rolling.rolling_angle << ",";
-  output_log_file << (_rolling.status.enabled_status ? "1" : "0") << ",";
-  output_log_file << (_rolling.status.estimate_status ? "1" : "0") << ",";
-  rclcpp::Time gga_clock(_gga.header.stamp);
-  double gga_time = gga_clock.seconds();
-  output_log_file << std::setprecision(std::numeric_limits<int>::max_digits10) << gga_time << ","; //timestamp
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _gga.lat << ","; //gga_llh.latitude
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _gga.lon << ","; //gga_llh.longitude
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _gga.alt +  _gga.undulation<< ","; //gga_llh.altitude
-  output_log_file << std::setprecision(std::numeric_limits<int>::max_digits10) << int(_gga.gps_qual) << ","; //gga_llh.gps_qual
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _eagleye_fix.latitude << ","; //eagleye_pp_llh.latitude
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _eagleye_fix.longitude << ","; //eagleye_pp_llh.longitude
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _eagleye_fix.altitude << ","; //eagleye_pp_llh.altitude
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_pp_llh.orientation_covariance[0]
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_pp_llh.orientation_covariance[1]
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_pp_llh.orientation_covariance[2]
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_pp_llh.orientation_covariance[3]
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_pp_llh.orientation_covariance[4]
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_pp_llh.orientation_covariance[5]
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_pp_llh.orientation_covariance[6]
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_pp_llh.orientation_covariance[7]
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << 0 << ","; //eagleye_pp_llh.orientation_covariance[8]
-  output_log_file << std::setprecision(std::numeric_limits<int>::max_digits10) << 0 << ","; //eagleye_pp_llh.status
-  output_log_file << std::setprecision(std::numeric_limits<int>::max_digits10) << 0 << ","; //eagleye_pp_llh.status
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _enu_relative_pos.enu_pos.x << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _enu_relative_pos.enu_pos.y << ",";
-  output_log_file << std::setprecision(std::numeric_limits<double>::max_digits10) << _enu_relative_pos.enu_pos.z << ",";
-  output_log_file << (_enu_relative_pos.status.enabled_status ? "1" : "0");
-  output_log_file << "\n";
-  }
-  return;
-}
+    imu_.header = msg->header;
+    imu_.orientation = msg->orientation;
+    imu_.orientation_covariance = msg->orientation_covariance;
+    imu_.angular_velocity = msg->angular_velocity;
+    imu_.angular_velocity_covariance = msg->angular_velocity_covariance;
+    imu_.linear_acceleration = msg->linear_acceleration;
+    imu_.linear_acceleration_covariance = msg->linear_acceleration_covariance;
 
-void imu_callback(const sensor_msgs::msg::Imu::ConstSharedPtr msg)
-{
-  _imu.header = msg->header;
-  _imu.orientation = msg->orientation;
-  _imu.orientation_covariance = msg->orientation_covariance;
-  _imu.angular_velocity = msg->angular_velocity;
-  _imu.angular_velocity_covariance = msg->angular_velocity_covariance;
-  _imu.linear_acceleration = msg->linear_acceleration;
-  _imu.linear_acceleration_covariance = msg->linear_acceleration_covariance;
+    if (print_status_) {
+      printStatus();
+    }
 
-  if (_print_status)
-  {
-    printStatus();
+    if (log_output_status_) {
+      outputLog();
+    }
   }
-
-  if(_log_output_status)
-  {
-    outputLog();
-  }
-
-}
+};
 
 int main(int argc, char** argv)
 {
   rclcpp::init(argc, argv);
-  auto node = rclcpp::Node::make_shared("eagleye_monitor");
-
-  std::string subscribe_twist_topic_name = "vehicle/twist";
-
-  std::string subscribe_rtklib_nav_topic_name = "gnss/rtklib_nav";
-  std::string subscribe_gga_topic_name = "gnss/gga";
-  std::string comparison_twist_topic_name = "/calculated_twist";
-
-  node->declare_parameter("rtklib_nav_topic",subscribe_rtklib_nav_topic_name);
-  node->declare_parameter("gga_topic",subscribe_gga_topic_name);
-  node->declare_parameter("monitor.comparison_twist_topic",comparison_twist_topic_name);
-  node->declare_parameter("monitor.print_status",_print_status);
-  node->declare_parameter("monitor.log_output_status",_log_output_status);
-  node->declare_parameter("monitor.use_compare_yaw_rate",_use_compare_yaw_rate);
-  node->declare_parameter("monitor.th_diff_rad_per_sec",_th_diff_rad_per_sec);
-  node->declare_parameter("monitor.th_num_continuous_abnormal_yaw_rate",_th_num_continuous_abnormal_yaw_rate);
-
-  node->get_parameter("rtklib_nav_topic",subscribe_rtklib_nav_topic_name);
-  node->get_parameter("gga_topic",subscribe_gga_topic_name);
-  node->get_parameter("monitor.comparison_twist_topic",comparison_twist_topic_name);
-  node->get_parameter("monitor.print_status",_print_status);
-  node->get_parameter("monitor.log_output_status",_log_output_status);
-  node->get_parameter("monitor.use_compare_yaw_rate",_use_compare_yaw_rate);
-  node->get_parameter("monitor.th_diff_rad_per_sec",_th_diff_rad_per_sec);
-  node->get_parameter("monitor.th_num_continuous_abnormal_yaw_rate",_th_num_continuous_abnormal_yaw_rate);
-
-  std::cout<< "subscribe_rtklib_nav_topic_name "<<subscribe_rtklib_nav_topic_name<<std::endl;
-  std::cout<< "subscribe_gga_topic_name "<<subscribe_gga_topic_name<<std::endl;
-  std::cout<< "print_status "<<_print_status<<std::endl;
-  std::cout<< "log_output_status "<<_log_output_status<<std::endl;
-  std::cout<< "use_compare_yaw_rate "<<_use_compare_yaw_rate<<std::endl;
-  if(_use_compare_yaw_rate) {
-  std::cout<< "comparison_twist_topic_name "<<comparison_twist_topic_name<<std::endl;
-  std::cout<< "th_diff_rad_per_sec "<<_th_diff_rad_per_sec<<std::endl;
-  std::cout<< "th_num_continuous_abnormal_yaw_rate "<<_th_num_continuous_abnormal_yaw_rate<<std::endl;
-  }
-
-  // // Diagnostic Updater
-  double update_time = 1.0 / _update_rate;
-  updater_ = std::make_shared<diagnostic_updater::Updater>(node, update_time);
-
-  updater_->setHardwareID("eagleye_topic_checker");
-  updater_->add("eagleye_input_imu", imu_topic_checker);
-  updater_->add("eagleye_input_rtklib_nav", rtklib_nav_topic_checker);
-  updater_->add("eagleye_input_navsat_gga", navsat_gga_topic_checker);
-  updater_->add("eagleye_input_velocity", velocity_topic_checker);
-  updater_->add("eagleye_velocity_scale_factor", velocity_scale_factor_topic_checker);
-  updater_->add("eagleye_distance", distance_topic_checker);
-  updater_->add("eagleye_heading_1st", heading_1st_topic_checker);
-  updater_->add("eagleye_heading_interpolate_1st", heading_interpolate_1st_topic_checker);
-  updater_->add("eagleye_heading_2nd", heading_2nd_topic_checker);
-  updater_->add("eagleye_heading_interpolate_2nd", heading_interpolate_2nd_topic_checker);
-  updater_->add("eagleye_heading_3rd", heading_3rd_topic_checker);
-  updater_->add("eagleye_heading_interpolate_3rd", heading_interpolate_3rd_topic_checker);
-  updater_->add("eagleye_yaw_rate_offset_stop", yaw_rate_offset_stop_topic_checker);
-  updater_->add("eagleye_yaw_rate_offset_1st", yaw_rate_offset_1st_topic_checker);
-  updater_->add("eagleye_yaw_rate_offset_2nd", yaw_rate_offset_2nd_topic_checker);
-  updater_->add("eagleye_slip_angle", slip_angle_topic_checker);
-  updater_->add("eagleye_enu_vel", enu_vel_topic_checker);
-  updater_->add("eagleye_height", height_topic_checker);
-  updater_->add("eagleye_pitching", pitching_topic_checker);
-  updater_->add("eagleye_enu_absolute_pos", enu_absolute_pos_topic_checker);
-  updater_->add("eagleye_enu_absolute_pos_interpolate", enu_absolute_pos_interpolate_topic_checker);
-  updater_->add("eagleye_twist", twist_topic_checker);
-  if(_use_compare_yaw_rate) updater_->add("eagleye_imu_comparison", imu_comparison_checker);
-
-  time_t time_;
-  time_ = time(NULL);
-  std::stringstream time_ss;
-  time_ss << time_;
-  std::string time_str = time_ss.str();
-  _output_log_dir = ament_index_cpp::get_package_share_directory("eagleye_rt") + "/log/eagleye_log_" + time_str + ".csv";
-  if(_log_output_status) std::cout << _output_log_dir << std::endl;
-
-  auto sub1 = node->create_subscription<sensor_msgs::msg::Imu>("imu/data_tf_converted", 1000, imu_callback);
-  auto sub2 = node->create_subscription<rtklib_msgs::msg::RtklibNav>(subscribe_rtklib_nav_topic_name, 1000, rtklib_nav_callback);
-  auto sub3 = node->create_subscription<sensor_msgs::msg::NavSatFix>("rtklib/fix", rclcpp::QoS(10), rtklib_fix_callback);
-  auto sub4 = node->create_subscription<nmea_msgs::msg::Gpgga>(subscribe_gga_topic_name, 1000, navsatfix_gga_callback);
-  auto sub5 = node->create_subscription<geometry_msgs::msg::TwistStamped>(subscribe_twist_topic_name, 1000, velocity_callback);
-  auto sub6 = node->create_subscription<eagleye_msgs::msg::VelocityScaleFactor>("velocity_scale_factor", rclcpp::QoS(10), velocity_scale_factor_callback);
-  auto sub7 = node->create_subscription<eagleye_msgs::msg::Distance>("distance", rclcpp::QoS(10), distance_callback);
-  auto sub8 = node->create_subscription<eagleye_msgs::msg::Heading>("heading_1st", rclcpp::QoS(10), heading_1st_callback);
-  auto sub9 = node->create_subscription<eagleye_msgs::msg::Heading>("heading_interpolate_1st", rclcpp::QoS(10), heading_interpolate_1st_callback);
-  auto sub10 = node->create_subscription<eagleye_msgs::msg::Heading>("heading_2nd", rclcpp::QoS(10), heading_2nd_callback);
-  auto sub11 = node->create_subscription<eagleye_msgs::msg::Heading>("heading_interpolate_2nd", rclcpp::QoS(10), heading_interpolate_2nd_callback);
-  auto sub12 = node->create_subscription<eagleye_msgs::msg::Heading>("heading_3rd", rclcpp::QoS(10), heading_3rd_callback);
-  auto sub13 = node->create_subscription<eagleye_msgs::msg::Heading>("heading_interpolate_3rd", rclcpp::QoS(10), heading_interpolate_3rd_callback);
-  auto sub14 = node->create_subscription<eagleye_msgs::msg::YawrateOffset>("yaw_rate_offset_stop", rclcpp::QoS(10), yaw_rate_offset_stop_callback);
-  auto sub15 = node->create_subscription<eagleye_msgs::msg::YawrateOffset>("yaw_rate_offset_1st", rclcpp::QoS(10), yaw_rate_offset_1st_callback);
-  auto sub16 = node->create_subscription<eagleye_msgs::msg::YawrateOffset>("yaw_rate_offset_2nd", rclcpp::QoS(10), yaw_rate_offset_2nd_callback);
-  auto sub17 = node->create_subscription<eagleye_msgs::msg::SlipAngle>("slip_angle", rclcpp::QoS(10), slip_angle_callback);
-  auto sub18 = node->create_subscription<eagleye_msgs::msg::Position>("enu_relative_pos", rclcpp::QoS(10), enu_relative_pos_callback);
-  auto sub19 = node->create_subscription<geometry_msgs::msg::Vector3Stamped>("enu_vel", rclcpp::QoS(10), enu_vel_callback);
-  auto sub20 = node->create_subscription<eagleye_msgs::msg::Height>("height", rclcpp::QoS(10), height_callback);
-  auto sub21 = node->create_subscription<eagleye_msgs::msg::Pitching>("pitching", rclcpp::QoS(10), pitching_callback);
-  auto sub22 = node->create_subscription<eagleye_msgs::msg::Position>("enu_absolute_pos", rclcpp::QoS(10), enu_absolute_pos_callback);
-  auto sub23 = node->create_subscription<eagleye_msgs::msg::Position>("enu_absolute_pos_interpolate", rclcpp::QoS(10), enu_absolute_pos_interpolate_callback);
-  auto sub24 = node->create_subscription<sensor_msgs::msg::NavSatFix>("fix", rclcpp::QoS(10), eagleye_fix_callback);
-  auto sub25 = node->create_subscription<geometry_msgs::msg::TwistStamped>("twist", rclcpp::QoS(10), eagleye_twist_callback);
-  auto sub26 = node->create_subscription<eagleye_msgs::msg::Rolling>("rolling", rclcpp::QoS(10), rolling_callback);
-  auto sub27 = node->create_subscription<geometry_msgs::msg::TwistStamped>(comparison_twist_topic_name, 1000, comparison_velocity_callback);
-  auto sub28 = node->create_subscription<geometry_msgs::msg::TwistStamped>("velocity", 1000, correction_velocity_callback);
-
-  rclcpp::spin(node);
-
+  rclcpp::spin(std::make_shared<MonitorNode>());
   return 0;
 }

--- a/eagleye_rt/src/position_interpolate_node.cpp
+++ b/eagleye_rt/src/position_interpolate_node.cpp
@@ -102,7 +102,7 @@ private:
   eagleye_msgs::msg::Position enu_absolute_pos_interpolate_;
   sensor_msgs::msg::NavSatFix eagleye_fix_;
   PositionInterpolateParameter position_interpolate_parameter_;
-  PositionInterpolateStatus position_interpolate_status_;
+  PositionInterpolateStatus position_interpolate_status_ = {};
 
   rclcpp::Publisher<eagleye_msgs::msg::Position>::SharedPtr pub_pos_;
   rclcpp::Publisher<sensor_msgs::msg::NavSatFix>::SharedPtr pub_fix_;

--- a/eagleye_rt/src/position_interpolate_node.cpp
+++ b/eagleye_rt/src/position_interpolate_node.cpp
@@ -28,128 +28,147 @@
  * Author MapIV Sekino
  */
 
-#include "rclcpp/rclcpp.hpp"
 #include "eagleye_coordinate/eagleye_coordinate.hpp"
 #include "eagleye_navigation/eagleye_navigation.hpp"
+#include "rclcpp/rclcpp.hpp"
 
-static eagleye_msgs::msg::Position enu_absolute_pos;
-static geometry_msgs::msg::Vector3Stamped enu_vel;
-static eagleye_msgs::msg::Height height;
-static eagleye_msgs::msg::Position gnss_smooth_pos;
-static nmea_msgs::msg::Gpgga gga;
-static eagleye_msgs::msg::Heading heading_interpolate_3rd;
-
-static eagleye_msgs::msg::Position enu_absolute_pos_interpolate;
-static sensor_msgs::msg::NavSatFix eagleye_fix;
-rclcpp::Publisher<eagleye_msgs::msg::Position>::SharedPtr pub1;
-rclcpp::Publisher<sensor_msgs::msg::NavSatFix>::SharedPtr pub2;
-
-struct PositionInterpolateParameter position_interpolate_parameter;
-struct PositionInterpolateStatus position_interpolate_status;
-
-std::string node_name = "eagleye_position_interpolate";
-
-void gga_callback(const nmea_msgs::msg::Gpgga::ConstSharedPtr msg)
+class PositionInterpolateNode : public rclcpp::Node
 {
-  gga = *msg;
-}
-
-void enu_absolute_pos_callback(const eagleye_msgs::msg::Position::ConstSharedPtr msg)
-{
-  enu_absolute_pos = *msg;
-}
-
-void gnss_smooth_pos_enu_callback(const eagleye_msgs::msg::Position::ConstSharedPtr msg)
-{
-  gnss_smooth_pos = *msg;
-}
-
-void height_callback(const eagleye_msgs::msg::Height::ConstSharedPtr msg)
-{
-  height = *msg;
-}
-
-void heading_interpolate_3rd_callback(const eagleye_msgs::msg::Heading::ConstSharedPtr msg)
-{
-  heading_interpolate_3rd = *msg;
-}
-
-void enu_vel_callback(const geometry_msgs::msg::Vector3Stamped::ConstSharedPtr msg)
-{
-  rclcpp::Time ros_clock(gga.header.stamp);
-  auto gga_time = ros_clock.seconds();
-
-  enu_vel = *msg;
-  enu_absolute_pos_interpolate.header = msg->header;
-  enu_absolute_pos_interpolate.header.frame_id = "base_link";
-  eagleye_fix.header = msg->header;
-  eagleye_fix.header.frame_id = "gnss";
-  position_interpolate_estimate(enu_absolute_pos,enu_vel,gnss_smooth_pos,height,heading_interpolate_3rd,position_interpolate_parameter,&position_interpolate_status,&enu_absolute_pos_interpolate,&eagleye_fix);
-  if (enu_absolute_pos.status.enabled_status == true)
+public:
+  PositionInterpolateNode() : Node("eagleye_position_interpolate")
   {
-    if(eagleye_fix.latitude == 0 && eagleye_fix.longitude == 0)
-    {
-      RCLCPP_WARN(rclcpp::get_logger(node_name), "eagleye_fix is not published because latitude and longitude are 0.");
+    std::string subscribe_gga_topic_name = "gnss/gga";
+
+    std::string yaml_file;
+    this->declare_parameter("yaml_file", yaml_file);
+    this->get_parameter("yaml_file", yaml_file);
+    std::cout << "yaml_file: " << yaml_file << std::endl;
+
+    try {
+      YAML::Node conf = YAML::LoadFile(yaml_file);
+
+      position_interpolate_parameter_.imu_rate =
+        conf["/**"]["ros__parameters"]["common"]["imu_rate"].as<double>();
+      position_interpolate_parameter_.stop_judgment_threshold =
+        conf["/**"]["ros__parameters"]["common"]["stop_judgment_threshold"].as<double>();
+      position_interpolate_parameter_.sync_search_period =
+        conf["/**"]["ros__parameters"]["position_interpolate"]["sync_search_period"].as<double>();
+      position_interpolate_parameter_.proc_noise =
+        conf["/**"]["ros__parameters"]["position_interpolate"]["proc_noise"].as<double>();
+
+      std::cout << "imu_rate " << position_interpolate_parameter_.imu_rate << std::endl;
+      std::cout << "stop_judgment_threshold "
+                << position_interpolate_parameter_.stop_judgment_threshold << std::endl;
+      std::cout << "sync_search_period " << position_interpolate_parameter_.sync_search_period
+                << std::endl;
+    } catch (YAML::Exception& e) {
+      std::cerr << "\033[1;31mheading_interpolate Node YAML Error: " << e.msg << "\033[0m"
+                << std::endl;
+      exit(3);
     }
-    else
-    {
-      pub1->publish(enu_absolute_pos_interpolate);
-      pub2->publish(eagleye_fix);
+
+    sub_enu_vel_ = this->create_subscription<geometry_msgs::msg::Vector3Stamped>(
+      "enu_vel", rclcpp::QoS(10),
+      std::bind(&PositionInterpolateNode::enuVelCallback, this, std::placeholders::_1));
+    sub_enu_absolute_pos_ = this->create_subscription<eagleye_msgs::msg::Position>(
+      "enu_absolute_pos", rclcpp::QoS(10),
+      std::bind(&PositionInterpolateNode::enuAbsolutePosCallback, this, std::placeholders::_1));
+    sub_gnss_smooth_pos_ = this->create_subscription<eagleye_msgs::msg::Position>(
+      "gnss_smooth_pos_enu", rclcpp::QoS(10),
+      std::bind(
+        &PositionInterpolateNode::gnssSmootPosEnuCallback, this, std::placeholders::_1));
+    sub_height_ = this->create_subscription<eagleye_msgs::msg::Height>(
+      "height", rclcpp::QoS(10),
+      std::bind(&PositionInterpolateNode::heightCallback, this, std::placeholders::_1));
+    sub_gga_ = this->create_subscription<nmea_msgs::msg::Gpgga>(
+      subscribe_gga_topic_name, rclcpp::QoS(10),
+      std::bind(&PositionInterpolateNode::ggaCallback, this, std::placeholders::_1));
+    sub_heading_interpolate_3rd_ = this->create_subscription<eagleye_msgs::msg::Heading>(
+      "heading_interpolate_3rd", rclcpp::QoS(10),
+      std::bind(
+        &PositionInterpolateNode::headingInterpolate3rdCallback, this, std::placeholders::_1));
+    pub_pos_ = this->create_publisher<eagleye_msgs::msg::Position>(
+      "enu_absolute_pos_interpolate", rclcpp::QoS(10));
+    pub_fix_ = this->create_publisher<sensor_msgs::msg::NavSatFix>("fix", rclcpp::QoS(10));
+  }
+
+private:
+  eagleye_msgs::msg::Position enu_absolute_pos_;
+  geometry_msgs::msg::Vector3Stamped enu_vel_;
+  eagleye_msgs::msg::Height height_;
+  eagleye_msgs::msg::Position gnss_smooth_pos_;
+  nmea_msgs::msg::Gpgga gga_;
+  eagleye_msgs::msg::Heading heading_interpolate_3rd_;
+  eagleye_msgs::msg::Position enu_absolute_pos_interpolate_;
+  sensor_msgs::msg::NavSatFix eagleye_fix_;
+  PositionInterpolateParameter position_interpolate_parameter_;
+  PositionInterpolateStatus position_interpolate_status_;
+
+  rclcpp::Publisher<eagleye_msgs::msg::Position>::SharedPtr pub_pos_;
+  rclcpp::Publisher<sensor_msgs::msg::NavSatFix>::SharedPtr pub_fix_;
+  rclcpp::Subscription<geometry_msgs::msg::Vector3Stamped>::SharedPtr sub_enu_vel_;
+  rclcpp::Subscription<eagleye_msgs::msg::Position>::SharedPtr sub_enu_absolute_pos_;
+  rclcpp::Subscription<eagleye_msgs::msg::Position>::SharedPtr sub_gnss_smooth_pos_;
+  rclcpp::Subscription<eagleye_msgs::msg::Height>::SharedPtr sub_height_;
+  rclcpp::Subscription<nmea_msgs::msg::Gpgga>::SharedPtr sub_gga_;
+  rclcpp::Subscription<eagleye_msgs::msg::Heading>::SharedPtr sub_heading_interpolate_3rd_;
+
+  void ggaCallback(const nmea_msgs::msg::Gpgga::ConstSharedPtr msg) { gga_ = *msg; }
+
+  void enuAbsolutePosCallback(const eagleye_msgs::msg::Position::ConstSharedPtr msg)
+  {
+    enu_absolute_pos_ = *msg;
+  }
+
+  void gnssSmootPosEnuCallback(const eagleye_msgs::msg::Position::ConstSharedPtr msg)
+  {
+    gnss_smooth_pos_ = *msg;
+  }
+
+  void heightCallback(const eagleye_msgs::msg::Height::ConstSharedPtr msg) { height_ = *msg; }
+
+  void headingInterpolate3rdCallback(const eagleye_msgs::msg::Heading::ConstSharedPtr msg)
+  {
+    heading_interpolate_3rd_ = *msg;
+  }
+
+  void enuVelCallback(const geometry_msgs::msg::Vector3Stamped::ConstSharedPtr msg)
+  {
+    rclcpp::Time ros_clock(gga_.header.stamp);
+    auto gga_time = ros_clock.seconds();
+
+    enu_vel_ = *msg;
+    enu_absolute_pos_interpolate_.header = msg->header;
+    enu_absolute_pos_interpolate_.header.frame_id = "base_link";
+    eagleye_fix_.header = msg->header;
+    eagleye_fix_.header.frame_id = "gnss";
+    position_interpolate_estimate(
+      enu_absolute_pos_, enu_vel_, gnss_smooth_pos_, height_, heading_interpolate_3rd_,
+      position_interpolate_parameter_, &position_interpolate_status_,
+      &enu_absolute_pos_interpolate_, &eagleye_fix_);
+    if (enu_absolute_pos_.status.enabled_status == true) {
+      if (eagleye_fix_.latitude == 0 && eagleye_fix_.longitude == 0) {
+        RCLCPP_WARN(
+          this->get_logger(),
+          "eagleye_fix is not published because latitude and longitude are 0.");
+      } else {
+        pub_pos_->publish(enu_absolute_pos_interpolate_);
+        pub_fix_->publish(eagleye_fix_);
+      }
+    } else if (gga_time != 0) {
+      sensor_msgs::msg::NavSatFix fix;
+      fix.header = gga_.header;
+      fix.latitude = gga_.lat;
+      fix.longitude = gga_.lon;
+      fix.altitude = gga_.alt + gga_.undulation;
+      pub_fix_->publish(fix);
     }
   }
-  else if (gga_time != 0)
-  {
-    sensor_msgs::msg::NavSatFix fix;
-    fix.header = gga.header;
-    fix.latitude = gga.lat;
-    fix.longitude = gga.lon;
-    fix.altitude = gga.alt + gga.undulation;
-    pub2->publish(fix);
-  }
-}
+};
 
 int main(int argc, char** argv)
 {
   rclcpp::init(argc, argv);
-  auto node = rclcpp::Node::make_shared(node_name);
-
-  std::string subscribe_gga_topic_name = "gnss/gga";
-
-  std::string yaml_file;
-  node->declare_parameter("yaml_file",yaml_file);
-  node->get_parameter("yaml_file",yaml_file);
-  std::cout << "yaml_file: " << yaml_file << std::endl;
-
-  try
-  {
-    YAML::Node conf = YAML::LoadFile(yaml_file);
-
-    position_interpolate_parameter.imu_rate = conf["/**"]["ros__parameters"]["common"]["imu_rate"].as<double>();
-    position_interpolate_parameter.stop_judgment_threshold = conf["/**"]["ros__parameters"]["common"]["stop_judgment_threshold"].as<double>();
-    position_interpolate_parameter.sync_search_period = conf["/**"]["ros__parameters"]["position_interpolate"]["sync_search_period"].as<double>();
-    position_interpolate_parameter.proc_noise = conf["/**"]["ros__parameters"]["position_interpolate"]["proc_noise"].as<double>();
-
-    std::cout << "imu_rate " << position_interpolate_parameter.imu_rate << std::endl;
-    std::cout << "stop_judgment_threshold " << position_interpolate_parameter.stop_judgment_threshold << std::endl;
-    std::cout << "sync_search_period " << position_interpolate_parameter.sync_search_period << std::endl;
-  }
-  catch (YAML::Exception& e)
-  {
-    std::cerr << "\033[1;31mheading_interpolate Node YAML Error: " << e.msg << "\033[0m" << std::endl;
-    exit(3);
-  }
-
-
-  auto sub1 = node->create_subscription<geometry_msgs::msg::Vector3Stamped>("enu_vel", rclcpp::QoS(10), enu_vel_callback); //ros::TransportHints().tcpNoDelay()
-  auto sub2 = node->create_subscription<eagleye_msgs::msg::Position>("enu_absolute_pos", rclcpp::QoS(10), enu_absolute_pos_callback); //ros::TransportHints().tcpNoDelay()
-  auto sub3 = node->create_subscription<eagleye_msgs::msg::Position>("gnss_smooth_pos_enu", rclcpp::QoS(10), gnss_smooth_pos_enu_callback); //ros::TransportHints().tcpNoDelay()
-  auto sub4 = node->create_subscription<eagleye_msgs::msg::Height>("height", rclcpp::QoS(10), height_callback); //ros::TransportHints().tcpNoDelay()
-  auto sub5 = node->create_subscription<nmea_msgs::msg::Gpgga>(subscribe_gga_topic_name, rclcpp::QoS(10), gga_callback); //ros::TransportHints().tcpNoDelay()
-  auto sub6 = node->create_subscription<eagleye_msgs::msg::Heading>("heading_interpolate_3rd", rclcpp::QoS(10), heading_interpolate_3rd_callback); //ros::TransportHints().tcpNoDelay()
-  pub1 = node->create_publisher<eagleye_msgs::msg::Position>("enu_absolute_pos_interpolate", rclcpp::QoS(10));
-  pub2 = node->create_publisher<sensor_msgs::msg::NavSatFix>("fix", rclcpp::QoS(10));
-
-  rclcpp::spin(node);
-
+  rclcpp::spin(std::make_shared<PositionInterpolateNode>());
   return 0;
 }

--- a/eagleye_rt/src/position_node.cpp
+++ b/eagleye_rt/src/position_node.cpp
@@ -158,7 +158,7 @@ private:
   geometry_msgs::msg::Vector3Stamped enu_vel_;
   nmea_msgs::msg::Gpgga gga_;
   PositionParameter position_parameter_;
-  PositionStatus position_status_;
+  PositionStatus position_status_ = {};
   std::string use_gnss_mode_;
   bool use_can_less_mode_ = false;
 

--- a/eagleye_rt/src/position_node.cpp
+++ b/eagleye_rt/src/position_node.cpp
@@ -28,9 +28,9 @@
  * Author MapIV Sekino
  */
 
-#include "rclcpp/rclcpp.hpp"
 #include "eagleye_coordinate/eagleye_coordinate.hpp"
 #include "eagleye_navigation/eagleye_navigation.hpp"
+#include "rclcpp/rclcpp.hpp"
 
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
@@ -40,209 +40,229 @@
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #endif
 
-static rtklib_msgs::msg::RtklibNav rtklib_nav;
-static geometry_msgs::msg::TwistStamped velocity;
-static eagleye_msgs::msg::StatusStamped velocity_status;
-static eagleye_msgs::msg::VelocityScaleFactor velocity_scale_factor;
-static eagleye_msgs::msg::Distance distance;
-static eagleye_msgs::msg::Heading heading_interpolate_3rd;
-static eagleye_msgs::msg::Position enu_absolute_pos;
-static geometry_msgs::msg::Vector3Stamped enu_vel;
-static nmea_msgs::msg::Gpgga gga;
-rclcpp::Publisher<eagleye_msgs::msg::Position>::SharedPtr pub;
-
-struct PositionParameter position_parameter;
-struct PositionStatus position_status;
-
-std::string use_gnss_mode;
-static bool use_can_less_mode;
-
-rclcpp::Clock clock_(RCL_ROS_TIME);
-tf2_ros::Buffer tfBuffer_(std::make_shared<rclcpp::Clock>(clock_));
-
-std::string node_name = "eagleye_position";
-
-void rtklib_nav_callback(const rtklib_msgs::msg::RtklibNav::ConstSharedPtr msg)
+class PositionNode : public rclcpp::Node
 {
-  rtklib_nav = *msg;
-}
-
-void velocity_callback(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg)
-{
-  velocity = *msg;
-}
-
-void velocity_status_callback(const eagleye_msgs::msg::StatusStamped::ConstSharedPtr msg)
-{
-  velocity_status = *msg;
-}
-
-void velocity_scale_factor_callback(const eagleye_msgs::msg::VelocityScaleFactor::ConstSharedPtr msg)
-{
-  velocity_scale_factor = *msg;
-}
-
-void distance_callback(const eagleye_msgs::msg::Distance::ConstSharedPtr msg)
-{
-  distance = *msg;
-}
-
-void heading_interpolate_3rd_callback(const eagleye_msgs::msg::Heading::ConstSharedPtr msg)
-{
-  heading_interpolate_3rd = *msg;
-}
-
-void gga_callback(const nmea_msgs::msg::Gpgga::ConstSharedPtr msg)
-{
-  gga = *msg;
-}
-
-
-void on_timer()
-{
-  geometry_msgs::msg::TransformStamped transformStamped;
-  try
+public:
+  PositionNode()
+  : Node("eagleye_position"),
+    tf_buffer_(this->get_clock()),
+    tf_listener_(tf_buffer_)
   {
-    transformStamped = tfBuffer_.lookupTransform(position_parameter.tf_gnss_parent_frame, position_parameter.tf_gnss_child_frame, tf2::TimePointZero);
+    std::string subscribe_rtklib_nav_topic_name = "gnss/rtklib_nav";
+    std::string subscribe_gga_topic_name = "gnss/gga";
 
-    position_parameter.tf_gnss_translation_x = transformStamped.transform.translation.x;
-    position_parameter.tf_gnss_translation_y = transformStamped.transform.translation.y;
-    position_parameter.tf_gnss_translation_z = transformStamped.transform.translation.z;
-    position_parameter.tf_gnss_rotation_x = transformStamped.transform.rotation.x;
-    position_parameter.tf_gnss_rotation_y = transformStamped.transform.rotation.y;
-    position_parameter.tf_gnss_rotation_z = transformStamped.transform.rotation.z;
-    position_parameter.tf_gnss_rotation_w = transformStamped.transform.rotation.w;
-  }
-  catch (tf2::TransformException& ex)
-  {
-    RCLCPP_WARN(rclcpp::get_logger(node_name), "%s", ex.what());
-    return;
-  }
-}
+    std::string yaml_file;
+    this->declare_parameter("yaml_file", yaml_file);
+    this->get_parameter("yaml_file", yaml_file);
+    std::cout << "yaml_file: " << yaml_file << std::endl;
 
-void enu_vel_callback(const geometry_msgs::msg::Vector3Stamped::ConstSharedPtr msg)
-{
-  if(use_can_less_mode && !velocity_status.status.enabled_status) return;
+    try {
+      YAML::Node conf = YAML::LoadFile(yaml_file);
 
-  eagleye_msgs::msg::StatusStamped velocity_enable_status;
-  if(use_can_less_mode)
-  {
-    velocity_enable_status = velocity_status;
-  }
-  else
-  {
-    velocity_enable_status.header = velocity_scale_factor.header;
-    velocity_enable_status.status = velocity_scale_factor.status;
+      use_gnss_mode_ = conf["/**"]["ros__parameters"]["use_gnss_mode"].as<std::string>();
+      use_can_less_mode_ = conf["/**"]["ros__parameters"]["use_can_less_mode"].as<bool>();
+
+      position_parameter_.ecef_base_pos_x =
+        conf["/**"]["ros__parameters"]["ecef_base_pos"]["x"].as<double>();
+      position_parameter_.ecef_base_pos_y =
+        conf["/**"]["ros__parameters"]["ecef_base_pos"]["y"].as<double>();
+      position_parameter_.ecef_base_pos_z =
+        conf["/**"]["ros__parameters"]["ecef_base_pos"]["z"].as<double>();
+      position_parameter_.tf_gnss_parent_frame =
+        conf["/**"]["ros__parameters"]["tf_gnss_frame"]["parent"].as<std::string>();
+      position_parameter_.tf_gnss_child_frame =
+        conf["/**"]["ros__parameters"]["tf_gnss_frame"]["child"].as<std::string>();
+      position_parameter_.imu_rate =
+        conf["/**"]["ros__parameters"]["common"]["imu_rate"].as<double>();
+      position_parameter_.gnss_rate =
+        conf["/**"]["ros__parameters"]["common"]["gnss_rate"].as<double>();
+      position_parameter_.moving_judgment_threshold =
+        conf["/**"]["ros__parameters"]["common"]["moving_judgment_threshold"].as<double>();
+      position_parameter_.estimated_interval =
+        conf["/**"]["ros__parameters"]["position"]["estimated_interval"].as<double>();
+      position_parameter_.update_distance =
+        conf["/**"]["ros__parameters"]["position"]["update_distance"].as<double>();
+      position_parameter_.outlier_threshold =
+        conf["/**"]["ros__parameters"]["position"]["outlier_threshold"].as<double>();
+      position_parameter_.gnss_receiving_threshold =
+        conf["/**"]["ros__parameters"]["position"]["gnss_receiving_threshold"].as<double>();
+      position_parameter_.outlier_ratio_threshold =
+        conf["/**"]["ros__parameters"]["position"]["outlier_ratio_threshold"].as<double>();
+      position_parameter_.gnss_error_covariance =
+        conf["/**"]["ros__parameters"]["position"]["gnss_error_covariance"].as<double>();
+
+      std::cout << "use_gnss_mode " << use_gnss_mode_ << std::endl;
+      std::cout << "use_can_less_mode " << use_can_less_mode_ << std::endl;
+      std::cout << "subscribe_rtklib_nav_topic_name " << subscribe_rtklib_nav_topic_name
+                << std::endl;
+      std::cout << "ecef_base_pos_x " << position_parameter_.ecef_base_pos_x << std::endl;
+      std::cout << "ecef_base_pos_y " << position_parameter_.ecef_base_pos_y << std::endl;
+      std::cout << "ecef_base_pos_z " << position_parameter_.ecef_base_pos_z << std::endl;
+      std::cout << "tf_gnss_frame/parent " << position_parameter_.tf_gnss_parent_frame
+                << std::endl;
+      std::cout << "tf_gnss_frame/child " << position_parameter_.tf_gnss_child_frame << std::endl;
+      std::cout << "imu_rate " << position_parameter_.imu_rate << std::endl;
+      std::cout << "gnss_rate " << position_parameter_.gnss_rate << std::endl;
+      std::cout << "moving_judgment_threshold " << position_parameter_.moving_judgment_threshold
+                << std::endl;
+      std::cout << "estimated_interval " << position_parameter_.estimated_interval << std::endl;
+      std::cout << "update_distance " << position_parameter_.update_distance << std::endl;
+      std::cout << "outlier_threshold " << position_parameter_.outlier_threshold << std::endl;
+      std::cout << "gnss_receiving_threshold " << position_parameter_.gnss_receiving_threshold
+                << std::endl;
+      std::cout << "outlier_ratio_threshold " << position_parameter_.outlier_ratio_threshold
+                << std::endl;
+    } catch (YAML::Exception& e) {
+      std::cerr << "\033[1;31mposition Node YAML Error: " << e.msg << "\033[0m" << std::endl;
+      exit(3);
+    }
+
+    sub_enu_vel_ = this->create_subscription<geometry_msgs::msg::Vector3Stamped>(
+      "enu_vel", 1000,
+      std::bind(&PositionNode::enuVelCallback, this, std::placeholders::_1));
+    sub_rtklib_nav_ = this->create_subscription<rtklib_msgs::msg::RtklibNav>(
+      subscribe_rtklib_nav_topic_name, 1000,
+      std::bind(&PositionNode::rtklibNavCallback, this, std::placeholders::_1));
+    sub_velocity_ = this->create_subscription<geometry_msgs::msg::TwistStamped>(
+      "velocity", rclcpp::QoS(10),
+      std::bind(&PositionNode::velocityCallback, this, std::placeholders::_1));
+    sub_velocity_status_ = this->create_subscription<eagleye_msgs::msg::StatusStamped>(
+      "velocity_status", rclcpp::QoS(10),
+      std::bind(&PositionNode::velocityStatusCallback, this, std::placeholders::_1));
+    sub_velocity_scale_factor_ = this->create_subscription<eagleye_msgs::msg::VelocityScaleFactor>(
+      "velocity_scale_factor", 1000,
+      std::bind(&PositionNode::velocityScaleFactorCallback, this, std::placeholders::_1));
+    sub_distance_ = this->create_subscription<eagleye_msgs::msg::Distance>(
+      "distance", 1000,
+      std::bind(&PositionNode::distanceCallback, this, std::placeholders::_1));
+    sub_heading_interpolate_3rd_ = this->create_subscription<eagleye_msgs::msg::Heading>(
+      "heading_interpolate_3rd", 1000,
+      std::bind(&PositionNode::headingInterpolate3rdCallback, this, std::placeholders::_1));
+    sub_gga_ = this->create_subscription<nmea_msgs::msg::Gpgga>(
+      subscribe_gga_topic_name, 1000,
+      std::bind(&PositionNode::ggaCallback, this, std::placeholders::_1));
+    pub_ = this->create_publisher<eagleye_msgs::msg::Position>("enu_absolute_pos", 1000);
+
+    timer_ = this->create_wall_timer(
+      std::chrono::milliseconds(500), std::bind(&PositionNode::onTimer, this));
   }
 
-  enu_vel = *msg;
-  enu_absolute_pos.header = msg->header;
-  enu_absolute_pos.header.frame_id = "base_link";
-  if (use_gnss_mode == "rtklib" || use_gnss_mode == "RTKLIB") // use RTKLIB mode
-    position_estimate(rtklib_nav, velocity, velocity_enable_status, distance, heading_interpolate_3rd, enu_vel,
-      position_parameter, &position_status, &enu_absolute_pos);
-  else if (use_gnss_mode == "nmea" || use_gnss_mode == "NMEA") // use NMEA mode
-    position_estimate(gga, velocity, velocity_enable_status, distance, heading_interpolate_3rd, enu_vel,
-      position_parameter, &position_status, &enu_absolute_pos);
-  if (enu_absolute_pos.status.estimate_status == true)
+private:
+  rtklib_msgs::msg::RtklibNav rtklib_nav_;
+  geometry_msgs::msg::TwistStamped velocity_;
+  eagleye_msgs::msg::StatusStamped velocity_status_;
+  eagleye_msgs::msg::VelocityScaleFactor velocity_scale_factor_;
+  eagleye_msgs::msg::Distance distance_;
+  eagleye_msgs::msg::Heading heading_interpolate_3rd_;
+  eagleye_msgs::msg::Position enu_absolute_pos_;
+  geometry_msgs::msg::Vector3Stamped enu_vel_;
+  nmea_msgs::msg::Gpgga gga_;
+  PositionParameter position_parameter_;
+  PositionStatus position_status_;
+  std::string use_gnss_mode_;
+  bool use_can_less_mode_ = false;
+
+  tf2_ros::Buffer tf_buffer_;
+  tf2_ros::TransformListener tf_listener_;
+  rclcpp::TimerBase::SharedPtr timer_;
+  rclcpp::Publisher<eagleye_msgs::msg::Position>::SharedPtr pub_;
+  rclcpp::Subscription<geometry_msgs::msg::Vector3Stamped>::SharedPtr sub_enu_vel_;
+  rclcpp::Subscription<rtklib_msgs::msg::RtklibNav>::SharedPtr sub_rtklib_nav_;
+  rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr sub_velocity_;
+  rclcpp::Subscription<eagleye_msgs::msg::StatusStamped>::SharedPtr sub_velocity_status_;
+  rclcpp::Subscription<eagleye_msgs::msg::VelocityScaleFactor>::SharedPtr
+    sub_velocity_scale_factor_;
+  rclcpp::Subscription<eagleye_msgs::msg::Distance>::SharedPtr sub_distance_;
+  rclcpp::Subscription<eagleye_msgs::msg::Heading>::SharedPtr sub_heading_interpolate_3rd_;
+  rclcpp::Subscription<nmea_msgs::msg::Gpgga>::SharedPtr sub_gga_;
+
+  void rtklibNavCallback(const rtklib_msgs::msg::RtklibNav::ConstSharedPtr msg)
   {
-    pub->publish(enu_absolute_pos);
+    rtklib_nav_ = *msg;
   }
-  enu_absolute_pos.status.estimate_status = false;
-}
+
+  void velocityCallback(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg)
+  {
+    velocity_ = *msg;
+  }
+
+  void velocityStatusCallback(const eagleye_msgs::msg::StatusStamped::ConstSharedPtr msg)
+  {
+    velocity_status_ = *msg;
+  }
+
+  void velocityScaleFactorCallback(
+    const eagleye_msgs::msg::VelocityScaleFactor::ConstSharedPtr msg)
+  {
+    velocity_scale_factor_ = *msg;
+  }
+
+  void distanceCallback(const eagleye_msgs::msg::Distance::ConstSharedPtr msg)
+  {
+    distance_ = *msg;
+  }
+
+  void headingInterpolate3rdCallback(const eagleye_msgs::msg::Heading::ConstSharedPtr msg)
+  {
+    heading_interpolate_3rd_ = *msg;
+  }
+
+  void ggaCallback(const nmea_msgs::msg::Gpgga::ConstSharedPtr msg) { gga_ = *msg; }
+
+  void onTimer()
+  {
+    geometry_msgs::msg::TransformStamped transformStamped;
+    try {
+      transformStamped = tf_buffer_.lookupTransform(
+        position_parameter_.tf_gnss_parent_frame, position_parameter_.tf_gnss_child_frame,
+        tf2::TimePointZero);
+
+      position_parameter_.tf_gnss_translation_x = transformStamped.transform.translation.x;
+      position_parameter_.tf_gnss_translation_y = transformStamped.transform.translation.y;
+      position_parameter_.tf_gnss_translation_z = transformStamped.transform.translation.z;
+      position_parameter_.tf_gnss_rotation_x = transformStamped.transform.rotation.x;
+      position_parameter_.tf_gnss_rotation_y = transformStamped.transform.rotation.y;
+      position_parameter_.tf_gnss_rotation_z = transformStamped.transform.rotation.z;
+      position_parameter_.tf_gnss_rotation_w = transformStamped.transform.rotation.w;
+    } catch (tf2::TransformException& ex) {
+      RCLCPP_WARN(this->get_logger(), "%s", ex.what());
+      return;
+    }
+  }
+
+  void enuVelCallback(const geometry_msgs::msg::Vector3Stamped::ConstSharedPtr msg)
+  {
+    if (use_can_less_mode_ && !velocity_status_.status.enabled_status) return;
+
+    eagleye_msgs::msg::StatusStamped velocity_enable_status;
+    if (use_can_less_mode_) {
+      velocity_enable_status = velocity_status_;
+    } else {
+      velocity_enable_status.header = velocity_scale_factor_.header;
+      velocity_enable_status.status = velocity_scale_factor_.status;
+    }
+
+    enu_vel_ = *msg;
+    enu_absolute_pos_.header = msg->header;
+    enu_absolute_pos_.header.frame_id = "base_link";
+    if (use_gnss_mode_ == "rtklib" || use_gnss_mode_ == "RTKLIB")
+      position_estimate(
+        rtklib_nav_, velocity_, velocity_enable_status, distance_, heading_interpolate_3rd_,
+        enu_vel_, position_parameter_, &position_status_, &enu_absolute_pos_);
+    else if (use_gnss_mode_ == "nmea" || use_gnss_mode_ == "NMEA")
+      position_estimate(
+        gga_, velocity_, velocity_enable_status, distance_, heading_interpolate_3rd_, enu_vel_,
+        position_parameter_, &position_status_, &enu_absolute_pos_);
+    if (enu_absolute_pos_.status.estimate_status == true) {
+      pub_->publish(enu_absolute_pos_);
+    }
+    enu_absolute_pos_.status.estimate_status = false;
+  }
+};
 
 int main(int argc, char** argv)
 {
   rclcpp::init(argc, argv);
-  auto node = rclcpp::Node::make_shared(node_name);
-
-  std::string subscribe_rtklib_nav_topic_name = "gnss/rtklib_nav";
-  std::string subscribe_gga_topic_name = "gnss/gga";
-
-  std::string yaml_file;
-  node->declare_parameter("yaml_file",yaml_file);
-  node->get_parameter("yaml_file",yaml_file);
-  std::cout << "yaml_file: " << yaml_file << std::endl;
-
-  try
-  {
-    YAML::Node conf = YAML::LoadFile(yaml_file);
-
-    use_gnss_mode = conf["/**"]["ros__parameters"]["use_gnss_mode"].as<std::string>();
-    use_can_less_mode = conf["/**"]["ros__parameters"]["use_can_less_mode"].as<bool>();
-
-    position_parameter.ecef_base_pos_x = conf["/**"]["ros__parameters"]["ecef_base_pos"]["x"].as<double>();
-    position_parameter.ecef_base_pos_y = conf["/**"]["ros__parameters"]["ecef_base_pos"]["y"].as<double>();
-    position_parameter.ecef_base_pos_z = conf["/**"]["ros__parameters"]["ecef_base_pos"]["z"].as<double>();
-
-    position_parameter.tf_gnss_parent_frame = conf["/**"]["ros__parameters"]["tf_gnss_frame"]["parent"].as<std::string>();
-    position_parameter.tf_gnss_child_frame = conf["/**"]["ros__parameters"]["tf_gnss_frame"]["child"].as<std::string>();
-
-    position_parameter.imu_rate = conf["/**"]["ros__parameters"]["common"]["imu_rate"].as<double>();
-    position_parameter.gnss_rate = conf["/**"]["ros__parameters"]["common"]["gnss_rate"].as<double>();
-    position_parameter.moving_judgment_threshold = conf["/**"]["ros__parameters"]["common"]["moving_judgment_threshold"].as<double>();
-
-    position_parameter.estimated_interval = conf["/**"]["ros__parameters"]["position"]["estimated_interval"].as<double>();
-    position_parameter.update_distance = conf["/**"]["ros__parameters"]["position"]["update_distance"].as<double>();
-    position_parameter.outlier_threshold = conf["/**"]["ros__parameters"]["position"]["outlier_threshold"].as<double>();
-
-    position_parameter.gnss_receiving_threshold = conf["/**"]["ros__parameters"]["position"]["gnss_receiving_threshold"].as<double>();
-    position_parameter.outlier_ratio_threshold = conf["/**"]["ros__parameters"]["position"]["outlier_ratio_threshold"].as<double>();
-
-    position_parameter.gnss_error_covariance = conf["/**"]["ros__parameters"]["position"]["gnss_error_covariance"].as<double>();
-
-    std::cout<< "use_gnss_mode " << use_gnss_mode << std::endl;
-    std::cout<< "use_can_less_mode " << use_can_less_mode << std::endl;
-
-    std::cout<< "subscribe_rtklib_nav_topic_name " << subscribe_rtklib_nav_topic_name << std::endl;
-
-    std::cout<< "ecef_base_pos_x " << position_parameter.ecef_base_pos_x << std::endl;
-    std::cout<< "ecef_base_pos_y " << position_parameter.ecef_base_pos_y << std::endl;
-    std::cout<< "ecef_base_pos_z " << position_parameter.ecef_base_pos_z << std::endl;
-
-    std::cout<< "tf_gnss_frame/parent " << position_parameter.tf_gnss_parent_frame << std::endl;
-    std::cout<< "tf_gnss_frame/child " << position_parameter.tf_gnss_child_frame << std::endl;
-
-    std::cout << "imu_rate " << position_parameter.imu_rate << std::endl;
-    std::cout << "gnss_rate " << position_parameter.gnss_rate << std::endl;
-    std::cout << "moving_judgment_threshold " << position_parameter.moving_judgment_threshold << std::endl;
-
-    std::cout << "estimated_interval " << position_parameter.estimated_interval << std::endl;
-    std::cout << "update_distance " << position_parameter.update_distance << std::endl;
-    std::cout << "outlier_threshold " << position_parameter.outlier_threshold << std::endl;
-    std::cout << "gnss_receiving_threshold " << position_parameter.gnss_receiving_threshold << std::endl;
-    std::cout << "outlier_ratio_threshold " << position_parameter.outlier_ratio_threshold << std::endl;
-  }
-  catch (YAML::Exception& e)
-  {
-    std::cerr << "\033[1;31mposition Node YAML Error: " << e.msg << "\033[0m" << std::endl;
-    exit(3);
-  }
-
-
-  auto sub1 = node->create_subscription<geometry_msgs::msg::Vector3Stamped>("enu_vel", 1000, enu_vel_callback);
-  auto sub2 = node->create_subscription<rtklib_msgs::msg::RtklibNav>(subscribe_rtklib_nav_topic_name, 1000, rtklib_nav_callback);
-  auto sub3 = node->create_subscription<geometry_msgs::msg::TwistStamped>("velocity", rclcpp::QoS(10), velocity_callback);
-  auto sub4 = node->create_subscription<eagleye_msgs::msg::StatusStamped>("velocity_status", rclcpp::QoS(10), velocity_status_callback);
-  auto sub5 = node->create_subscription<eagleye_msgs::msg::VelocityScaleFactor>("velocity_scale_factor", 1000, velocity_scale_factor_callback);
-  auto sub6 = node->create_subscription<eagleye_msgs::msg::Distance>("distance", 1000, distance_callback);
-  auto sub7 = node->create_subscription<eagleye_msgs::msg::Heading>("heading_interpolate_3rd", 1000, heading_interpolate_3rd_callback);
-  auto sub8 = node->create_subscription<nmea_msgs::msg::Gpgga>(subscribe_gga_topic_name, 1000, gga_callback);
-
-  pub = node->create_publisher<eagleye_msgs::msg::Position>("enu_absolute_pos", 1000);
-
-  const auto period_ns =
-      std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::duration<double>(0.5));
-  // auto timer_callback = std::bind(&on_timer, node);
-  auto timer_callback = std::bind(on_timer);
-  auto timer = std::make_shared<rclcpp::GenericTimer<decltype(timer_callback)>>(
-    node->get_clock(), period_ns, std::move(timer_callback),
-    node->get_node_base_interface()->get_context());
-  node->get_node_timers_interface()->add_timer(timer, nullptr);
-
-  tf2_ros::TransformListener listener(tfBuffer_);
-
-  rclcpp::spin(node);
-
+  rclcpp::spin(std::make_shared<PositionNode>());
   return 0;
 }

--- a/eagleye_rt/src/rolling_node.cpp
+++ b/eagleye_rt/src/rolling_node.cpp
@@ -31,104 +31,108 @@
 #include "eagleye_coordinate/eagleye_coordinate.hpp"
 #include "eagleye_navigation/eagleye_navigation.hpp"
 
-rclcpp::Publisher<eagleye_msgs::msg::Rolling>::SharedPtr _rolling_pub;
-
-static geometry_msgs::msg::TwistStamped _velocity_msg;
-static eagleye_msgs::msg::StatusStamped _velocity_status_msg;
-static eagleye_msgs::msg::YawrateOffset _yaw_rate_offset_2nd_msg;
-static eagleye_msgs::msg::YawrateOffset _yaw_rate_offset_stop_msg;
-static sensor_msgs::msg::Imu _imu_msg;
-
-static eagleye_msgs::msg::Rolling _rolling_msg;
-
-struct RollingParameter _rolling_parameter;
-struct RollingStatus _rolling_status;
-
-static bool _use_can_less_mode;
-
-void velocity_callback(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg)
+class RollingNode : public rclcpp::Node
 {
-  _velocity_msg = *msg;
-}
-
-void velocity_status_callback(const eagleye_msgs::msg::StatusStamped::ConstSharedPtr msg)
-{
-  _velocity_status_msg = *msg;
-}
-
-void yaw_rate_offset_stop_callback(const eagleye_msgs::msg::YawrateOffset::ConstSharedPtr msg)
-{
-  _yaw_rate_offset_stop_msg = *msg;
-}
-
-void yaw_rate_offset_2nd_callback(const eagleye_msgs::msg::YawrateOffset::ConstSharedPtr msg)
-{
-  _yaw_rate_offset_2nd_msg = *msg;
-}
-
-void imu_callback(const sensor_msgs::msg::Imu::ConstSharedPtr msg)
-{
-  if(_use_can_less_mode && !_velocity_status_msg.status.enabled_status) return;
-  _imu_msg = *msg;
-  rolling_estimate(_imu_msg, _velocity_msg, _yaw_rate_offset_stop_msg, _yaw_rate_offset_2nd_msg,
-                   _rolling_parameter, &_rolling_status, &_rolling_msg);
-  _rolling_pub->publish(_rolling_msg);
-}
-
-void setParam(rclcpp::Node::SharedPtr node)
-{
-  std::string yaml_file;
-  node->declare_parameter("yaml_file",yaml_file);
-  node->get_parameter("yaml_file",yaml_file);
-  std::cout << "yaml_file: " << yaml_file << std::endl;
-
-  try
+public:
+  RollingNode() : Node("eagleye_rolling")
   {
-    YAML::Node conf = YAML::LoadFile(yaml_file);
+    std::string yaml_file;
+    this->declare_parameter("yaml_file", yaml_file);
+    this->get_parameter("yaml_file", yaml_file);
+    std::cout << "yaml_file: " << yaml_file << std::endl;
 
-    _use_can_less_mode = conf["/**"]["ros__parameters"]["use_can_less_mode"].as<bool>();
-    _rolling_parameter.stop_judgment_threshold = conf["/**"]["ros__parameters"]["common"]["stop_judgment_threshold"].as<double>();
-    _rolling_parameter.filter_process_noise = conf["/**"]["ros__parameters"]["rolling"]["filter_process_noise"].as<double>();
-    _rolling_parameter.filter_observation_noise = conf["/**"]["ros__parameters"]["rolling"]["filter_observation_noise"].as<double>();
+    try {
+      YAML::Node conf = YAML::LoadFile(yaml_file);
 
-    std::cout<< "use_can_less_mode " << _use_can_less_mode << std::endl;
-    std::cout << "stop_judgment_threshold " << _rolling_parameter.stop_judgment_threshold << std::endl;
-    std::cout << "filter_process_noise " << _rolling_parameter.filter_process_noise << std::endl;
-    std::cout << "filter_observation_noise " << _rolling_parameter.filter_observation_noise << std::endl;
+      use_can_less_mode_ = conf["/**"]["ros__parameters"]["use_can_less_mode"].as<bool>();
+      rolling_parameter_.stop_judgment_threshold =
+        conf["/**"]["ros__parameters"]["common"]["stop_judgment_threshold"].as<double>();
+      rolling_parameter_.filter_process_noise =
+        conf["/**"]["ros__parameters"]["rolling"]["filter_process_noise"].as<double>();
+      rolling_parameter_.filter_observation_noise =
+        conf["/**"]["ros__parameters"]["rolling"]["filter_observation_noise"].as<double>();
+
+      std::cout << "use_can_less_mode " << use_can_less_mode_ << std::endl;
+      std::cout << "stop_judgment_threshold " << rolling_parameter_.stop_judgment_threshold
+                << std::endl;
+      std::cout << "filter_process_noise " << rolling_parameter_.filter_process_noise << std::endl;
+      std::cout << "filter_observation_noise " << rolling_parameter_.filter_observation_noise
+                << std::endl;
+    } catch (YAML::Exception& e) {
+      std::cerr << "\033[1;31mrolling Node YAML Error: " << e.msg << "\033[0m" << std::endl;
+      exit(3);
+    }
+
+    sub_imu_ = this->create_subscription<sensor_msgs::msg::Imu>(
+      "imu/data_tf_converted", 1000,
+      std::bind(&RollingNode::imuCallback, this, std::placeholders::_1));
+    sub_velocity_ = this->create_subscription<geometry_msgs::msg::TwistStamped>(
+      "velocity", rclcpp::QoS(10),
+      std::bind(&RollingNode::velocityCallback, this, std::placeholders::_1));
+    sub_velocity_status_ = this->create_subscription<eagleye_msgs::msg::StatusStamped>(
+      "velocity_status", rclcpp::QoS(10),
+      std::bind(&RollingNode::velocityStatusCallback, this, std::placeholders::_1));
+    sub_yaw_rate_offset_2nd_ = this->create_subscription<eagleye_msgs::msg::YawrateOffset>(
+      "yaw_rate_offset_2nd", 1000,
+      std::bind(&RollingNode::yawRateOffset2ndCallback, this, std::placeholders::_1));
+    sub_yaw_rate_offset_stop_ = this->create_subscription<eagleye_msgs::msg::YawrateOffset>(
+      "yaw_rate_offset_stop", 1000,
+      std::bind(&RollingNode::yawRateOffsetStopCallback, this, std::placeholders::_1));
+    pub_ = this->create_publisher<eagleye_msgs::msg::Rolling>("rolling", 1000);
   }
-  catch (YAML::Exception& e)
+
+private:
+  geometry_msgs::msg::TwistStamped velocity_;
+  eagleye_msgs::msg::StatusStamped velocity_status_;
+  eagleye_msgs::msg::YawrateOffset yaw_rate_offset_2nd_;
+  eagleye_msgs::msg::YawrateOffset yaw_rate_offset_stop_;
+  sensor_msgs::msg::Imu imu_;
+  eagleye_msgs::msg::Rolling rolling_;
+  RollingParameter rolling_parameter_;
+  RollingStatus rolling_status_;
+  bool use_can_less_mode_ = false;
+
+  rclcpp::Publisher<eagleye_msgs::msg::Rolling>::SharedPtr pub_;
+  rclcpp::Subscription<sensor_msgs::msg::Imu>::SharedPtr sub_imu_;
+  rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr sub_velocity_;
+  rclcpp::Subscription<eagleye_msgs::msg::StatusStamped>::SharedPtr sub_velocity_status_;
+  rclcpp::Subscription<eagleye_msgs::msg::YawrateOffset>::SharedPtr sub_yaw_rate_offset_2nd_;
+  rclcpp::Subscription<eagleye_msgs::msg::YawrateOffset>::SharedPtr sub_yaw_rate_offset_stop_;
+
+  void velocityCallback(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg)
   {
-    std::cerr << "\033[1;31mrolling Node YAML Error: " << e.msg << "\033[0m" << std::endl;
-    exit(3);
+    velocity_ = *msg;
   }
-}
 
-void rolling_node(rclcpp::Node::SharedPtr node)
-{
-  setParam(node);
+  void velocityStatusCallback(const eagleye_msgs::msg::StatusStamped::ConstSharedPtr msg)
+  {
+    velocity_status_ = *msg;
+  }
 
-  auto imu_sub =
-      node->create_subscription<sensor_msgs::msg::Imu>("imu/data_tf_converted", 1000, imu_callback);
-  auto velocity_sub =
-      node->create_subscription<geometry_msgs::msg::TwistStamped>("velocity", rclcpp::QoS(10), velocity_callback);
-  auto velocity_status_sub =
-      node->create_subscription<eagleye_msgs::msg::StatusStamped>("velocity_status", rclcpp::QoS(10), velocity_status_callback);
-  auto yaw_rate_offset_2nd_sub =
-      node->create_subscription<eagleye_msgs::msg::YawrateOffset>("yaw_rate_offset_2nd", 1000, yaw_rate_offset_2nd_callback);
-  auto yaw_rate_offset_stop_sub =
-      node->create_subscription<eagleye_msgs::msg::YawrateOffset>("yaw_rate_offset_stop", 1000, yaw_rate_offset_stop_callback);
+  void yawRateOffsetStopCallback(const eagleye_msgs::msg::YawrateOffset::ConstSharedPtr msg)
+  {
+    yaw_rate_offset_stop_ = *msg;
+  }
 
-  _rolling_pub = node->create_publisher<eagleye_msgs::msg::Rolling>("rolling", 1000);
+  void yawRateOffset2ndCallback(const eagleye_msgs::msg::YawrateOffset::ConstSharedPtr msg)
+  {
+    yaw_rate_offset_2nd_ = *msg;
+  }
 
-  rclcpp::spin(node);
-}
+  void imuCallback(const sensor_msgs::msg::Imu::ConstSharedPtr msg)
+  {
+    if (use_can_less_mode_ && !velocity_status_.status.enabled_status) return;
+    imu_ = *msg;
+    rolling_estimate(
+      imu_, velocity_, yaw_rate_offset_stop_, yaw_rate_offset_2nd_, rolling_parameter_,
+      &rolling_status_, &rolling_);
+    pub_->publish(rolling_);
+  }
+};
 
 int main(int argc, char** argv)
 {
   rclcpp::init(argc, argv);
-  auto node = rclcpp::Node::make_shared("eagleye_rolling");
-
-  rolling_node(node);
-
+  rclcpp::spin(std::make_shared<RollingNode>());
   return 0;
 }

--- a/eagleye_rt/src/rolling_node.cpp
+++ b/eagleye_rt/src/rolling_node.cpp
@@ -89,7 +89,7 @@ private:
   sensor_msgs::msg::Imu imu_;
   eagleye_msgs::msg::Rolling rolling_;
   RollingParameter rolling_parameter_;
-  RollingStatus rolling_status_;
+  RollingStatus rolling_status_ = {};
   bool use_can_less_mode_ = false;
 
   rclcpp::Publisher<eagleye_msgs::msg::Rolling>::SharedPtr pub_;

--- a/eagleye_rt/src/rtk_dead_reckoning_node.cpp
+++ b/eagleye_rt/src/rtk_dead_reckoning_node.cpp
@@ -28,9 +28,9 @@
  * Author MapIV Sekino
  */
 
-#include "rclcpp/rclcpp.hpp"
 #include "eagleye_coordinate/eagleye_coordinate.hpp"
 #include "eagleye_navigation/eagleye_navigation.hpp"
+#include "rclcpp/rclcpp.hpp"
 
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
@@ -40,158 +40,181 @@
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #endif
 
-static rtklib_msgs::msg::RtklibNav rtklib_nav;
-static nmea_msgs::msg::Gpgga gga;
-static geometry_msgs::msg::Vector3Stamped enu_vel;
-
-static eagleye_msgs::msg::Position enu_absolute_rtk_dead_reckoning;
-static sensor_msgs::msg::NavSatFix eagleye_fix;
-static eagleye_msgs::msg::Heading heading_interpolate_3rd;
-
-rclcpp::Publisher<eagleye_msgs::msg::Position>::SharedPtr pub1;
-rclcpp::Publisher<sensor_msgs::msg::NavSatFix>::SharedPtr pub2;
-
-struct RtkDeadreckoningParameter rtk_dead_reckoning_parameter;
-struct RtkDeadreckoningStatus rtk_dead_reckoning_status;
-
-std::string use_gnss_mode;
-
-rclcpp::Clock clock_(RCL_ROS_TIME);
-tf2_ros::Buffer tfBuffer_(std::make_shared<rclcpp::Clock>(clock_));
-
-void rtklib_nav_callback(const rtklib_msgs::msg::RtklibNav::ConstSharedPtr msg)
+class RtkDeadReckoningNode : public rclcpp::Node
 {
-  rtklib_nav = *msg;
-}
-
-void gga_callback(const nmea_msgs::msg::Gpgga::ConstSharedPtr msg)
-{
-  gga = *msg;
-}
-
-void heading_interpolate_3rd_callback(const eagleye_msgs::msg::Heading::ConstSharedPtr msg)
-{
-  heading_interpolate_3rd = *msg;
-}
-
-
-void on_timer()
-{
-  geometry_msgs::msg::TransformStamped transformStamped;
-  try
+public:
+  RtkDeadReckoningNode()
+  : Node("eagleye_rtk_dead_reckoning"),
+    tf_buffer_(this->get_clock()),
+    tf_listener_(tf_buffer_)
   {
-    transformStamped = tfBuffer_.lookupTransform(rtk_dead_reckoning_parameter.tf_gnss_parent_frame, rtk_dead_reckoning_parameter.tf_gnss_child_frame, tf2::TimePointZero);
+    std::string subscribe_rtklib_nav_topic_name = "gnss/rtklib_nav";
+    std::string subscribe_gga_topic_name = "gnss/gga";
 
-    rtk_dead_reckoning_parameter.tf_gnss_translation_x = transformStamped.transform.translation.x;
-    rtk_dead_reckoning_parameter.tf_gnss_translation_y = transformStamped.transform.translation.y;
-    rtk_dead_reckoning_parameter.tf_gnss_translation_z = transformStamped.transform.translation.z;
-    rtk_dead_reckoning_parameter.tf_gnss_rotation_x = transformStamped.transform.rotation.x;
-    rtk_dead_reckoning_parameter.tf_gnss_rotation_y = transformStamped.transform.rotation.y;
-    rtk_dead_reckoning_parameter.tf_gnss_rotation_z = transformStamped.transform.rotation.z;
-    rtk_dead_reckoning_parameter.tf_gnss_rotation_w = transformStamped.transform.rotation.w;
-  }
-  catch (tf2::TransformException& ex)
-  {
-    // RCLCPP_ERROR(this->get_logger(), "%s", ex.what());
-    return;
-  }
-}
+    std::string yaml_file;
+    this->declare_parameter("yaml_file", yaml_file);
+    this->get_parameter("yaml_file", yaml_file);
+    std::cout << "yaml_file: " << yaml_file << std::endl;
 
-void enu_vel_callback(const geometry_msgs::msg::Vector3Stamped::ConstSharedPtr msg)
-{
-  rclcpp::Time ros_clock(gga.header.stamp);
-  auto gga_time = ros_clock.seconds();
+    try {
+      YAML::Node conf = YAML::LoadFile(yaml_file);
 
-  enu_vel.header = msg->header;
-  enu_vel.vector = msg->vector;
-  enu_absolute_rtk_dead_reckoning.header = msg->header;
-  enu_absolute_rtk_dead_reckoning.header.frame_id = "base_link";
-  eagleye_fix.header = msg->header;
-  eagleye_fix.header.frame_id = "gnss";
-  if (use_gnss_mode == "rtklib" || use_gnss_mode == "RTKLIB") // use RTKLIB mode
-    rtk_dead_reckoning_estimate(rtklib_nav,enu_vel,gga,heading_interpolate_3rd,rtk_dead_reckoning_parameter,&rtk_dead_reckoning_status,&enu_absolute_rtk_dead_reckoning,&eagleye_fix);
-  else if (use_gnss_mode == "nmea" || use_gnss_mode == "NMEA") // use NMEA mode
-    rtk_dead_reckoning_estimate(enu_vel,gga,heading_interpolate_3rd,rtk_dead_reckoning_parameter,&rtk_dead_reckoning_status,&enu_absolute_rtk_dead_reckoning,&eagleye_fix);
-  if (enu_absolute_rtk_dead_reckoning.status.enabled_status == true)
-  {
-    pub1->publish(enu_absolute_rtk_dead_reckoning);
-    pub2->publish(eagleye_fix);
+      use_gnss_mode_ = conf["/**"]["ros__parameters"]["use_gnss_mode"].as<std::string>();
+      rtk_dead_reckoning_parameter_.ecef_base_pos_x =
+        conf["/**"]["ros__parameters"]["ecef_base_pos"]["x"].as<double>();
+      rtk_dead_reckoning_parameter_.ecef_base_pos_y =
+        conf["/**"]["ros__parameters"]["ecef_base_pos"]["y"].as<double>();
+      rtk_dead_reckoning_parameter_.ecef_base_pos_z =
+        conf["/**"]["ros__parameters"]["ecef_base_pos"]["z"].as<double>();
+      rtk_dead_reckoning_parameter_.use_ecef_base_position =
+        conf["/**"]["ros__parameters"]["ecef_base_pos"]["use_ecef_base_position"].as<bool>();
+      rtk_dead_reckoning_parameter_.tf_gnss_parent_frame =
+        conf["/**"]["ros__parameters"]["tf_gnss_frame"]["parent"].as<std::string>();
+      rtk_dead_reckoning_parameter_.tf_gnss_child_frame =
+        conf["/**"]["ros__parameters"]["tf_gnss_frame"]["child"].as<std::string>();
+      rtk_dead_reckoning_parameter_.stop_judgment_threshold =
+        conf["/**"]["ros__parameters"]["common"]["stop_judgment_threshold"].as<double>();
+      rtk_dead_reckoning_parameter_.rtk_fix_STD =
+        conf["/**"]["ros__parameters"]["rtk_dead_reckoning"]["rtk_fix_STD"].as<double>();
+      rtk_dead_reckoning_parameter_.proc_noise =
+        conf["/**"]["ros__parameters"]["rtk_dead_reckoning"]["proc_noise"].as<double>();
+
+      std::cout << "use_gnss_mode " << use_gnss_mode_ << std::endl;
+      std::cout << "ecef_base_pos_x " << rtk_dead_reckoning_parameter_.ecef_base_pos_x
+                << std::endl;
+      std::cout << "ecef_base_pos_y " << rtk_dead_reckoning_parameter_.ecef_base_pos_y
+                << std::endl;
+      std::cout << "ecef_base_pos_z " << rtk_dead_reckoning_parameter_.ecef_base_pos_z
+                << std::endl;
+      std::cout << "use_ecef_base_position "
+                << rtk_dead_reckoning_parameter_.use_ecef_base_position << std::endl;
+      std::cout << "tf_gnss_frame/parent " << rtk_dead_reckoning_parameter_.tf_gnss_parent_frame
+                << std::endl;
+      std::cout << "tf_gnss_frame/child " << rtk_dead_reckoning_parameter_.tf_gnss_child_frame
+                << std::endl;
+      std::cout << "stop_judgment_threshold "
+                << rtk_dead_reckoning_parameter_.stop_judgment_threshold << std::endl;
+      std::cout << "rtk_fix_STD " << rtk_dead_reckoning_parameter_.rtk_fix_STD << std::endl;
+      std::cout << "proc_noise " << rtk_dead_reckoning_parameter_.proc_noise << std::endl;
+    } catch (YAML::Exception& e) {
+      std::cerr << "\033[1;31mrtk_dead_reckoning Node YAML Error: " << e.msg << "\033[0m"
+                << std::endl;
+      exit(3);
+    }
+
+    sub_rtklib_nav_ = this->create_subscription<rtklib_msgs::msg::RtklibNav>(
+      subscribe_rtklib_nav_topic_name, 1000,
+      std::bind(&RtkDeadReckoningNode::rtklibNavCallback, this, std::placeholders::_1));
+    sub_enu_vel_ = this->create_subscription<geometry_msgs::msg::Vector3Stamped>(
+      "enu_vel", 1000,
+      std::bind(&RtkDeadReckoningNode::enuVelCallback, this, std::placeholders::_1));
+    sub_gga_ = this->create_subscription<nmea_msgs::msg::Gpgga>(
+      subscribe_gga_topic_name, 1000,
+      std::bind(&RtkDeadReckoningNode::ggaCallback, this, std::placeholders::_1));
+    sub_heading_interpolate_3rd_ = this->create_subscription<eagleye_msgs::msg::Heading>(
+      "heading_interpolate_3rd", 1000,
+      std::bind(
+        &RtkDeadReckoningNode::headingInterpolate3rdCallback, this, std::placeholders::_1));
+    pub1_ = this->create_publisher<eagleye_msgs::msg::Position>("enu_absolute_pos_interpolate",
+      1000);
+    pub2_ = this->create_publisher<sensor_msgs::msg::NavSatFix>("fix", 1000);
+
+    timer_ = this->create_wall_timer(
+      std::chrono::milliseconds(500), std::bind(&RtkDeadReckoningNode::onTimer, this));
   }
-  else if (gga_time != 0)
+
+private:
+  rtklib_msgs::msg::RtklibNav rtklib_nav_;
+  nmea_msgs::msg::Gpgga gga_;
+  geometry_msgs::msg::Vector3Stamped enu_vel_;
+  eagleye_msgs::msg::Position enu_absolute_rtk_dead_reckoning_;
+  sensor_msgs::msg::NavSatFix eagleye_fix_;
+  eagleye_msgs::msg::Heading heading_interpolate_3rd_;
+  RtkDeadreckoningParameter rtk_dead_reckoning_parameter_;
+  RtkDeadreckoningStatus rtk_dead_reckoning_status_;
+  std::string use_gnss_mode_;
+
+  tf2_ros::Buffer tf_buffer_;
+  tf2_ros::TransformListener tf_listener_;
+  rclcpp::TimerBase::SharedPtr timer_;
+  rclcpp::Publisher<eagleye_msgs::msg::Position>::SharedPtr pub1_;
+  rclcpp::Publisher<sensor_msgs::msg::NavSatFix>::SharedPtr pub2_;
+  rclcpp::Subscription<rtklib_msgs::msg::RtklibNav>::SharedPtr sub_rtklib_nav_;
+  rclcpp::Subscription<geometry_msgs::msg::Vector3Stamped>::SharedPtr sub_enu_vel_;
+  rclcpp::Subscription<nmea_msgs::msg::Gpgga>::SharedPtr sub_gga_;
+  rclcpp::Subscription<eagleye_msgs::msg::Heading>::SharedPtr sub_heading_interpolate_3rd_;
+
+  void rtklibNavCallback(const rtklib_msgs::msg::RtklibNav::ConstSharedPtr msg)
   {
-    sensor_msgs::msg::NavSatFix fix;
-    fix.header = gga.header;
-    fix.latitude = gga.lat;
-    fix.longitude = gga.lon;
-    fix.altitude = gga.alt + gga.undulation;
-    pub2->publish(fix);
+    rtklib_nav_ = *msg;
   }
-}
+
+  void ggaCallback(const nmea_msgs::msg::Gpgga::ConstSharedPtr msg) { gga_ = *msg; }
+
+  void headingInterpolate3rdCallback(const eagleye_msgs::msg::Heading::ConstSharedPtr msg)
+  {
+    heading_interpolate_3rd_ = *msg;
+  }
+
+  void onTimer()
+  {
+    geometry_msgs::msg::TransformStamped transformStamped;
+    try {
+      transformStamped = tf_buffer_.lookupTransform(
+        rtk_dead_reckoning_parameter_.tf_gnss_parent_frame,
+        rtk_dead_reckoning_parameter_.tf_gnss_child_frame, tf2::TimePointZero);
+
+      rtk_dead_reckoning_parameter_.tf_gnss_translation_x =
+        transformStamped.transform.translation.x;
+      rtk_dead_reckoning_parameter_.tf_gnss_translation_y =
+        transformStamped.transform.translation.y;
+      rtk_dead_reckoning_parameter_.tf_gnss_translation_z =
+        transformStamped.transform.translation.z;
+      rtk_dead_reckoning_parameter_.tf_gnss_rotation_x = transformStamped.transform.rotation.x;
+      rtk_dead_reckoning_parameter_.tf_gnss_rotation_y = transformStamped.transform.rotation.y;
+      rtk_dead_reckoning_parameter_.tf_gnss_rotation_z = transformStamped.transform.rotation.z;
+      rtk_dead_reckoning_parameter_.tf_gnss_rotation_w = transformStamped.transform.rotation.w;
+    } catch (tf2::TransformException& ex) {
+      return;
+    }
+  }
+
+  void enuVelCallback(const geometry_msgs::msg::Vector3Stamped::ConstSharedPtr msg)
+  {
+    rclcpp::Time ros_clock(gga_.header.stamp);
+    auto gga_time = ros_clock.seconds();
+
+    enu_vel_.header = msg->header;
+    enu_vel_.vector = msg->vector;
+    enu_absolute_rtk_dead_reckoning_.header = msg->header;
+    enu_absolute_rtk_dead_reckoning_.header.frame_id = "base_link";
+    eagleye_fix_.header = msg->header;
+    eagleye_fix_.header.frame_id = "gnss";
+    if (use_gnss_mode_ == "rtklib" || use_gnss_mode_ == "RTKLIB")
+      rtk_dead_reckoning_estimate(
+        rtklib_nav_, enu_vel_, gga_, heading_interpolate_3rd_, rtk_dead_reckoning_parameter_,
+        &rtk_dead_reckoning_status_, &enu_absolute_rtk_dead_reckoning_, &eagleye_fix_);
+    else if (use_gnss_mode_ == "nmea" || use_gnss_mode_ == "NMEA")
+      rtk_dead_reckoning_estimate(
+        enu_vel_, gga_, heading_interpolate_3rd_, rtk_dead_reckoning_parameter_,
+        &rtk_dead_reckoning_status_, &enu_absolute_rtk_dead_reckoning_, &eagleye_fix_);
+    if (enu_absolute_rtk_dead_reckoning_.status.enabled_status == true) {
+      pub1_->publish(enu_absolute_rtk_dead_reckoning_);
+      pub2_->publish(eagleye_fix_);
+    } else if (gga_time != 0) {
+      sensor_msgs::msg::NavSatFix fix;
+      fix.header = gga_.header;
+      fix.latitude = gga_.lat;
+      fix.longitude = gga_.lon;
+      fix.altitude = gga_.alt + gga_.undulation;
+      pub2_->publish(fix);
+    }
+  }
+};
 
 int main(int argc, char** argv)
 {
   rclcpp::init(argc, argv);
-  auto node = rclcpp::Node::make_shared("eagleye_rtk_dead_reckoning");
-
-  std::string subscribe_rtklib_nav_topic_name = "gnss/rtklib_nav";
-  std::string subscribe_gga_topic_name = "gnss/gga";
-
-  std::string yaml_file;
-  node->declare_parameter("yaml_file",yaml_file);
-  node->get_parameter("yaml_file",yaml_file);
-  std::cout << "yaml_file: " << yaml_file << std::endl;
-
-  try
-  {
-    YAML::Node conf = YAML::LoadFile(yaml_file);
-
-    use_gnss_mode = conf["/**"]["ros__parameters"]["use_gnss_mode"].as<std::string>();
-
-    rtk_dead_reckoning_parameter.ecef_base_pos_x = conf["/**"]["ros__parameters"]["ecef_base_pos"]["x"].as<double>();
-    rtk_dead_reckoning_parameter.ecef_base_pos_y = conf["/**"]["ros__parameters"]["ecef_base_pos"]["y"].as<double>();
-    rtk_dead_reckoning_parameter.ecef_base_pos_z = conf["/**"]["ros__parameters"]["ecef_base_pos"]["z"].as<double>();
-    rtk_dead_reckoning_parameter.use_ecef_base_position = conf["/**"]["ros__parameters"]["ecef_base_pos"]["use_ecef_base_position"].as<bool>();
-    rtk_dead_reckoning_parameter.tf_gnss_parent_frame = conf["/**"]["ros__parameters"]["tf_gnss_frame"]["parent"].as<std::string>();
-    rtk_dead_reckoning_parameter.tf_gnss_child_frame = conf["/**"]["ros__parameters"]["tf_gnss_frame"]["child"].as<std::string>();
-    rtk_dead_reckoning_parameter.stop_judgment_threshold = conf["/**"]["ros__parameters"]["common"]["stop_judgment_threshold"].as<double>();
-    rtk_dead_reckoning_parameter.rtk_fix_STD = conf["/**"]["ros__parameters"]["rtk_dead_reckoning"]["rtk_fix_STD"].as<double>();
-    rtk_dead_reckoning_parameter.proc_noise = conf["/**"]["ros__parameters"]["rtk_dead_reckoning"]["proc_noise"].as<double>();
-
-    std::cout << "use_gnss_mode " << use_gnss_mode << std::endl;
-
-    std::cout << "ecef_base_pos_x " << rtk_dead_reckoning_parameter.ecef_base_pos_x << std::endl;
-    std::cout << "ecef_base_pos_y " << rtk_dead_reckoning_parameter.ecef_base_pos_y << std::endl;
-    std::cout << "ecef_base_pos_z " << rtk_dead_reckoning_parameter.ecef_base_pos_z << std::endl;
-    std::cout << "use_ecef_base_position " << rtk_dead_reckoning_parameter.use_ecef_base_position << std::endl;
-    std::cout << "tf_gnss_frame/parent " << rtk_dead_reckoning_parameter.tf_gnss_parent_frame << std::endl;
-    std::cout << "tf_gnss_frame/child " << rtk_dead_reckoning_parameter.tf_gnss_child_frame << std::endl;
-    std::cout << "stop_judgment_threshold " << rtk_dead_reckoning_parameter.stop_judgment_threshold << std::endl;
-    std::cout << "rtk_fix_STD " << rtk_dead_reckoning_parameter.rtk_fix_STD << std::endl;
-    std::cout << "proc_noise " << rtk_dead_reckoning_parameter.proc_noise << std::endl;
-  }
-  catch (YAML::Exception& e)
-  {
-    std::cerr << "\033[1;31mrtk_dead_reckoning Node YAML Error: " << e.msg << "\033[0m" << std::endl;
-    exit(3);
-  }
-
-  auto sub1 = node->create_subscription<rtklib_msgs::msg::RtklibNav>(subscribe_rtklib_nav_topic_name, 1000, rtklib_nav_callback);
-  auto sub2 = node->create_subscription<geometry_msgs::msg::Vector3Stamped>("enu_vel", 1000, enu_vel_callback);
-  auto sub3 = node->create_subscription<nmea_msgs::msg::Gpgga>(subscribe_gga_topic_name, 1000, gga_callback);
-  auto sub4 = node->create_subscription<eagleye_msgs::msg::Heading>("heading_interpolate_3rd", 1000, heading_interpolate_3rd_callback);
-  
-  pub1 = node->create_publisher<eagleye_msgs::msg::Position>("enu_absolute_pos_interpolate", 1000);
-  pub2 = node->create_publisher<sensor_msgs::msg::NavSatFix>("fix", 1000);
-
-  const auto period_ns =
-      std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::duration<double>(0.5));
-  auto timer_callback = std::bind(on_timer);
-  auto timer = std::make_shared<rclcpp::GenericTimer<decltype(timer_callback)>>(
-    node->get_clock(), period_ns, std::move(timer_callback),
-    node->get_node_base_interface()->get_context());
-  node->get_node_timers_interface()->add_timer(timer, nullptr);
-
-  rclcpp::spin(node);
-
+  rclcpp::spin(std::make_shared<RtkDeadReckoningNode>());
   return 0;
 }

--- a/eagleye_rt/src/rtk_dead_reckoning_node.cpp
+++ b/eagleye_rt/src/rtk_dead_reckoning_node.cpp
@@ -131,7 +131,7 @@ private:
   sensor_msgs::msg::NavSatFix eagleye_fix_;
   eagleye_msgs::msg::Heading heading_interpolate_3rd_;
   RtkDeadreckoningParameter rtk_dead_reckoning_parameter_;
-  RtkDeadreckoningStatus rtk_dead_reckoning_status_;
+  RtkDeadreckoningStatus rtk_dead_reckoning_status_ = {};
   std::string use_gnss_mode_;
 
   tf2_ros::Buffer tf_buffer_;

--- a/eagleye_rt/src/rtk_heading_node.cpp
+++ b/eagleye_rt/src/rtk_heading_node.cpp
@@ -164,7 +164,7 @@ private:
   eagleye_msgs::msg::Heading heading_interpolate_;
   eagleye_msgs::msg::Heading heading_;
   RtkHeadingParameter heading_parameter_;
-  RtkHeadingStatus heading_status_;
+  RtkHeadingStatus heading_status_ = {};
   bool use_can_less_mode_ = false;
 
   rclcpp::Publisher<eagleye_msgs::msg::Heading>::SharedPtr pub_;

--- a/eagleye_rt/src/rtk_heading_node.cpp
+++ b/eagleye_rt/src/rtk_heading_node.cpp
@@ -28,187 +28,214 @@
  * Author MapIV Sekino
  */
 
-#include "rclcpp/rclcpp.hpp"
 #include "eagleye_coordinate/eagleye_coordinate.hpp"
 #include "eagleye_navigation/eagleye_navigation.hpp"
+#include "rclcpp/rclcpp.hpp"
 
-static nmea_msgs::msg::Gpgga gga;
-static sensor_msgs::msg::Imu imu;
-static geometry_msgs::msg::TwistStamped velocity;
-static eagleye_msgs::msg::StatusStamped velocity_status;
-static eagleye_msgs::msg::Distance distance;
-static eagleye_msgs::msg::YawrateOffset yaw_rate_offset_stop;
-static eagleye_msgs::msg::YawrateOffset yaw_rate_offset;
-static eagleye_msgs::msg::SlipAngle slip_angle;
-static eagleye_msgs::msg::Heading heading_interpolate;
-
-rclcpp::Publisher<eagleye_msgs::msg::Heading>::SharedPtr pub;
-static eagleye_msgs::msg::Heading heading;
-
-struct RtkHeadingParameter heading_parameter;
-struct RtkHeadingStatus heading_status;
-
-static bool use_can_less_mode;
-
-void velocity_callback(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg)
+class RtkHeadingNode : public rclcpp::Node
 {
-  velocity = *msg;
-}
-
-void gga_callback(const nmea_msgs::msg::Gpgga::ConstSharedPtr msg)
-{
-  gga = *msg;
-}
-
-void velocity_status_callback(const eagleye_msgs::msg::StatusStamped::ConstSharedPtr msg)
-{
-  velocity_status = *msg;
-}
-
-void yaw_rate_offset_stop_callback(const eagleye_msgs::msg::YawrateOffset::ConstSharedPtr msg)
-{
-  yaw_rate_offset_stop = *msg;
-}
-
-void yaw_rate_offset_callback(const eagleye_msgs::msg::YawrateOffset::ConstSharedPtr msg)
-{
-  yaw_rate_offset = *msg;
-}
-
-void slip_angle_callback(const eagleye_msgs::msg::SlipAngle::ConstSharedPtr msg)
-{
-  slip_angle = *msg;
-}
-
-void heading_interpolate_callback(const eagleye_msgs::msg::Heading::ConstSharedPtr msg)
-{
-  heading_interpolate = *msg;
-}
-
-void distance_callback(const eagleye_msgs::msg::Distance::ConstSharedPtr msg)
-{
-  distance = *msg;
-}
-
-void imu_callback(const sensor_msgs::msg::Imu::ConstSharedPtr msg)
-{
-  if(use_can_less_mode && !velocity_status.status.enabled_status) return;
-
-  imu = *msg;
-  heading.header = msg->header;
-  heading.header.frame_id = "base_link";
-  rtk_heading_estimate(gga,imu,velocity,distance,yaw_rate_offset_stop,yaw_rate_offset,slip_angle,heading_interpolate,heading_parameter,&heading_status,&heading);
-
-  if (heading.status.estimate_status == true)
+public:
+  RtkHeadingNode(int argc, char** argv) : Node("eagleye_rtk_heading")
   {
-    pub->publish(heading);
+    std::string subscribe_gga_topic_name = "gnss/gga";
+
+    std::string yaml_file;
+    this->declare_parameter("yaml_file", yaml_file);
+    this->get_parameter("yaml_file", yaml_file);
+    std::cout << "yaml_file: " << yaml_file << std::endl;
+
+    try {
+      YAML::Node conf = YAML::LoadFile(yaml_file);
+
+      use_can_less_mode_ = conf["/**"]["ros__parameters"]["use_can_less_mode"].as<bool>();
+      heading_parameter_.imu_rate =
+        conf["/**"]["ros__parameters"]["common"]["imu_rate"].as<double>();
+      heading_parameter_.gnss_rate =
+        conf["/**"]["ros__parameters"]["common"]["gnss_rate"].as<double>();
+      heading_parameter_.stop_judgment_threshold =
+        conf["/**"]["ros__parameters"]["common"]["stop_judgment_threshold"].as<double>();
+      heading_parameter_.slow_judgment_threshold =
+        conf["/**"]["ros__parameters"]["common"]["slow_judgment_threshold"].as<double>();
+      heading_parameter_.update_distance =
+        conf["/**"]["ros__parameters"]["rtk_heading"]["update_distance"].as<double>();
+      heading_parameter_.estimated_minimum_interval =
+        conf["/**"]["ros__parameters"]["rtk_heading"]["estimated_minimum_interval"].as<double>();
+      heading_parameter_.estimated_maximum_interval =
+        conf["/**"]["ros__parameters"]["rtk_heading"]["estimated_maximum_interval"].as<double>();
+      heading_parameter_.gnss_receiving_threshold =
+        conf["/**"]["ros__parameters"]["rtk_heading"]["gnss_receiving_threshold"].as<double>();
+      heading_parameter_.outlier_threshold =
+        conf["/**"]["ros__parameters"]["rtk_heading"]["outlier_threshold"].as<double>();
+      heading_parameter_.outlier_ratio_threshold =
+        conf["/**"]["ros__parameters"]["rtk_heading"]["outlier_ratio_threshold"].as<double>();
+      heading_parameter_.curve_judgment_threshold =
+        conf["/**"]["ros__parameters"]["rtk_heading"]["curve_judgment_threshold"].as<double>();
+
+      std::cout << "use_can_less_mode " << use_can_less_mode_ << std::endl;
+      std::cout << "subscribe_gga_topic_name " << subscribe_gga_topic_name << std::endl;
+      std::cout << "imu_rate " << heading_parameter_.imu_rate << std::endl;
+      std::cout << "gnss_rate " << heading_parameter_.gnss_rate << std::endl;
+      std::cout << "stop_judgment_threshold " << heading_parameter_.stop_judgment_threshold
+                << std::endl;
+      std::cout << "slow_judgment_threshold " << heading_parameter_.slow_judgment_threshold
+                << std::endl;
+      std::cout << "update_distance " << heading_parameter_.update_distance << std::endl;
+      std::cout << "estimated_minimum_interval " << heading_parameter_.estimated_minimum_interval
+                << std::endl;
+      std::cout << "estimated_maximum_interval " << heading_parameter_.estimated_maximum_interval
+                << std::endl;
+      std::cout << "gnss_receiving_threshold " << heading_parameter_.gnss_receiving_threshold
+                << std::endl;
+      std::cout << "outlier_threshold " << heading_parameter_.outlier_threshold << std::endl;
+      std::cout << "outlier_ratio_threshold " << heading_parameter_.outlier_ratio_threshold
+                << std::endl;
+      std::cout << "curve_judgment_threshold " << heading_parameter_.curve_judgment_threshold
+                << std::endl;
+    } catch (YAML::Exception& e) {
+      std::cerr << "\033[1;31mrtk_heading Node YAML Error: " << e.msg << "\033[0m" << std::endl;
+      exit(3);
+    }
+
+    std::string publish_topic_name = "/publish_topic_name/invalid";
+    std::string subscribe_topic_name = "/subscribe_topic_name/invalid";
+    std::string subscribe_topic_name2 = "/subscribe_topic_name2/invalid";
+
+    if (argc > 2) {
+      if (strcmp(argv[1], "1st") == 0) {
+        publish_topic_name = "heading_1st";
+        subscribe_topic_name = "yaw_rate_offset_stop";
+        subscribe_topic_name2 = "heading_interpolate_1st";
+      } else if (strcmp(argv[1], "2nd") == 0) {
+        publish_topic_name = "heading_2nd";
+        subscribe_topic_name = "yaw_rate_offset_1st";
+        subscribe_topic_name2 = "heading_interpolate_2nd";
+      } else if (strcmp(argv[1], "3rd") == 0) {
+        publish_topic_name = "heading_3rd";
+        subscribe_topic_name = "yaw_rate_offset_2nd";
+        subscribe_topic_name2 = "heading_interpolate_3rd";
+      } else {
+        RCLCPP_ERROR(this->get_logger(), "Invalid argument");
+        rclcpp::shutdown();
+      }
+    } else {
+      RCLCPP_ERROR(this->get_logger(), "No arguments");
+      rclcpp::shutdown();
+    }
+
+    sub_imu_ = this->create_subscription<sensor_msgs::msg::Imu>(
+      "imu/data_tf_converted", 1000,
+      std::bind(&RtkHeadingNode::imuCallback, this, std::placeholders::_1));
+    sub_gga_ = this->create_subscription<nmea_msgs::msg::Gpgga>(
+      subscribe_gga_topic_name, 1000,
+      std::bind(&RtkHeadingNode::ggaCallback, this, std::placeholders::_1));
+    sub_velocity_ = this->create_subscription<geometry_msgs::msg::TwistStamped>(
+      "velocity", rclcpp::QoS(10),
+      std::bind(&RtkHeadingNode::velocityCallback, this, std::placeholders::_1));
+    sub_velocity_status_ = this->create_subscription<eagleye_msgs::msg::StatusStamped>(
+      "velocity_status", rclcpp::QoS(10),
+      std::bind(&RtkHeadingNode::velocityStatusCallback, this, std::placeholders::_1));
+    sub_yaw_rate_offset_stop_ = this->create_subscription<eagleye_msgs::msg::YawrateOffset>(
+      "yaw_rate_offset_stop", 1000,
+      std::bind(&RtkHeadingNode::yawRateOffsetStopCallback, this, std::placeholders::_1));
+    sub_yaw_rate_offset_ = this->create_subscription<eagleye_msgs::msg::YawrateOffset>(
+      subscribe_topic_name, 1000,
+      std::bind(&RtkHeadingNode::yawRateOffsetCallback, this, std::placeholders::_1));
+    sub_slip_angle_ = this->create_subscription<eagleye_msgs::msg::SlipAngle>(
+      "slip_angle", 1000,
+      std::bind(&RtkHeadingNode::slipAngleCallback, this, std::placeholders::_1));
+    sub_heading_interpolate_ = this->create_subscription<eagleye_msgs::msg::Heading>(
+      subscribe_topic_name2, 1000,
+      std::bind(&RtkHeadingNode::headingInterpolateCallback, this, std::placeholders::_1));
+    sub_distance_ = this->create_subscription<eagleye_msgs::msg::Distance>(
+      "distance", 1000,
+      std::bind(&RtkHeadingNode::distanceCallback, this, std::placeholders::_1));
+    pub_ = this->create_publisher<eagleye_msgs::msg::Heading>(publish_topic_name, 1000);
   }
-  heading.status.estimate_status = false;
-}
+
+private:
+  nmea_msgs::msg::Gpgga gga_;
+  sensor_msgs::msg::Imu imu_;
+  geometry_msgs::msg::TwistStamped velocity_;
+  eagleye_msgs::msg::StatusStamped velocity_status_;
+  eagleye_msgs::msg::Distance distance_;
+  eagleye_msgs::msg::YawrateOffset yaw_rate_offset_stop_;
+  eagleye_msgs::msg::YawrateOffset yaw_rate_offset_;
+  eagleye_msgs::msg::SlipAngle slip_angle_;
+  eagleye_msgs::msg::Heading heading_interpolate_;
+  eagleye_msgs::msg::Heading heading_;
+  RtkHeadingParameter heading_parameter_;
+  RtkHeadingStatus heading_status_;
+  bool use_can_less_mode_ = false;
+
+  rclcpp::Publisher<eagleye_msgs::msg::Heading>::SharedPtr pub_;
+  rclcpp::Subscription<sensor_msgs::msg::Imu>::SharedPtr sub_imu_;
+  rclcpp::Subscription<nmea_msgs::msg::Gpgga>::SharedPtr sub_gga_;
+  rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr sub_velocity_;
+  rclcpp::Subscription<eagleye_msgs::msg::StatusStamped>::SharedPtr sub_velocity_status_;
+  rclcpp::Subscription<eagleye_msgs::msg::YawrateOffset>::SharedPtr sub_yaw_rate_offset_stop_;
+  rclcpp::Subscription<eagleye_msgs::msg::YawrateOffset>::SharedPtr sub_yaw_rate_offset_;
+  rclcpp::Subscription<eagleye_msgs::msg::SlipAngle>::SharedPtr sub_slip_angle_;
+  rclcpp::Subscription<eagleye_msgs::msg::Heading>::SharedPtr sub_heading_interpolate_;
+  rclcpp::Subscription<eagleye_msgs::msg::Distance>::SharedPtr sub_distance_;
+
+  void velocityCallback(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg)
+  {
+    velocity_ = *msg;
+  }
+
+  void ggaCallback(const nmea_msgs::msg::Gpgga::ConstSharedPtr msg) { gga_ = *msg; }
+
+  void velocityStatusCallback(const eagleye_msgs::msg::StatusStamped::ConstSharedPtr msg)
+  {
+    velocity_status_ = *msg;
+  }
+
+  void yawRateOffsetStopCallback(const eagleye_msgs::msg::YawrateOffset::ConstSharedPtr msg)
+  {
+    yaw_rate_offset_stop_ = *msg;
+  }
+
+  void yawRateOffsetCallback(const eagleye_msgs::msg::YawrateOffset::ConstSharedPtr msg)
+  {
+    yaw_rate_offset_ = *msg;
+  }
+
+  void slipAngleCallback(const eagleye_msgs::msg::SlipAngle::ConstSharedPtr msg)
+  {
+    slip_angle_ = *msg;
+  }
+
+  void headingInterpolateCallback(const eagleye_msgs::msg::Heading::ConstSharedPtr msg)
+  {
+    heading_interpolate_ = *msg;
+  }
+
+  void distanceCallback(const eagleye_msgs::msg::Distance::ConstSharedPtr msg)
+  {
+    distance_ = *msg;
+  }
+
+  void imuCallback(const sensor_msgs::msg::Imu::ConstSharedPtr msg)
+  {
+    if (use_can_less_mode_ && !velocity_status_.status.enabled_status) return;
+
+    imu_ = *msg;
+    heading_.header = msg->header;
+    heading_.header.frame_id = "base_link";
+    rtk_heading_estimate(
+      gga_, imu_, velocity_, distance_, yaw_rate_offset_stop_, yaw_rate_offset_, slip_angle_,
+      heading_interpolate_, heading_parameter_, &heading_status_, &heading_);
+
+    if (heading_.status.estimate_status == true) {
+      pub_->publish(heading_);
+    }
+    heading_.status.estimate_status = false;
+  }
+};
 
 int main(int argc, char** argv)
 {
   rclcpp::init(argc, argv);
-  auto node = rclcpp::Node::make_shared("eagleye_rtk_heading");
-
-
-  std::string subscribe_gga_topic_name = "gnss/gga";
-
-  std::string yaml_file;
-  node->declare_parameter("yaml_file",yaml_file);
-  node->get_parameter("yaml_file",yaml_file);
-  std::cout << "yaml_file: " << yaml_file << std::endl;
-  try
-  {
-    YAML::Node conf = YAML::LoadFile(yaml_file);
-
-    use_can_less_mode = conf["/**"]["ros__parameters"]["use_can_less_mode"].as<bool>();
-
-    heading_parameter.imu_rate = conf["/**"]["ros__parameters"]["common"]["imu_rate"].as<double>();
-    heading_parameter.gnss_rate = conf["/**"]["ros__parameters"]["common"]["gnss_rate"].as<double>();
-    heading_parameter.stop_judgment_threshold = conf["/**"]["ros__parameters"]["common"]["stop_judgment_threshold"].as<double>();
-    heading_parameter.slow_judgment_threshold = conf["/**"]["ros__parameters"]["common"]["slow_judgment_threshold"].as<double>();
-
-    heading_parameter.update_distance = conf["/**"]["ros__parameters"]["rtk_heading"]["update_distance"].as<double>();
-    heading_parameter.estimated_minimum_interval = conf["/**"]["ros__parameters"]["rtk_heading"]["estimated_minimum_interval"].as<double>();
-    heading_parameter.estimated_maximum_interval = conf["/**"]["ros__parameters"]["rtk_heading"]["estimated_maximum_interval"].as<double>();
-    heading_parameter.gnss_receiving_threshold = conf["/**"]["ros__parameters"]["rtk_heading"]["gnss_receiving_threshold"].as<double>();
-    heading_parameter.outlier_threshold = conf["/**"]["ros__parameters"]["rtk_heading"]["outlier_threshold"].as<double>();
-    heading_parameter.outlier_ratio_threshold = conf["/**"]["ros__parameters"]["rtk_heading"]["outlier_ratio_threshold"].as<double>();
-    heading_parameter.curve_judgment_threshold = conf["/**"]["ros__parameters"]["rtk_heading"]["curve_judgment_threshold"].as<double>();
-
-    std::cout<< "use_can_less_mode " << use_can_less_mode << std::endl;
-
-    std::cout<< "subscribe_gga_topic_name " << subscribe_gga_topic_name << std::endl;
-
-    std::cout << "imu_rate " << heading_parameter.imu_rate << std::endl;
-    std::cout << "gnss_rate " << heading_parameter.gnss_rate << std::endl;
-    std::cout << "stop_judgment_threshold " << heading_parameter.stop_judgment_threshold << std::endl;
-    std::cout << "slow_judgment_threshold " << heading_parameter.slow_judgment_threshold << std::endl;
-
-    std::cout << "update_distance " << heading_parameter.update_distance << std::endl;
-    std::cout << "estimated_minimum_interval " << heading_parameter.estimated_minimum_interval << std::endl;
-    std::cout << "estimated_maximum_interval " << heading_parameter.estimated_maximum_interval << std::endl;
-    std::cout << "gnss_receiving_threshold " << heading_parameter.gnss_receiving_threshold << std::endl;
-    std::cout << "outlier_threshold " << heading_parameter.outlier_threshold << std::endl;
-    std::cout << "outlier_ratio_threshold " << heading_parameter.outlier_ratio_threshold << std::endl;
-    std::cout << "curve_judgment_threshold " << heading_parameter.curve_judgment_threshold << std::endl;
-  }
-  catch (YAML::Exception& e)
-  {
-    std::cerr << "\033[1;31mrtk_heading Node YAML Error: " << e.msg << "\033[0m" << std::endl;
-    exit(3);
-  }
-
-  std::string publish_topic_name = "/publish_topic_name/invalid";
-  std::string subscribe_topic_name = "/subscribe_topic_name/invalid";
-  std::string subscribe_topic_name2 = "/subscribe_topic_name2/invalid";
-
-  if (argc > 2)
-  {
-    if (strcmp(argv[1], "1st") == 0)
-    {
-      publish_topic_name = "heading_1st";
-      subscribe_topic_name = "yaw_rate_offset_stop";
-      subscribe_topic_name2 = "heading_interpolate_1st";
-    }
-    else if (strcmp(argv[1], "2nd") == 0)
-    {
-      publish_topic_name = "heading_2nd";
-      subscribe_topic_name = "yaw_rate_offset_1st";
-      subscribe_topic_name2 = "heading_interpolate_2nd";
-    }
-    else if (strcmp(argv[1], "3rd") == 0)
-    {
-      publish_topic_name = "heading_3rd";
-      subscribe_topic_name = "yaw_rate_offset_2nd";
-      subscribe_topic_name2 = "heading_interpolate_3rd";
-    }
-    else
-    {
-      RCLCPP_ERROR(node->get_logger(),"Invalid argument");
-      rclcpp::shutdown();
-    }
-  }
-  else
-  {
-    RCLCPP_ERROR(node->get_logger(),"No arguments");
-    rclcpp::shutdown();
-  }
-
-  auto sub1 = node->create_subscription<sensor_msgs::msg::Imu>("imu/data_tf_converted", 1000, imu_callback);
-  auto sub2 = node->create_subscription<nmea_msgs::msg::Gpgga>(subscribe_gga_topic_name, 1000, gga_callback);
-  auto sub3 = node->create_subscription<geometry_msgs::msg::TwistStamped>("velocity", rclcpp::QoS(10), velocity_callback);
-  auto sub4 = node->create_subscription<eagleye_msgs::msg::StatusStamped>("velocity_status", rclcpp::QoS(10), velocity_status_callback);
-  auto sub5 = node->create_subscription<eagleye_msgs::msg::YawrateOffset>("yaw_rate_offset_stop", 1000, yaw_rate_offset_stop_callback);
-  auto sub6 = node->create_subscription<eagleye_msgs::msg::YawrateOffset>(subscribe_topic_name, 1000, yaw_rate_offset_callback);
-  auto sub7 = node->create_subscription<eagleye_msgs::msg::SlipAngle>("slip_angle", 1000, slip_angle_callback);
-  auto sub8 = node->create_subscription<eagleye_msgs::msg::Heading>(subscribe_topic_name2, 1000, heading_interpolate_callback);
-  auto sub9 = node->create_subscription<eagleye_msgs::msg::Distance>("distance", 1000, distance_callback);
-
-  pub = node->create_publisher<eagleye_msgs::msg::Heading>(publish_topic_name, 1000);
-
-  rclcpp::spin(node);
-
+  rclcpp::spin(std::make_shared<RtkHeadingNode>(argc, argv));
   return 0;
 }

--- a/eagleye_rt/src/slip_angle_node.cpp
+++ b/eagleye_rt/src/slip_angle_node.cpp
@@ -28,107 +28,127 @@
  * Author MapIV Sekino
  */
 
-#include "rclcpp/rclcpp.hpp"
 #include "eagleye_coordinate/eagleye_coordinate.hpp"
 #include "eagleye_navigation/eagleye_navigation.hpp"
+#include "rclcpp/rclcpp.hpp"
 
-static sensor_msgs::msg::Imu imu;
-static geometry_msgs::msg::TwistStamped velocity;
-static eagleye_msgs::msg::StatusStamped velocity_status;
-static eagleye_msgs::msg::VelocityScaleFactor velocity_scale_factor;
-static eagleye_msgs::msg::YawrateOffset yaw_rate_offset_stop;
-static eagleye_msgs::msg::YawrateOffset yaw_rate_offset_2nd;
-
-rclcpp::Publisher<eagleye_msgs::msg::SlipAngle>::SharedPtr pub;
-static eagleye_msgs::msg::SlipAngle slip_angle;
-
-struct SlipangleParameter slip_angle_parameter;
-
-static bool use_can_less_mode;
-
-void velocity_callback(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg)
+class SlipAngleNode : public rclcpp::Node
 {
-  velocity = *msg;
-}
-
-void velocity_status_callback(const eagleye_msgs::msg::StatusStamped::ConstSharedPtr msg)
-{
-  velocity_status = *msg;
-}
-
-void velocity_scale_factor_callback(const eagleye_msgs::msg::VelocityScaleFactor::ConstSharedPtr msg)
-{
-  velocity_scale_factor = *msg;
-}
-
-void yaw_rate_offset_stop_callback(const eagleye_msgs::msg::YawrateOffset::ConstSharedPtr msg)
-{
-  yaw_rate_offset_stop = *msg;
-}
-
-void yaw_rate_offset_2nd_callback(const eagleye_msgs::msg::YawrateOffset::ConstSharedPtr msg)
-{
-  yaw_rate_offset_2nd = *msg;
-}
-
-void imu_callback(const sensor_msgs::msg::Imu::ConstSharedPtr msg)
-{
-  if(use_can_less_mode && !velocity_status.status.enabled_status) return;
-
-  eagleye_msgs::msg::StatusStamped velocity_enable_status;
-  if(use_can_less_mode)
+public:
+  SlipAngleNode() : Node("eagleye_slip_angle")
   {
-    velocity_enable_status = velocity_status;
-  }
-  else
-  {
-    velocity_enable_status.header = velocity_scale_factor.header;
-    velocity_enable_status.status = velocity_scale_factor.status;
+    std::string yaml_file;
+    this->declare_parameter("yaml_file", yaml_file);
+    this->get_parameter("yaml_file", yaml_file);
+    std::cout << "yaml_file: " << yaml_file << std::endl;
+
+    try {
+      YAML::Node conf = YAML::LoadFile(yaml_file);
+
+      use_can_less_mode_ = conf["/**"]["ros__parameters"]["use_can_less_mode"].as<bool>();
+      slip_angle_parameter_.stop_judgment_threshold =
+        conf["/**"]["ros__parameters"]["common"]["stop_judgment_threshold"].as<double>();
+      slip_angle_parameter_.manual_coefficient =
+        conf["/**"]["ros__parameters"]["slip_angle"]["manual_coefficient"].as<double>();
+
+      std::cout << "stop_judgment_threshold " << slip_angle_parameter_.stop_judgment_threshold
+                << std::endl;
+      std::cout << "manual_coefficient " << slip_angle_parameter_.manual_coefficient << std::endl;
+    } catch (YAML::Exception& e) {
+      std::cerr << "\033[1;31mslip_angle Node YAML Error: " << e.msg << "\033[0m" << std::endl;
+      exit(3);
+    }
+
+    sub_imu_ = this->create_subscription<sensor_msgs::msg::Imu>(
+      "imu/data_tf_converted", rclcpp::QoS(10),
+      std::bind(&SlipAngleNode::imuCallback, this, std::placeholders::_1));
+    sub_velocity_scale_factor_ = this->create_subscription<eagleye_msgs::msg::VelocityScaleFactor>(
+      "velocity_scale_factor", rclcpp::QoS(10),
+      std::bind(&SlipAngleNode::velocityScaleFactorCallback, this, std::placeholders::_1));
+    sub_yaw_rate_offset_stop_ = this->create_subscription<eagleye_msgs::msg::YawrateOffset>(
+      "yaw_rate_offset_stop", rclcpp::QoS(10),
+      std::bind(&SlipAngleNode::yawRateOffsetStopCallback, this, std::placeholders::_1));
+    sub_yaw_rate_offset_2nd_ = this->create_subscription<eagleye_msgs::msg::YawrateOffset>(
+      "yaw_rate_offset_2nd", rclcpp::QoS(10),
+      std::bind(&SlipAngleNode::yawRateOffset2ndCallback, this, std::placeholders::_1));
+    sub_velocity_ = this->create_subscription<geometry_msgs::msg::TwistStamped>(
+      "velocity", rclcpp::QoS(10),
+      std::bind(&SlipAngleNode::velocityCallback, this, std::placeholders::_1));
+    pub_ = this->create_publisher<eagleye_msgs::msg::SlipAngle>("slip_angle", rclcpp::QoS(10));
   }
 
-  imu = *msg;
-  slip_angle.header = msg->header;
-  slip_angle.header.frame_id = "base_link";
-  slip_angle_estimate(imu,velocity,velocity_enable_status,yaw_rate_offset_stop,yaw_rate_offset_2nd,slip_angle_parameter,&slip_angle);
-  pub->publish(slip_angle);
-  slip_angle.status.estimate_status = false;
-}
+private:
+  sensor_msgs::msg::Imu imu_;
+  geometry_msgs::msg::TwistStamped velocity_;
+  eagleye_msgs::msg::StatusStamped velocity_status_;
+  eagleye_msgs::msg::VelocityScaleFactor velocity_scale_factor_;
+  eagleye_msgs::msg::YawrateOffset yaw_rate_offset_stop_;
+  eagleye_msgs::msg::YawrateOffset yaw_rate_offset_2nd_;
+  eagleye_msgs::msg::SlipAngle slip_angle_;
+  SlipangleParameter slip_angle_parameter_;
+  bool use_can_less_mode_ = false;
+
+  rclcpp::Publisher<eagleye_msgs::msg::SlipAngle>::SharedPtr pub_;
+  rclcpp::Subscription<sensor_msgs::msg::Imu>::SharedPtr sub_imu_;
+  rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr sub_velocity_;
+  rclcpp::Subscription<eagleye_msgs::msg::StatusStamped>::SharedPtr sub_velocity_status_;
+  rclcpp::Subscription<eagleye_msgs::msg::VelocityScaleFactor>::SharedPtr
+    sub_velocity_scale_factor_;
+  rclcpp::Subscription<eagleye_msgs::msg::YawrateOffset>::SharedPtr sub_yaw_rate_offset_stop_;
+  rclcpp::Subscription<eagleye_msgs::msg::YawrateOffset>::SharedPtr sub_yaw_rate_offset_2nd_;
+
+  void velocityCallback(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg)
+  {
+    velocity_ = *msg;
+  }
+
+  void velocityStatusCallback(const eagleye_msgs::msg::StatusStamped::ConstSharedPtr msg)
+  {
+    velocity_status_ = *msg;
+  }
+
+  void velocityScaleFactorCallback(
+    const eagleye_msgs::msg::VelocityScaleFactor::ConstSharedPtr msg)
+  {
+    velocity_scale_factor_ = *msg;
+  }
+
+  void yawRateOffsetStopCallback(const eagleye_msgs::msg::YawrateOffset::ConstSharedPtr msg)
+  {
+    yaw_rate_offset_stop_ = *msg;
+  }
+
+  void yawRateOffset2ndCallback(const eagleye_msgs::msg::YawrateOffset::ConstSharedPtr msg)
+  {
+    yaw_rate_offset_2nd_ = *msg;
+  }
+
+  void imuCallback(const sensor_msgs::msg::Imu::ConstSharedPtr msg)
+  {
+    if (use_can_less_mode_ && !velocity_status_.status.enabled_status) return;
+
+    eagleye_msgs::msg::StatusStamped velocity_enable_status;
+    if (use_can_less_mode_) {
+      velocity_enable_status = velocity_status_;
+    } else {
+      velocity_enable_status.header = velocity_scale_factor_.header;
+      velocity_enable_status.status = velocity_scale_factor_.status;
+    }
+
+    imu_ = *msg;
+    slip_angle_.header = msg->header;
+    slip_angle_.header.frame_id = "base_link";
+    slip_angle_estimate(
+      imu_, velocity_, velocity_enable_status, yaw_rate_offset_stop_, yaw_rate_offset_2nd_,
+      slip_angle_parameter_, &slip_angle_);
+    pub_->publish(slip_angle_);
+    slip_angle_.status.estimate_status = false;
+  }
+};
 
 int main(int argc, char** argv)
 {
   rclcpp::init(argc, argv);
-  auto node = rclcpp::Node::make_shared("eagleye_slip_angle");
-  
-  std::string yaml_file;
-  node->declare_parameter("yaml_file",yaml_file);
-  node->get_parameter("yaml_file",yaml_file);
-  std::cout << "yaml_file: " << yaml_file << std::endl;
-
-  try
-  {
-    YAML::Node conf = YAML::LoadFile(yaml_file);
-
-    slip_angle_parameter.stop_judgment_threshold = conf["/**"]["ros__parameters"]["common"]["stop_judgment_threshold"].as<double>();
-    slip_angle_parameter.manual_coefficient = conf["/**"]["ros__parameters"]["slip_angle"]["manual_coefficient"].as<double>();
-
-    std::cout << "stop_judgment_threshold " << slip_angle_parameter.stop_judgment_threshold << std::endl;
-    std::cout << "manual_coefficient " << slip_angle_parameter.manual_coefficient << std::endl;
-  }
-  catch (YAML::Exception& e)
-  {
-    std::cerr << "\033[1;31mslip_angle Node YAML Error: " << e.msg << "\033[0m" << std::endl;
-    exit(3);
-  }
-
-  auto sub1 = node->create_subscription<sensor_msgs::msg::Imu>("imu/data_tf_converted", rclcpp::QoS(10), imu_callback);  //ros::TransportHints().tcpNoDelay()
-  auto sub2 = node->create_subscription<eagleye_msgs::msg::VelocityScaleFactor>("velocity_scale_factor", rclcpp::QoS(10), velocity_scale_factor_callback);  //ros::TransportHints().tcpNoDelay()
-  auto sub3 = node->create_subscription<eagleye_msgs::msg::YawrateOffset>("yaw_rate_offset_stop", rclcpp::QoS(10), yaw_rate_offset_stop_callback);  //ros::TransportHints().tcpNoDelay()
-  auto sub4 = node->create_subscription<eagleye_msgs::msg::YawrateOffset>("yaw_rate_offset_2nd", rclcpp::QoS(10), yaw_rate_offset_2nd_callback);  //ros::TransportHints().tcpNoDelay()
-  auto sub5 = node->create_subscription<geometry_msgs::msg::TwistStamped>("velocity", rclcpp::QoS(10), velocity_callback);  //ros::TransportHints().tcpNoDelay()
-  pub = node->create_publisher<eagleye_msgs::msg::SlipAngle>("slip_angle", rclcpp::QoS(10));
-
-  rclcpp::spin(node);
-
-
+  rclcpp::spin(std::make_shared<SlipAngleNode>());
   return 0;
 }

--- a/eagleye_rt/src/slip_coefficient_node.cpp
+++ b/eagleye_rt/src/slip_coefficient_node.cpp
@@ -123,7 +123,7 @@ private:
   eagleye_msgs::msg::YawrateOffset yaw_rate_offset_2nd_;
   eagleye_msgs::msg::Heading heading_interpolate_3rd_;
   SlipCoefficientParameter slip_coefficient_parameter_;
-  SlipCoefficientStatus slip_coefficient_status_;
+  SlipCoefficientStatus slip_coefficient_status_ = {};
   double estimate_coefficient_ = 0.0;
   bool is_first_correction_velocity_ = false;
   bool use_can_less_mode_ = false;

--- a/eagleye_rt/src/slip_coefficient_node.cpp
+++ b/eagleye_rt/src/slip_coefficient_node.cpp
@@ -28,135 +28,178 @@
  * Author MapIV Takanose
  */
 
-#include "rclcpp/rclcpp.hpp"
 #include "eagleye_coordinate/eagleye_coordinate.hpp"
 #include "eagleye_navigation/eagleye_navigation.hpp"
+#include "rclcpp/rclcpp.hpp"
 
-#include <iostream>
 #include <fstream>
 #include <iomanip>
+#include <iostream>
 
-static rtklib_msgs::msg::RtklibNav rtklib_nav;
-static sensor_msgs::msg::Imu imu;
-static geometry_msgs::msg::TwistStamped velocity;
-static eagleye_msgs::msg::StatusStamped velocity_status;
-static eagleye_msgs::msg::YawrateOffset yaw_rate_offset_stop;
-static eagleye_msgs::msg::YawrateOffset yaw_rate_offset_2nd;
-static eagleye_msgs::msg::Heading heading_interpolate_3rd;
-
-struct SlipCoefficientParameter slip_coefficient_parameter;
-struct SlipCoefficientStatus slip_coefficient_status;
-
-static double estimate_coefficient;
-
-bool is_first_correction_velocity = false;
-static bool use_can_less_mode;
-
-void rtklib_nav_callback(const rtklib_msgs::msg::RtklibNav::ConstSharedPtr msg)
+class SlipCoefficientNode : public rclcpp::Node
 {
-  rtklib_nav = *msg;
-}
-
-void velocity_callback(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg)
-{
-  velocity = *msg;
-  if (is_first_correction_velocity == false && msg->twist.linear.x > slip_coefficient_parameter.moving_judgment_threshold)
+public:
+  SlipCoefficientNode() : Node("eagleye_slip_coefficient")
   {
-    is_first_correction_velocity = true;
+    std::string subscribe_rtklib_nav_topic_name = "gnss/rtklib_nav";
+
+    std::string yaml_file;
+    this->declare_parameter("yaml_file", yaml_file);
+    this->get_parameter("yaml_file", yaml_file);
+    std::cout << "yaml_file: " << yaml_file << std::endl;
+
+    try {
+      YAML::Node conf = YAML::LoadFile(yaml_file);
+
+      use_can_less_mode_ = conf["/**"]["ros__parameters"]["use_can_less_mode"].as<bool>();
+      slip_coefficient_parameter_.imu_rate =
+        conf["/**"]["ros__parameters"]["common"]["imu_rate"].as<double>();
+      slip_coefficient_parameter_.stop_judgment_threshold =
+        conf["/**"]["ros__parameters"]["common"]["stop_judgment_threshold"].as<double>();
+      slip_coefficient_parameter_.moving_judgment_threshold =
+        conf["/**"]["ros__parameters"]["common"]["moving_judgment_threshold"].as<double>();
+      slip_coefficient_parameter_.estimated_minimum_interval =
+        conf["/**"]["ros__parameters"]["slip_coefficient"]["estimated_minimum_interval"]
+          .as<double>();
+      slip_coefficient_parameter_.estimated_maximum_interval =
+        conf["/**"]["ros__parameters"]["slip_coefficient"]["estimated_maximum_interval"]
+          .as<double>();
+      slip_coefficient_parameter_.curve_judgment_threshold =
+        conf["/**"]["ros__parameters"]["slip_coefficient"]["curve_judgment_threshold"].as<double>();
+      slip_coefficient_parameter_.lever_arm =
+        conf["/**"]["ros__parameters"]["slip_coefficient"]["lever_arm"].as<double>();
+
+      std::cout << "use_can_less_mode " << use_can_less_mode_ << std::endl;
+      std::cout << "imu_rate " << slip_coefficient_parameter_.imu_rate << std::endl;
+      std::cout << "stop_judgment_threshold "
+                << slip_coefficient_parameter_.stop_judgment_threshold << std::endl;
+      std::cout << "moving_judgment_threshold "
+                << slip_coefficient_parameter_.moving_judgment_threshold << std::endl;
+      std::cout << "estimated_minimum_interval "
+                << slip_coefficient_parameter_.estimated_minimum_interval << std::endl;
+      std::cout << "estimated_maximum_interval "
+                << slip_coefficient_parameter_.estimated_maximum_interval << std::endl;
+      std::cout << "curve_judgment_threshold "
+                << slip_coefficient_parameter_.curve_judgment_threshold << std::endl;
+      std::cout << "lever_arm " << slip_coefficient_parameter_.lever_arm << std::endl;
+    } catch (YAML::Exception& e) {
+      std::cerr << "\033[1;31mslip_coefficient Node YAML Error: " << e.msg << "\033[0m"
+                << std::endl;
+      exit(3);
+    }
+
+    sub_imu_ = this->create_subscription<sensor_msgs::msg::Imu>(
+      "imu/data_tf_converted", 1000,
+      std::bind(&SlipCoefficientNode::imuCallback, this, std::placeholders::_1));
+    sub_rtklib_nav_ = this->create_subscription<rtklib_msgs::msg::RtklibNav>(
+      subscribe_rtklib_nav_topic_name, 1000,
+      std::bind(&SlipCoefficientNode::rtklibNavCallback, this, std::placeholders::_1));
+    sub_velocity_ = this->create_subscription<geometry_msgs::msg::TwistStamped>(
+      "velocity", rclcpp::QoS(10),
+      std::bind(&SlipCoefficientNode::velocityCallback, this, std::placeholders::_1));
+    sub_velocity_status_ = this->create_subscription<eagleye_msgs::msg::StatusStamped>(
+      "velocity_status", rclcpp::QoS(10),
+      std::bind(&SlipCoefficientNode::velocityStatusCallback, this, std::placeholders::_1));
+    sub_yaw_rate_offset_stop_ = this->create_subscription<eagleye_msgs::msg::YawrateOffset>(
+      "yaw_rate_offset_stop", rclcpp::QoS(10),
+      std::bind(&SlipCoefficientNode::yawRateOffsetStopCallback, this, std::placeholders::_1));
+    sub_yaw_rate_offset_2nd_ = this->create_subscription<eagleye_msgs::msg::YawrateOffset>(
+      "yaw_rate_offset_2nd", rclcpp::QoS(10),
+      std::bind(&SlipCoefficientNode::yawRateOffset2ndCallback, this, std::placeholders::_1));
+    sub_heading_interpolate_3rd_ = this->create_subscription<eagleye_msgs::msg::Heading>(
+      "heading_interpolate_3rd", rclcpp::QoS(10),
+      std::bind(
+        &SlipCoefficientNode::headingInterpolate3rdCallback, this, std::placeholders::_1));
   }
-}
 
-void velocity_status_callback(const eagleye_msgs::msg::StatusStamped::ConstSharedPtr msg)
-{
-  velocity_status = *msg;
-}
+  double getEstimateCoefficient() const { return estimate_coefficient_; }
 
-void yaw_rate_offset_stop_callback(const eagleye_msgs::msg::YawrateOffset::ConstSharedPtr msg)
-{
-  yaw_rate_offset_stop = *msg;
-}
+private:
+  rtklib_msgs::msg::RtklibNav rtklib_nav_;
+  sensor_msgs::msg::Imu imu_;
+  geometry_msgs::msg::TwistStamped velocity_;
+  eagleye_msgs::msg::StatusStamped velocity_status_;
+  eagleye_msgs::msg::YawrateOffset yaw_rate_offset_stop_;
+  eagleye_msgs::msg::YawrateOffset yaw_rate_offset_2nd_;
+  eagleye_msgs::msg::Heading heading_interpolate_3rd_;
+  SlipCoefficientParameter slip_coefficient_parameter_;
+  SlipCoefficientStatus slip_coefficient_status_;
+  double estimate_coefficient_ = 0.0;
+  bool is_first_correction_velocity_ = false;
+  bool use_can_less_mode_ = false;
 
-void yaw_rate_offset_2nd_callback(const eagleye_msgs::msg::YawrateOffset::ConstSharedPtr msg)
-{
-  yaw_rate_offset_2nd = *msg;
-}
+  rclcpp::Subscription<sensor_msgs::msg::Imu>::SharedPtr sub_imu_;
+  rclcpp::Subscription<rtklib_msgs::msg::RtklibNav>::SharedPtr sub_rtklib_nav_;
+  rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr sub_velocity_;
+  rclcpp::Subscription<eagleye_msgs::msg::StatusStamped>::SharedPtr sub_velocity_status_;
+  rclcpp::Subscription<eagleye_msgs::msg::YawrateOffset>::SharedPtr sub_yaw_rate_offset_stop_;
+  rclcpp::Subscription<eagleye_msgs::msg::YawrateOffset>::SharedPtr sub_yaw_rate_offset_2nd_;
+  rclcpp::Subscription<eagleye_msgs::msg::Heading>::SharedPtr sub_heading_interpolate_3rd_;
 
-void heading_interpolate_3rd_callback(const eagleye_msgs::msg::Heading::ConstSharedPtr msg)
-{
-  heading_interpolate_3rd = *msg;
-}
+  void rtklibNavCallback(const rtklib_msgs::msg::RtklibNav::ConstSharedPtr msg)
+  {
+    rtklib_nav_ = *msg;
+  }
 
-void imu_callback(const sensor_msgs::msg::Imu::ConstSharedPtr msg)
-{
-  if (is_first_correction_velocity == false) return;
-  if (use_can_less_mode && !velocity_status.status.enabled_status) return;
+  void velocityCallback(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg)
+  {
+    velocity_ = *msg;
+    if (
+      is_first_correction_velocity_ == false &&
+      msg->twist.linear.x > slip_coefficient_parameter_.moving_judgment_threshold) {
+      is_first_correction_velocity_ = true;
+    }
+  }
 
-  imu = *msg;
-  slip_coefficient_estimate(imu,rtklib_nav,velocity,yaw_rate_offset_stop,yaw_rate_offset_2nd,heading_interpolate_3rd,slip_coefficient_parameter,&slip_coefficient_status,&estimate_coefficient);
+  void velocityStatusCallback(const eagleye_msgs::msg::StatusStamped::ConstSharedPtr msg)
+  {
+    velocity_status_ = *msg;
+  }
 
-  std::cout << "--- \033[1;34m slip_coefficient \033[m ------------------------------"<< std::endl;
-  std::cout<<"\033[1m estimate_coefficient \033[m "<<estimate_coefficient<<std::endl;
-  std::cout << std::endl;
-}
+  void yawRateOffsetStopCallback(const eagleye_msgs::msg::YawrateOffset::ConstSharedPtr msg)
+  {
+    yaw_rate_offset_stop_ = *msg;
+  }
+
+  void yawRateOffset2ndCallback(const eagleye_msgs::msg::YawrateOffset::ConstSharedPtr msg)
+  {
+    yaw_rate_offset_2nd_ = *msg;
+  }
+
+  void headingInterpolate3rdCallback(const eagleye_msgs::msg::Heading::ConstSharedPtr msg)
+  {
+    heading_interpolate_3rd_ = *msg;
+  }
+
+  void imuCallback(const sensor_msgs::msg::Imu::ConstSharedPtr msg)
+  {
+    if (is_first_correction_velocity_ == false) return;
+    if (use_can_less_mode_ && !velocity_status_.status.enabled_status) return;
+
+    imu_ = *msg;
+    slip_coefficient_estimate(
+      imu_, rtklib_nav_, velocity_, yaw_rate_offset_stop_, yaw_rate_offset_2nd_,
+      heading_interpolate_3rd_, slip_coefficient_parameter_, &slip_coefficient_status_,
+      &estimate_coefficient_);
+
+    std::cout << "--- \033[1;34m slip_coefficient \033[m ------------------------------"
+              << std::endl;
+    std::cout << "\033[1m estimate_coefficient \033[m " << estimate_coefficient_ << std::endl;
+    std::cout << std::endl;
+  }
+};
 
 int main(int argc, char** argv)
 {
   rclcpp::init(argc, argv);
-  auto node = rclcpp::Node::make_shared("eagleye_slip_coefficient");
-
-  std::string subscribe_rtklib_nav_topic_name = "gnss/rtklib_nav";
-
-  std::string yaml_file;
-  node->declare_parameter("yaml_file",yaml_file);
-  node->get_parameter("yaml_file",yaml_file);
-  std::cout << "yaml_file: " << yaml_file << std::endl;
-
-  try
-  {
-    YAML::Node conf = YAML::LoadFile(yaml_file);
-
-    use_can_less_mode = conf["/**"]["ros__parameters"]["use_can_less_mode"].as<bool>();
-
-    slip_coefficient_parameter.imu_rate = conf["/**"]["ros__parameters"]["common"]["imu_rate"].as<double>();
-    slip_coefficient_parameter.stop_judgment_threshold = conf["/**"]["ros__parameters"]["common"]["stop_judgment_threshold"].as<double>();
-    slip_coefficient_parameter.moving_judgment_threshold = conf["/**"]["ros__parameters"]["common"]["moving_judgment_threshold"].as<double>();
-
-    slip_coefficient_parameter.estimated_minimum_interval = conf["/**"]["ros__parameters"]["slip_coefficient"]["estimated_minimum_interval"].as<double>();
-    slip_coefficient_parameter.estimated_maximum_interval = conf["/**"]["ros__parameters"]["slip_coefficient"]["estimated_maximum_interval"].as<double>();
-    slip_coefficient_parameter.curve_judgment_threshold = conf["/**"]["ros__parameters"]["slip_coefficient"]["curve_judgment_threshold"].as<double>();
-    slip_coefficient_parameter.lever_arm = conf["/**"]["ros__parameters"]["slip_coefficient"]["lever_arm"].as<double>();
-
-    std::cout<< "use_can_less_mode " << use_can_less_mode << std::endl;
-
-    std::cout << "imu_rate " << slip_coefficient_parameter.imu_rate << std::endl;
-    std::cout << "stop_judgment_threshold " << slip_coefficient_parameter.stop_judgment_threshold << std::endl;
-    std::cout << "moving_judgment_threshold " << slip_coefficient_parameter.moving_judgment_threshold << std::endl;
-
-    std::cout << "estimated_minimum_interval " << slip_coefficient_parameter.estimated_minimum_interval << std::endl;
-    std::cout << "estimated_maximum_interval " << slip_coefficient_parameter.estimated_maximum_interval << std::endl;
-    std::cout << "curve_judgment_threshold " << slip_coefficient_parameter.curve_judgment_threshold << std::endl;
-    std::cout << "lever_arm " << slip_coefficient_parameter.lever_arm << std::endl;
-  }
-  catch (YAML::Exception& e)
-  {
-    std::cerr << "\033[1;31mslip_coefficient Node YAML Error: " << e.msg << "\033[0m" << std::endl;
-    exit(3);
-  }
-
-  auto sub1 = node->create_subscription<sensor_msgs::msg::Imu>("imu/data_tf_converted", 1000, imu_callback);
-  auto sub2 = node->create_subscription<rtklib_msgs::msg::RtklibNav>(subscribe_rtklib_nav_topic_name, 1000, rtklib_nav_callback);
-  auto sub3 = node->create_subscription<geometry_msgs::msg::TwistStamped>("velocity", rclcpp::QoS(10), velocity_callback);
-  auto sub4 = node->create_subscription<eagleye_msgs::msg::StatusStamped>("velocity_status", rclcpp::QoS(10), velocity_status_callback);
-  auto sub5 = node->create_subscription<eagleye_msgs::msg::YawrateOffset>("yaw_rate_offset_stop", rclcpp::QoS(10), yaw_rate_offset_stop_callback);
-  auto sub6 = node->create_subscription<eagleye_msgs::msg::YawrateOffset>("yaw_rate_offset_2nd", rclcpp::QoS(10), yaw_rate_offset_2nd_callback);
-  auto sub7 = node->create_subscription<eagleye_msgs::msg::Heading>("heading_interpolate_3rd", rclcpp::QoS(10), heading_interpolate_3rd_callback);
-
+  auto node = std::make_shared<SlipCoefficientNode>();
   rclcpp::spin(node);
 
   std::string str;
   node->declare_parameter(str, "output_dir");
   std::ofstream ofs(str, std::ios_base::trunc | std::ios_base::out);
-  ofs << "slip_coefficient" << " : " << estimate_coefficient << std::endl;
+  ofs << "slip_coefficient"
+      << " : " << node->getEstimateCoefficient() << std::endl;
   ofs.close();
 
   return 0;

--- a/eagleye_rt/src/smoothing_node.cpp
+++ b/eagleye_rt/src/smoothing_node.cpp
@@ -28,137 +28,147 @@
  * Author MapIV Takanose
  */
 
-#include "rclcpp/rclcpp.hpp"
 #include "eagleye_coordinate/eagleye_coordinate.hpp"
 #include "eagleye_navigation/eagleye_navigation.hpp"
+#include "rclcpp/rclcpp.hpp"
 
-static rtklib_msgs::msg::RtklibNav rtklib_nav;
-static eagleye_msgs::msg::Position enu_absolute_pos,gnss_smooth_pos_enu;
-static geometry_msgs::msg::TwistStamped velocity;
-static eagleye_msgs::msg::StatusStamped velocity_status;
-rclcpp::Publisher<eagleye_msgs::msg::Position>::SharedPtr pub;
-
-struct PositionParameter position_parameter;
-struct SmoothingParameter smoothing_parameter;
-struct SmoothingStatus smoothing_status;
-
-static bool use_can_less_mode;
-
-rclcpp::Clock clock_(RCL_ROS_TIME);
-tf2_ros::Buffer tfBuffer_(std::make_shared<rclcpp::Clock>(clock_));
-
-const std::string node_name = "eagleye_smoothing";
-
-void velocity_callback(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg)
+class SmoothingNode : public rclcpp::Node
 {
-  velocity = *msg;
-}
-
-void velocity_status_callback(const eagleye_msgs::msg::StatusStamped::ConstSharedPtr msg)
-{
-  velocity_status = *msg;
-}
-
-void rtklib_nav_callback(const rtklib_msgs::msg::RtklibNav::ConstSharedPtr msg)
-{
-  if(use_can_less_mode && !velocity_status.status.enabled_status) return;
-
-  rtklib_nav = *msg;
-  gnss_smooth_pos_enu.header = msg->header;
-  gnss_smooth_pos_enu.header.frame_id = "base_link";
-  smoothing_estimate(rtklib_nav,velocity,smoothing_parameter,&smoothing_status,&gnss_smooth_pos_enu);
-  gnss_smooth_pos_enu.enu_pos.z -= position_parameter.tf_gnss_translation_z;
-  pub->publish(gnss_smooth_pos_enu);
-}
-
-void on_timer()
-{
-  geometry_msgs::msg::TransformStamped transformStamped;
-  try
+public:
+  SmoothingNode()
+  : Node("eagleye_smoothing"),
+    tf_buffer_(this->get_clock()),
+    tf_listener_(tf_buffer_)
   {
-    transformStamped = tfBuffer_.lookupTransform(position_parameter.tf_gnss_parent_frame, position_parameter.tf_gnss_child_frame, tf2::TimePointZero);
+    std::string subscribe_rtklib_nav_topic_name = "gnss/rtklib_nav";
 
-    position_parameter.tf_gnss_translation_x = transformStamped.transform.translation.x;
-    position_parameter.tf_gnss_translation_y = transformStamped.transform.translation.y;
-    position_parameter.tf_gnss_translation_z = transformStamped.transform.translation.z;
-    position_parameter.tf_gnss_rotation_x = transformStamped.transform.rotation.x;
-    position_parameter.tf_gnss_rotation_y = transformStamped.transform.rotation.y;
-    position_parameter.tf_gnss_rotation_z = transformStamped.transform.rotation.z;
-    position_parameter.tf_gnss_rotation_w = transformStamped.transform.rotation.w;
+    std::string yaml_file;
+    this->declare_parameter("yaml_file", yaml_file);
+    this->get_parameter("yaml_file", yaml_file);
+    std::cout << "yaml_file: " << yaml_file << std::endl;
+
+    try {
+      YAML::Node conf = YAML::LoadFile(yaml_file);
+
+      use_can_less_mode_ = conf["/**"]["ros__parameters"]["use_can_less_mode"].as<bool>();
+      position_parameter_.tf_gnss_parent_frame =
+        conf["/**"]["ros__parameters"]["tf_gnss_frame"]["parent"].as<std::string>();
+      position_parameter_.tf_gnss_child_frame =
+        conf["/**"]["ros__parameters"]["tf_gnss_frame"]["child"].as<std::string>();
+      smoothing_parameter_.ecef_base_pos_x =
+        conf["/**"]["ros__parameters"]["ecef_base_pos"]["x"].as<double>();
+      smoothing_parameter_.ecef_base_pos_y =
+        conf["/**"]["ros__parameters"]["ecef_base_pos"]["y"].as<double>();
+      smoothing_parameter_.ecef_base_pos_z =
+        conf["/**"]["ros__parameters"]["ecef_base_pos"]["z"].as<double>();
+      smoothing_parameter_.gnss_rate =
+        conf["/**"]["ros__parameters"]["common"]["gnss_rate"].as<double>();
+      smoothing_parameter_.moving_judgment_threshold =
+        conf["/**"]["ros__parameters"]["common"]["moving_judgment_threshold"].as<double>();
+      smoothing_parameter_.moving_average_time =
+        conf["/**"]["ros__parameters"]["smoothing"]["moving_average_time"].as<double>();
+      smoothing_parameter_.moving_ratio_threshold =
+        conf["/**"]["ros__parameters"]["smoothing"]["moving_ratio_threshold"].as<double>();
+
+      std::cout << "use_can_less_mode " << use_can_less_mode_ << std::endl;
+      std::cout << "subscribe_rtklib_nav_topic_name " << subscribe_rtklib_nav_topic_name
+                << std::endl;
+      std::cout << "ecef_base_pos_x " << smoothing_parameter_.ecef_base_pos_x << std::endl;
+      std::cout << "ecef_base_pos_y " << smoothing_parameter_.ecef_base_pos_y << std::endl;
+      std::cout << "ecef_base_pos_z " << smoothing_parameter_.ecef_base_pos_z << std::endl;
+      std::cout << "gnss_rate " << smoothing_parameter_.gnss_rate << std::endl;
+      std::cout << "moving_judgment_threshold " << smoothing_parameter_.moving_judgment_threshold
+                << std::endl;
+      std::cout << "moving_average_time " << smoothing_parameter_.moving_average_time << std::endl;
+      std::cout << "moving_ratio_threshold " << smoothing_parameter_.moving_ratio_threshold
+                << std::endl;
+    } catch (YAML::Exception& e) {
+      std::cerr << "\033[1;31msmoothing Node YAML Error: " << e.msg << "\033[0m" << std::endl;
+      exit(3);
+    }
+
+    sub_velocity_ = this->create_subscription<geometry_msgs::msg::TwistStamped>(
+      "velocity", rclcpp::QoS(10),
+      std::bind(&SmoothingNode::velocityCallback, this, std::placeholders::_1));
+    sub_velocity_status_ = this->create_subscription<eagleye_msgs::msg::StatusStamped>(
+      "velocity_status", rclcpp::QoS(10),
+      std::bind(&SmoothingNode::velocityStatusCallback, this, std::placeholders::_1));
+    sub_rtklib_nav_ = this->create_subscription<rtklib_msgs::msg::RtklibNav>(
+      subscribe_rtklib_nav_topic_name, 1000,
+      std::bind(&SmoothingNode::rtklibNavCallback, this, std::placeholders::_1));
+    pub_ =
+      this->create_publisher<eagleye_msgs::msg::Position>("gnss_smooth_pos_enu", rclcpp::QoS(10));
+
+    timer_ = this->create_wall_timer(
+      std::chrono::milliseconds(500), std::bind(&SmoothingNode::onTimer, this));
   }
-  catch (tf2::TransformException& ex)
+
+private:
+  rtklib_msgs::msg::RtklibNav rtklib_nav_;
+  eagleye_msgs::msg::Position gnss_smooth_pos_enu_;
+  geometry_msgs::msg::TwistStamped velocity_;
+  eagleye_msgs::msg::StatusStamped velocity_status_;
+  PositionParameter position_parameter_;
+  SmoothingParameter smoothing_parameter_;
+  SmoothingStatus smoothing_status_;
+  bool use_can_less_mode_ = false;
+
+  tf2_ros::Buffer tf_buffer_;
+  tf2_ros::TransformListener tf_listener_;
+  rclcpp::TimerBase::SharedPtr timer_;
+  rclcpp::Publisher<eagleye_msgs::msg::Position>::SharedPtr pub_;
+  rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr sub_velocity_;
+  rclcpp::Subscription<eagleye_msgs::msg::StatusStamped>::SharedPtr sub_velocity_status_;
+  rclcpp::Subscription<rtklib_msgs::msg::RtklibNav>::SharedPtr sub_rtklib_nav_;
+
+  void velocityCallback(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg)
   {
-    RCLCPP_WARN(rclcpp::get_logger(node_name), "%s", ex.what());
-    return;
+    velocity_ = *msg;
   }
-}
 
+  void velocityStatusCallback(const eagleye_msgs::msg::StatusStamped::ConstSharedPtr msg)
+  {
+    velocity_status_ = *msg;
+  }
+
+  void rtklibNavCallback(const rtklib_msgs::msg::RtklibNav::ConstSharedPtr msg)
+  {
+    if (use_can_less_mode_ && !velocity_status_.status.enabled_status) return;
+
+    rtklib_nav_ = *msg;
+    gnss_smooth_pos_enu_.header = msg->header;
+    gnss_smooth_pos_enu_.header.frame_id = "base_link";
+    smoothing_estimate(
+      rtklib_nav_, velocity_, smoothing_parameter_, &smoothing_status_, &gnss_smooth_pos_enu_);
+    gnss_smooth_pos_enu_.enu_pos.z -= position_parameter_.tf_gnss_translation_z;
+    pub_->publish(gnss_smooth_pos_enu_);
+  }
+
+  void onTimer()
+  {
+    geometry_msgs::msg::TransformStamped transformStamped;
+    try {
+      transformStamped = tf_buffer_.lookupTransform(
+        position_parameter_.tf_gnss_parent_frame, position_parameter_.tf_gnss_child_frame,
+        tf2::TimePointZero);
+
+      position_parameter_.tf_gnss_translation_x = transformStamped.transform.translation.x;
+      position_parameter_.tf_gnss_translation_y = transformStamped.transform.translation.y;
+      position_parameter_.tf_gnss_translation_z = transformStamped.transform.translation.z;
+      position_parameter_.tf_gnss_rotation_x = transformStamped.transform.rotation.x;
+      position_parameter_.tf_gnss_rotation_y = transformStamped.transform.rotation.y;
+      position_parameter_.tf_gnss_rotation_z = transformStamped.transform.rotation.z;
+      position_parameter_.tf_gnss_rotation_w = transformStamped.transform.rotation.w;
+    } catch (tf2::TransformException& ex) {
+      RCLCPP_WARN(this->get_logger(), "%s", ex.what());
+      return;
+    }
+  }
+};
 
 int main(int argc, char** argv)
 {
   rclcpp::init(argc, argv);
-  auto node = rclcpp::Node::make_shared(node_name);
-
-  std::string subscribe_rtklib_nav_topic_name = "gnss/rtklib_nav";
-
-  std::string yaml_file;
-  node->declare_parameter("yaml_file",yaml_file);
-  node->get_parameter("yaml_file",yaml_file);
-  std::cout << "yaml_file: " << yaml_file << std::endl;
-
-  try
-  {
-    YAML::Node conf = YAML::LoadFile(yaml_file);
-
-    use_can_less_mode = conf["/**"]["ros__parameters"]["use_can_less_mode"].as<bool>();
-
-    position_parameter.tf_gnss_parent_frame = conf["/**"]["ros__parameters"]["tf_gnss_frame"]["parent"].as<std::string>();
-    position_parameter.tf_gnss_child_frame = conf["/**"]["ros__parameters"]["tf_gnss_frame"]["child"].as<std::string>();
-
-    smoothing_parameter.ecef_base_pos_x = conf["/**"]["ros__parameters"]["ecef_base_pos"]["x"].as<double>();
-    smoothing_parameter.ecef_base_pos_y = conf["/**"]["ros__parameters"]["ecef_base_pos"]["y"].as<double>();
-    smoothing_parameter.ecef_base_pos_z = conf["/**"]["ros__parameters"]["ecef_base_pos"]["z"].as<double>();
-
-    smoothing_parameter.gnss_rate = conf["/**"]["ros__parameters"]["common"]["gnss_rate"].as<double>();
-    smoothing_parameter.moving_judgment_threshold = conf["/**"]["ros__parameters"]["common"]["moving_judgment_threshold"].as<double>();
-    smoothing_parameter.moving_average_time = conf["/**"]["ros__parameters"]["smoothing"]["moving_average_time"].as<double>();
-    smoothing_parameter.moving_ratio_threshold = conf["/**"]["ros__parameters"]["smoothing"]["moving_ratio_threshold"].as<double>();
-
-    std::cout<< "use_can_less_mode " << use_can_less_mode << std::endl;
-
-    std::cout<< "subscribe_rtklib_nav_topic_name " << subscribe_rtklib_nav_topic_name << std::endl;
-
-    std::cout<< "ecef_base_pos_x " << smoothing_parameter.ecef_base_pos_x << std::endl;
-    std::cout<< "ecef_base_pos_y " << smoothing_parameter.ecef_base_pos_y << std::endl;
-    std::cout<< "ecef_base_pos_z " << smoothing_parameter.ecef_base_pos_z << std::endl;
-
-    std::cout << "gnss_rate " << smoothing_parameter.gnss_rate << std::endl;
-    std::cout << "moving_judgment_threshold " << smoothing_parameter.moving_judgment_threshold << std::endl;
-    std::cout << "moving_average_time " << smoothing_parameter.moving_average_time << std::endl;
-    std::cout << "moving_ratio_threshold " << smoothing_parameter.moving_ratio_threshold << std::endl;
-  }
-  catch (YAML::Exception& e)
-  {
-    std::cerr << "\033[1;31msmoothing Node YAML Error: " << e.msg << "\033[0m" << std::endl;
-    exit(3);
-  }
-
-  auto sub1 = node->create_subscription<geometry_msgs::msg::TwistStamped>("velocity", rclcpp::QoS(10), velocity_callback);
-  auto sub2 = node->create_subscription<eagleye_msgs::msg::StatusStamped>("velocity_status", rclcpp::QoS(10), velocity_status_callback);
-  auto sub3 = node->create_subscription<rtklib_msgs::msg::RtklibNav>(subscribe_rtklib_nav_topic_name, 1000, rtklib_nav_callback);
-  pub = node->create_publisher<eagleye_msgs::msg::Position>("gnss_smooth_pos_enu", rclcpp::QoS(10));
-
-  const auto period_ns =
-      std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::duration<double>(0.5));
-  auto timer_callback = std::bind(on_timer);
-  auto timer = std::make_shared<rclcpp::GenericTimer<decltype(timer_callback)>>(
-    node->get_clock(), period_ns, std::move(timer_callback),
-    node->get_node_base_interface()->get_context());
-  node->get_node_timers_interface()->add_timer(timer, nullptr);
-
-  tf2_ros::TransformListener listener(tfBuffer_);
-
-  rclcpp::spin(node);
-
+  rclcpp::spin(std::make_shared<SmoothingNode>());
   return 0;
 }

--- a/eagleye_rt/src/smoothing_node.cpp
+++ b/eagleye_rt/src/smoothing_node.cpp
@@ -110,7 +110,7 @@ private:
   eagleye_msgs::msg::StatusStamped velocity_status_;
   PositionParameter position_parameter_;
   SmoothingParameter smoothing_parameter_;
-  SmoothingStatus smoothing_status_;
+  SmoothingStatus smoothing_status_ = {};
   bool use_can_less_mode_ = false;
 
   tf2_ros::Buffer tf_buffer_;

--- a/eagleye_rt/src/trajectory_node.cpp
+++ b/eagleye_rt/src/trajectory_node.cpp
@@ -149,7 +149,7 @@ private:
   geometry_msgs::msg::TwistWithCovarianceStamped eagleye_twist_with_covariance_;
 
   TrajectoryParameter trajectory_parameter_;
-  TrajectoryStatus trajectory_status_;
+  TrajectoryStatus trajectory_status_ = {};
 
   double th_deadlock_time_ = 1;
   double imu_time_last_ = 0;

--- a/eagleye_rt/src/trajectory_node.cpp
+++ b/eagleye_rt/src/trajectory_node.cpp
@@ -28,215 +28,254 @@
  * Author MapIV Sekino
  */
 
-#include "rclcpp/rclcpp.hpp"
 #include "eagleye_coordinate/eagleye_coordinate.hpp"
 #include "eagleye_navigation/eagleye_navigation.hpp"
+#include "rclcpp/rclcpp.hpp"
 
-static sensor_msgs::msg::Imu imu;
-static geometry_msgs::msg::TwistStamped velocity;
-static eagleye_msgs::msg::StatusStamped velocity_status;
-static geometry_msgs::msg::TwistStamped correction_velocity;
-static eagleye_msgs::msg::VelocityScaleFactor velocity_scale_factor;
-static eagleye_msgs::msg::Heading heading_interpolate_3rd;
-static eagleye_msgs::msg::YawrateOffset yaw_rate_offset_stop;
-static eagleye_msgs::msg::YawrateOffset yaw_rate_offset_2nd;
-static eagleye_msgs::msg::Pitching pitching;
-
-static geometry_msgs::msg::Vector3Stamped enu_vel;
-static eagleye_msgs::msg::Position enu_relative_pos;
-static geometry_msgs::msg::TwistStamped eagleye_twist;
-static geometry_msgs::msg::TwistWithCovarianceStamped eagleye_twist_with_covariance;
-rclcpp::Publisher<geometry_msgs::msg::Vector3Stamped>::SharedPtr pub1;
-rclcpp::Publisher<eagleye_msgs::msg::Position>::SharedPtr pub2;
-rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr pub3;
-rclcpp::Publisher<geometry_msgs::msg::TwistWithCovarianceStamped>::SharedPtr pub4;
-
-struct TrajectoryParameter trajectory_parameter;
-struct TrajectoryStatus trajectory_status;
-
-static double timer_update_rate = 10;
-static double th_deadlock_time = 1;
-
-static double imu_time_last,velocity_time_last;
-static bool input_status;
-
-static bool use_can_less_mode;
-
-static std::string node_name = "eagleye_trajectory";
-
-void correction_velocity_callback(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg)
+class TrajectoryNode : public rclcpp::Node
 {
-  correction_velocity = *msg;
-}
-
-void velocity_status_callback(const eagleye_msgs::msg::StatusStamped::ConstSharedPtr msg)
-{
-  velocity_status = *msg;
-}
-
-void velocity_scale_factor_callback(const eagleye_msgs::msg::VelocityScaleFactor::ConstSharedPtr msg)
-{
-  velocity_scale_factor = *msg;
-}
-
-void heading_interpolate_3rd_callback(const eagleye_msgs::msg::Heading::ConstSharedPtr msg)
-{
-  heading_interpolate_3rd = *msg;
-}
-
-void yaw_rate_offset_stop_callback(const eagleye_msgs::msg::YawrateOffset::ConstSharedPtr msg)
-{
-  yaw_rate_offset_stop = *msg;
-}
-
-void yaw_rate_offset_2nd_callback(const eagleye_msgs::msg::YawrateOffset::ConstSharedPtr msg)
-{
-  yaw_rate_offset_2nd = *msg;
-}
-
-void pitching_callback(const eagleye_msgs::msg::Pitching::ConstSharedPtr msg)
-{
-  pitching = *msg;
-}
-
-void velocity_callback(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg)
-{
-  velocity = *msg;
-}
-
-void on_timer()
-{
-  rclcpp::Time imu_clock(imu.header.stamp);
-  double imu_time = imu_clock.seconds();
-  rclcpp::Time velocity_clock(velocity.header.stamp);
-  double velocity_time = velocity_clock.seconds();
-  if (std::abs(imu_time - imu_time_last) < th_deadlock_time &&
-      std::abs(velocity_time - velocity_time_last) < th_deadlock_time &&
-      std::abs(velocity_time - imu_time) < th_deadlock_time)
+public:
+  TrajectoryNode() : Node("eagleye_trajectory")
   {
-    input_status = true;
-  }
-  else
-  {
-    input_status = false;
-    RCLCPP_WARN(rclcpp::get_logger(node_name), "Twist is missing the required input topics.");
-  }
+    std::string subscribe_twist_topic_name = "vehicle/twist";
 
-  if (imu_time != imu_time_last) imu_time_last = imu_time;
-  if (velocity_time != velocity_time_last) velocity_time_last = velocity_time;
-}
+    std::string yaml_file;
+    this->declare_parameter("yaml_file", yaml_file);
+    this->get_parameter("yaml_file", yaml_file);
+    std::cout << "yaml_file: " << yaml_file << std::endl;
 
-void imu_callback(const sensor_msgs::msg::Imu::ConstSharedPtr msg)
-{
-  if(use_can_less_mode && !velocity_status.status.enabled_status) return;
+    double timer_update_rate = 10;
 
-  eagleye_msgs::msg::StatusStamped velocity_enable_status;
-  if(use_can_less_mode)
-  {
-    velocity_enable_status = velocity_status;
-  }
-  else
-  {
-    velocity_enable_status.header = velocity_scale_factor.header;
-    velocity_enable_status.status = velocity_scale_factor.status;
-  }
+    try {
+      YAML::Node conf = YAML::LoadFile(yaml_file);
 
-  imu = *msg;
-  if(input_status)
-  {
-    enu_vel.header = msg->header;
-    enu_vel.header.frame_id = "gnss";
-    enu_relative_pos.header = msg->header;
-    enu_relative_pos.header.frame_id = "base_link";
-    eagleye_twist.header = msg->header;
-    eagleye_twist.header.frame_id = "base_link";
-    eagleye_twist_with_covariance.header = msg->header;
-    eagleye_twist_with_covariance.header.frame_id = "base_link";
-    trajectory3d_estimate(imu,correction_velocity,velocity_enable_status,heading_interpolate_3rd,yaw_rate_offset_stop,yaw_rate_offset_2nd,pitching,
-      trajectory_parameter,&trajectory_status,&enu_vel,&enu_relative_pos,&eagleye_twist, &eagleye_twist_with_covariance);
+      use_can_less_mode_ = conf["/**"]["ros__parameters"]["use_can_less_mode"].as<bool>();
+      trajectory_parameter_.stop_judgment_threshold =
+        conf["/**"]["ros__parameters"]["common"]["stop_judgment_threshold"].as<double>();
+      trajectory_parameter_.curve_judgment_threshold =
+        conf["/**"]["ros__parameters"]["trajectory"]["curve_judgment_threshold"].as<double>();
+      trajectory_parameter_.sensor_noise_velocity =
+        conf["/**"]["ros__parameters"]["trajectory"]["sensor_noise_velocity"].as<double>();
+      trajectory_parameter_.sensor_scale_noise_velocity =
+        conf["/**"]["ros__parameters"]["trajectory"]["sensor_scale_noise_velocity"]
+          .as<double>();
+      trajectory_parameter_.sensor_noise_yaw_rate =
+        conf["/**"]["ros__parameters"]["trajectory"]["sensor_noise_yaw_rate"].as<double>();
+      trajectory_parameter_.sensor_bias_noise_yaw_rate =
+        conf["/**"]["ros__parameters"]["trajectory"]["sensor_bias_noise_yaw_rate"].as<double>();
+      timer_update_rate =
+        conf["/**"]["ros__parameters"]["trajectory"]["timer_update_rate"].as<double>();
 
-    if (heading_interpolate_3rd.status.enabled_status)
-    {
-      pub1->publish(enu_vel);
-      pub2->publish(enu_relative_pos);
+      std::cout << "use_can_less_mode " << use_can_less_mode_ << std::endl;
+      std::cout << "subscribe_twist_topic_name " << subscribe_twist_topic_name << std::endl;
+      std::cout << "stop_judgment_threshold " << trajectory_parameter_.stop_judgment_threshold
+                << std::endl;
+      std::cout << "curve_judgment_threshold " << trajectory_parameter_.curve_judgment_threshold
+                << std::endl;
+      std::cout << "sensor_noise_velocity " << trajectory_parameter_.sensor_noise_velocity
+                << std::endl;
+      std::cout << "sensor_scale_noise_velocity "
+                << trajectory_parameter_.sensor_scale_noise_velocity << std::endl;
+      std::cout << "sensor_noise_yaw_rate " << trajectory_parameter_.sensor_noise_yaw_rate
+                << std::endl;
+      std::cout << "sensor_bias_noise_yaw_rate "
+                << trajectory_parameter_.sensor_bias_noise_yaw_rate << std::endl;
+      std::cout << "timer_update_rate " << timer_update_rate << std::endl;
+    } catch (YAML::Exception& e) {
+      std::cerr << "\033[1;31mtrajectory Node YAML Error: " << e.msg << "\033[0m" << std::endl;
+      exit(3);
     }
-    pub3->publish(eagleye_twist);
-    pub4->publish(eagleye_twist_with_covariance);
+
+    sub_imu_ = this->create_subscription<sensor_msgs::msg::Imu>(
+      "imu/data_tf_converted", 1000,
+      std::bind(&TrajectoryNode::imuCallback, this, std::placeholders::_1));
+    sub_velocity_ = this->create_subscription<geometry_msgs::msg::TwistStamped>(
+      subscribe_twist_topic_name, rclcpp::QoS(10),
+      std::bind(&TrajectoryNode::velocityCallback, this, std::placeholders::_1));
+    sub_correction_velocity_ = this->create_subscription<geometry_msgs::msg::TwistStamped>(
+      "velocity", rclcpp::QoS(10),
+      std::bind(&TrajectoryNode::correctionVelocityCallback, this, std::placeholders::_1));
+    sub_velocity_status_ = this->create_subscription<eagleye_msgs::msg::StatusStamped>(
+      "velocity_status", rclcpp::QoS(10),
+      std::bind(&TrajectoryNode::velocityStatusCallback, this, std::placeholders::_1));
+    sub_velocity_scale_factor_ =
+      this->create_subscription<eagleye_msgs::msg::VelocityScaleFactor>(
+        "velocity_scale_factor", rclcpp::QoS(10),
+        std::bind(
+          &TrajectoryNode::velocityScaleFactorCallback, this, std::placeholders::_1));
+    sub_heading_interpolate_3rd_ = this->create_subscription<eagleye_msgs::msg::Heading>(
+      "heading_interpolate_3rd", rclcpp::QoS(10),
+      std::bind(
+        &TrajectoryNode::headingInterpolate3rdCallback, this, std::placeholders::_1));
+    sub_yaw_rate_offset_stop_ = this->create_subscription<eagleye_msgs::msg::YawrateOffset>(
+      "yaw_rate_offset_stop", rclcpp::QoS(10),
+      std::bind(&TrajectoryNode::yawRateOffsetStopCallback, this, std::placeholders::_1));
+    sub_yaw_rate_offset_2nd_ = this->create_subscription<eagleye_msgs::msg::YawrateOffset>(
+      "yaw_rate_offset_2nd", rclcpp::QoS(10),
+      std::bind(&TrajectoryNode::yawRateOffset2ndCallback, this, std::placeholders::_1));
+    sub_pitching_ = this->create_subscription<eagleye_msgs::msg::Pitching>(
+      "pitching", rclcpp::QoS(10),
+      std::bind(&TrajectoryNode::pitchingCallback, this, std::placeholders::_1));
+
+    pub_enu_vel_ =
+      this->create_publisher<geometry_msgs::msg::Vector3Stamped>("enu_vel", 1000);
+    pub_enu_relative_pos_ =
+      this->create_publisher<eagleye_msgs::msg::Position>("enu_relative_pos", 1000);
+    pub_twist_ = this->create_publisher<geometry_msgs::msg::TwistStamped>("twist", 1000);
+    pub_twist_with_covariance_ =
+      this->create_publisher<geometry_msgs::msg::TwistWithCovarianceStamped>(
+        "twist_with_covariance", 1000);
+
+    const auto period_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
+      std::chrono::duration<double>(1.0 / timer_update_rate));
+    timer_ = this->create_wall_timer(
+      period_ns, std::bind(&TrajectoryNode::onTimer, this));
   }
-}
+
+private:
+  sensor_msgs::msg::Imu imu_;
+  geometry_msgs::msg::TwistStamped velocity_;
+  eagleye_msgs::msg::StatusStamped velocity_status_;
+  geometry_msgs::msg::TwistStamped correction_velocity_;
+  eagleye_msgs::msg::VelocityScaleFactor velocity_scale_factor_;
+  eagleye_msgs::msg::Heading heading_interpolate_3rd_;
+  eagleye_msgs::msg::YawrateOffset yaw_rate_offset_stop_;
+  eagleye_msgs::msg::YawrateOffset yaw_rate_offset_2nd_;
+  eagleye_msgs::msg::Pitching pitching_;
+
+  geometry_msgs::msg::Vector3Stamped enu_vel_;
+  eagleye_msgs::msg::Position enu_relative_pos_;
+  geometry_msgs::msg::TwistStamped eagleye_twist_;
+  geometry_msgs::msg::TwistWithCovarianceStamped eagleye_twist_with_covariance_;
+
+  TrajectoryParameter trajectory_parameter_;
+  TrajectoryStatus trajectory_status_;
+
+  double th_deadlock_time_ = 1;
+  double imu_time_last_ = 0;
+  double velocity_time_last_ = 0;
+  bool input_status_ = false;
+  bool use_can_less_mode_ = false;
+
+  rclcpp::TimerBase::SharedPtr timer_;
+  rclcpp::Publisher<geometry_msgs::msg::Vector3Stamped>::SharedPtr pub_enu_vel_;
+  rclcpp::Publisher<eagleye_msgs::msg::Position>::SharedPtr pub_enu_relative_pos_;
+  rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr pub_twist_;
+  rclcpp::Publisher<geometry_msgs::msg::TwistWithCovarianceStamped>::SharedPtr
+    pub_twist_with_covariance_;
+  rclcpp::Subscription<sensor_msgs::msg::Imu>::SharedPtr sub_imu_;
+  rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr sub_velocity_;
+  rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr sub_correction_velocity_;
+  rclcpp::Subscription<eagleye_msgs::msg::StatusStamped>::SharedPtr sub_velocity_status_;
+  rclcpp::Subscription<eagleye_msgs::msg::VelocityScaleFactor>::SharedPtr
+    sub_velocity_scale_factor_;
+  rclcpp::Subscription<eagleye_msgs::msg::Heading>::SharedPtr sub_heading_interpolate_3rd_;
+  rclcpp::Subscription<eagleye_msgs::msg::YawrateOffset>::SharedPtr sub_yaw_rate_offset_stop_;
+  rclcpp::Subscription<eagleye_msgs::msg::YawrateOffset>::SharedPtr sub_yaw_rate_offset_2nd_;
+  rclcpp::Subscription<eagleye_msgs::msg::Pitching>::SharedPtr sub_pitching_;
+
+  void correctionVelocityCallback(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg)
+  {
+    correction_velocity_ = *msg;
+  }
+
+  void velocityStatusCallback(const eagleye_msgs::msg::StatusStamped::ConstSharedPtr msg)
+  {
+    velocity_status_ = *msg;
+  }
+
+  void velocityScaleFactorCallback(
+    const eagleye_msgs::msg::VelocityScaleFactor::ConstSharedPtr msg)
+  {
+    velocity_scale_factor_ = *msg;
+  }
+
+  void headingInterpolate3rdCallback(const eagleye_msgs::msg::Heading::ConstSharedPtr msg)
+  {
+    heading_interpolate_3rd_ = *msg;
+  }
+
+  void yawRateOffsetStopCallback(const eagleye_msgs::msg::YawrateOffset::ConstSharedPtr msg)
+  {
+    yaw_rate_offset_stop_ = *msg;
+  }
+
+  void yawRateOffset2ndCallback(const eagleye_msgs::msg::YawrateOffset::ConstSharedPtr msg)
+  {
+    yaw_rate_offset_2nd_ = *msg;
+  }
+
+  void pitchingCallback(const eagleye_msgs::msg::Pitching::ConstSharedPtr msg)
+  {
+    pitching_ = *msg;
+  }
+
+  void velocityCallback(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg)
+  {
+    velocity_ = *msg;
+  }
+
+  void onTimer()
+  {
+    rclcpp::Time imu_clock(imu_.header.stamp);
+    double imu_time = imu_clock.seconds();
+    rclcpp::Time velocity_clock(velocity_.header.stamp);
+    double velocity_time = velocity_clock.seconds();
+    if (
+      std::abs(imu_time - imu_time_last_) < th_deadlock_time_ &&
+      std::abs(velocity_time - velocity_time_last_) < th_deadlock_time_ &&
+      std::abs(velocity_time - imu_time) < th_deadlock_time_) {
+      input_status_ = true;
+    } else {
+      input_status_ = false;
+      RCLCPP_WARN(this->get_logger(), "Twist is missing the required input topics.");
+    }
+
+    if (imu_time != imu_time_last_) imu_time_last_ = imu_time;
+    if (velocity_time != velocity_time_last_) velocity_time_last_ = velocity_time;
+  }
+
+  void imuCallback(const sensor_msgs::msg::Imu::ConstSharedPtr msg)
+  {
+    if (use_can_less_mode_ && !velocity_status_.status.enabled_status) return;
+
+    eagleye_msgs::msg::StatusStamped velocity_enable_status;
+    if (use_can_less_mode_) {
+      velocity_enable_status = velocity_status_;
+    } else {
+      velocity_enable_status.header = velocity_scale_factor_.header;
+      velocity_enable_status.status = velocity_scale_factor_.status;
+    }
+
+    imu_ = *msg;
+    if (input_status_) {
+      enu_vel_.header = msg->header;
+      enu_vel_.header.frame_id = "gnss";
+      enu_relative_pos_.header = msg->header;
+      enu_relative_pos_.header.frame_id = "base_link";
+      eagleye_twist_.header = msg->header;
+      eagleye_twist_.header.frame_id = "base_link";
+      eagleye_twist_with_covariance_.header = msg->header;
+      eagleye_twist_with_covariance_.header.frame_id = "base_link";
+      trajectory3d_estimate(
+        imu_, correction_velocity_, velocity_enable_status, heading_interpolate_3rd_,
+        yaw_rate_offset_stop_, yaw_rate_offset_2nd_, pitching_, trajectory_parameter_,
+        &trajectory_status_, &enu_vel_, &enu_relative_pos_, &eagleye_twist_,
+        &eagleye_twist_with_covariance_);
+
+      if (heading_interpolate_3rd_.status.enabled_status) {
+        pub_enu_vel_->publish(enu_vel_);
+        pub_enu_relative_pos_->publish(enu_relative_pos_);
+      }
+      pub_twist_->publish(eagleye_twist_);
+      pub_twist_with_covariance_->publish(eagleye_twist_with_covariance_);
+    }
+  }
+};
 
 int main(int argc, char** argv)
 {
   rclcpp::init(argc, argv);
-  auto node = rclcpp::Node::make_shared(node_name);
-
-  std::string subscribe_twist_topic_name = "vehicle/twist";
-
-  std::string yaml_file;
-  node->declare_parameter("yaml_file",yaml_file);
-  node->get_parameter("yaml_file",yaml_file);
-  std::cout << "yaml_file: " << yaml_file << std::endl;
-
-  try
-  {
-    YAML::Node conf = YAML::LoadFile(yaml_file);
-
-    use_can_less_mode = conf["/**"]["ros__parameters"]["use_can_less_mode"].as<bool>();
-    trajectory_parameter.stop_judgment_threshold = conf["/**"]["ros__parameters"]["common"]["stop_judgment_threshold"].as<double>();
-    trajectory_parameter.curve_judgment_threshold = conf["/**"]["ros__parameters"]["trajectory"]["curve_judgment_threshold"].as<double>();
-    trajectory_parameter.sensor_noise_velocity = conf["/**"]["ros__parameters"]["trajectory"]["sensor_noise_velocity"].as<double>();
-    trajectory_parameter.sensor_scale_noise_velocity = conf["/**"]["ros__parameters"]["trajectory"]["sensor_scale_noise_velocity"].as<double>();
-    trajectory_parameter.sensor_noise_yaw_rate = conf["/**"]["ros__parameters"]["trajectory"]["sensor_noise_yaw_rate"].as<double>();
-    trajectory_parameter.sensor_bias_noise_yaw_rate = conf["/**"]["ros__parameters"]["trajectory"]["sensor_bias_noise_yaw_rate"].as<double>();
-    timer_update_rate = conf["/**"]["ros__parameters"]["trajectory"]["timer_update_rate"].as<double>();
-    // deadlock_threshold = conf["/**"]["ros__parameters"]["trajectory"]["deadlock_threshold"].as<double>();
-
-    std::cout<< "use_can_less_mode " << use_can_less_mode << std::endl;
-
-    std::cout<< "subscribe_twist_topic_name " << subscribe_twist_topic_name << std::endl;
-
-    std::cout << "stop_judgment_threshold " << trajectory_parameter.stop_judgment_threshold << std::endl;
-
-    std::cout << "curve_judgment_threshold " << trajectory_parameter.curve_judgment_threshold << std::endl;
-
-    std::cout << "sensor_noise_velocity " << trajectory_parameter.sensor_noise_velocity << std::endl;
-    std::cout << "sensor_scale_noise_velocity " << trajectory_parameter.sensor_scale_noise_velocity << std::endl;
-    std::cout << "sensor_noise_yaw_rate " << trajectory_parameter.sensor_noise_yaw_rate << std::endl;
-    std::cout << "sensor_bias_noise_yaw_rate " << trajectory_parameter.sensor_bias_noise_yaw_rate << std::endl;
-
-    std::cout << "timer_update_rate " << timer_update_rate << std::endl;
-    // std::cout << "deadlock_threshold " << deadlock_threshold << std::endl;
-  }
-  catch (YAML::Exception& e)
-  {
-    std::cerr << "\033[1;31mtrajectory Node YAML Error: " << e.msg << "\033[0m" << std::endl;
-    exit(3);
-  }
-
-  auto sub1 = node->create_subscription<sensor_msgs::msg::Imu>("imu/data_tf_converted", 1000, imu_callback);
-  auto sub2 = node->create_subscription<geometry_msgs::msg::TwistStamped>(subscribe_twist_topic_name, rclcpp::QoS(10), velocity_callback);
-  auto sub3 = node->create_subscription<geometry_msgs::msg::TwistStamped>("velocity", rclcpp::QoS(10), correction_velocity_callback);
-  auto sub4 = node->create_subscription<eagleye_msgs::msg::StatusStamped>("velocity_status", rclcpp::QoS(10), velocity_status_callback);
-  auto sub5 = node->create_subscription<eagleye_msgs::msg::VelocityScaleFactor>("velocity_scale_factor", rclcpp::QoS(10), velocity_scale_factor_callback);
-  auto sub6 = node->create_subscription<eagleye_msgs::msg::Heading>("heading_interpolate_3rd", rclcpp::QoS(10), heading_interpolate_3rd_callback);
-  auto sub7 = node->create_subscription<eagleye_msgs::msg::YawrateOffset>("yaw_rate_offset_stop", rclcpp::QoS(10), yaw_rate_offset_stop_callback);
-  auto sub8 = node->create_subscription<eagleye_msgs::msg::YawrateOffset>("yaw_rate_offset_2nd", rclcpp::QoS(10), yaw_rate_offset_2nd_callback);
-  auto sub9 = node->create_subscription<eagleye_msgs::msg::Pitching>("pitching", rclcpp::QoS(10), pitching_callback);
-  pub1 = node->create_publisher<geometry_msgs::msg::Vector3Stamped>("enu_vel", 1000);
-  pub2 = node->create_publisher<eagleye_msgs::msg::Position>("enu_relative_pos", 1000);
-  pub3 = node->create_publisher<geometry_msgs::msg::TwistStamped>("twist", 1000);
-  pub4 = node->create_publisher<geometry_msgs::msg::TwistWithCovarianceStamped>("twist_with_covariance", 1000);
-
-  double delta_time = 1.0 / static_cast<double>(timer_update_rate);
-  auto timer_callback = std::bind(on_timer);
-  const auto period_ns =
-    std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::duration<double>(delta_time));
-  auto timer = std::make_shared<rclcpp::GenericTimer<decltype(timer_callback)>>(
-    node->get_clock(), period_ns, std::move(timer_callback),
-    node->get_node_base_interface()->get_context());
-  node->get_node_timers_interface()->add_timer(timer, nullptr);
-
-  rclcpp::spin(node);
-
+  rclcpp::spin(std::make_shared<TrajectoryNode>());
   return 0;
 }

--- a/eagleye_rt/src/velocity_estimator_node.cpp
+++ b/eagleye_rt/src/velocity_estimator_node.cpp
@@ -28,80 +28,79 @@
  * Author MapIV Takanose
  */
 
-#include "rclcpp/rclcpp.hpp"
-#include <yaml-cpp/yaml.h>
-
 #include "eagleye_coordinate/eagleye_coordinate.hpp"
 #include "eagleye_navigation/eagleye_navigation.hpp"
+#include "rclcpp/rclcpp.hpp"
 
-rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr velocity_pub;
-rclcpp::Publisher<eagleye_msgs::msg::StatusStamped>::SharedPtr velocity_status_pub;
+#include <yaml-cpp/yaml.h>
 
-static rtklib_msgs::msg::RtklibNav rtklib_nav_msg;
-static nmea_msgs::msg::Gpgga gga_msg;
-static sensor_msgs::msg::Imu imu_msg;
-
-VelocityEstimator velocity_estimator;
-static geometry_msgs::msg::TwistStamped velocity_msg;
-
-static std::string yaml_file;
-static std::string subscribe_rtklib_nav_topic_name = "gnss/rtklib_nav";
-static std::string subscribe_gga_topic_name = "gnss/gga";
-
-void rtklib_nav_callback(const rtklib_msgs::msg::RtklibNav::ConstSharedPtr msg)
+class VelocityEstimatorNode : public rclcpp::Node
 {
-  rtklib_nav_msg = *msg;
-}
-
-void gga_callback(const nmea_msgs::msg::Gpgga::ConstSharedPtr msg)
-{
-  gga_msg = *msg;
-}
-
-void imu_callback(const sensor_msgs::msg::Imu::ConstSharedPtr msg)
-{
-  imu_msg = *msg;
-
-  velocity_estimator.VelocityEstimate(imu_msg, rtklib_nav_msg, gga_msg, &velocity_msg);
-
-  eagleye_msgs::msg::StatusStamped velocity_status;
-  velocity_status.header = msg->header;
-  velocity_status.status = velocity_estimator.getStatus();
-  velocity_status_pub->publish(velocity_status);
-
-  if(velocity_status.status.enabled_status)
+public:
+  VelocityEstimatorNode() : Node("eagleye_velocity_estimator")
   {
-    velocity_pub->publish(velocity_msg);
+    std::string yaml_file;
+    this->declare_parameter("yaml_file", yaml_file);
+    this->get_parameter("yaml_file", yaml_file);
+
+    velocity_estimator_.setParam(yaml_file);
+
+    sub_rtklib_nav_ = this->create_subscription<rtklib_msgs::msg::RtklibNav>(
+      "gnss/rtklib_nav", 1000,
+      std::bind(&VelocityEstimatorNode::rtklibNavCallback, this, std::placeholders::_1));
+    sub_gga_ = this->create_subscription<nmea_msgs::msg::Gpgga>(
+      "gnss/gga", 1000,
+      std::bind(&VelocityEstimatorNode::ggaCallback, this, std::placeholders::_1));
+    sub_imu_ = this->create_subscription<sensor_msgs::msg::Imu>(
+      "imu/data_tf_converted", 1000,
+      std::bind(&VelocityEstimatorNode::imuCallback, this, std::placeholders::_1));
+
+    pub_velocity_ =
+      this->create_publisher<geometry_msgs::msg::TwistStamped>("velocity", 1000);
+    pub_velocity_status_ =
+      this->create_publisher<eagleye_msgs::msg::StatusStamped>("velocity_status", 1000);
   }
 
-}
+private:
+  rtklib_msgs::msg::RtklibNav rtklib_nav_msg_;
+  nmea_msgs::msg::Gpgga gga_msg_;
+  sensor_msgs::msg::Imu imu_msg_;
+  geometry_msgs::msg::TwistStamped velocity_msg_;
+  VelocityEstimator velocity_estimator_;
 
-void velocity_estimator_node(rclcpp::Node::SharedPtr node)
-{
-  node->declare_parameter("yaml_file",yaml_file);
-  node->get_parameter("yaml_file",yaml_file);
+  rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr pub_velocity_;
+  rclcpp::Publisher<eagleye_msgs::msg::StatusStamped>::SharedPtr pub_velocity_status_;
+  rclcpp::Subscription<rtklib_msgs::msg::RtklibNav>::SharedPtr sub_rtklib_nav_;
+  rclcpp::Subscription<nmea_msgs::msg::Gpgga>::SharedPtr sub_gga_;
+  rclcpp::Subscription<sensor_msgs::msg::Imu>::SharedPtr sub_imu_;
 
-  velocity_estimator.setParam(yaml_file);
+  void rtklibNavCallback(const rtklib_msgs::msg::RtklibNav::ConstSharedPtr msg)
+  {
+    rtklib_nav_msg_ = *msg;
+  }
 
-  auto rtklib_sub =
-      node->create_subscription<rtklib_msgs::msg::RtklibNav>(subscribe_rtklib_nav_topic_name, 1000, rtklib_nav_callback);
-  auto gga_sub = 
-      node->create_subscription<nmea_msgs::msg::Gpgga>(subscribe_gga_topic_name, 1000, gga_callback);
-  auto imu_sub =
-      node->create_subscription<sensor_msgs::msg::Imu>("imu/data_tf_converted", 1000, imu_callback);
+  void ggaCallback(const nmea_msgs::msg::Gpgga::ConstSharedPtr msg) { gga_msg_ = *msg; }
 
-  velocity_pub = node->create_publisher<geometry_msgs::msg::TwistStamped>("velocity", 1000);
-  velocity_status_pub = node->create_publisher<eagleye_msgs::msg::StatusStamped>("velocity_status", 1000);
+  void imuCallback(const sensor_msgs::msg::Imu::ConstSharedPtr msg)
+  {
+    imu_msg_ = *msg;
 
-  rclcpp::spin(node);
-}
+    velocity_estimator_.VelocityEstimate(imu_msg_, rtklib_nav_msg_, gga_msg_, &velocity_msg_);
+
+    eagleye_msgs::msg::StatusStamped velocity_status;
+    velocity_status.header = msg->header;
+    velocity_status.status = velocity_estimator_.getStatus();
+    pub_velocity_status_->publish(velocity_status);
+
+    if (velocity_status.status.enabled_status) {
+      pub_velocity_->publish(velocity_msg_);
+    }
+  }
+};
 
 int main(int argc, char** argv)
 {
   rclcpp::init(argc, argv);
-  auto node = rclcpp::Node::make_shared("eagleye_velocity_estimator");
-
-  velocity_estimator_node(node);
-
+  rclcpp::spin(std::make_shared<VelocityEstimatorNode>());
   return 0;
-} 
+}

--- a/eagleye_rt/src/velocity_scale_factor_node.cpp
+++ b/eagleye_rt/src/velocity_scale_factor_node.cpp
@@ -156,7 +156,7 @@ private:
   eagleye_msgs::msg::VelocityScaleFactor velocity_scale_factor_;
 
   VelocityScaleFactorParameter velocity_scale_factor_parameter_;
-  VelocityScaleFactorStatus velocity_scale_factor_status_;
+  VelocityScaleFactorStatus velocity_scale_factor_status_ = {};
 
   std::string use_gnss_mode_;
   bool is_first_move_ = false;

--- a/eagleye_rt/src/velocity_scale_factor_node.cpp
+++ b/eagleye_rt/src/velocity_scale_factor_node.cpp
@@ -28,249 +28,280 @@
  * Author MapIV Sekino
  */
 
-#include "rclcpp/rclcpp.hpp"
 #include "eagleye_coordinate/eagleye_coordinate.hpp"
 #include "eagleye_navigation/eagleye_navigation.hpp"
+#include "rclcpp/rclcpp.hpp"
 
-static rtklib_msgs::msg::RtklibNav _rtklib_nav;
-static nmea_msgs::msg::Gprmc _nmea_rmc;
-static geometry_msgs::msg::TwistStamped _velocity;
-static sensor_msgs::msg::Imu _imu;
-static geometry_msgs::msg::TwistStamped _correction_velocity;
-
-rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr _pub1;
-rclcpp::Publisher<eagleye_msgs::msg::VelocityScaleFactor>::SharedPtr _pub2;
-static eagleye_msgs::msg::VelocityScaleFactor _velocity_scale_factor;
-
-struct VelocityScaleFactorParameter _velocity_scale_factor_parameter;
-struct VelocityScaleFactorStatus _velocity_scale_factor_status;
-
-std::string _use_gnss_mode;
-
-bool _is_first_move = false;
-
-std::string _velocity_scale_factor_save_str;
-double _saved_vsf_estimater_number;
-double _saved_velocity_scale_factor = 1.0;
-double _previous_velocity_scale_factor = 1.0;
-double _th_velocity_scale_factor_percent = 20;
-
-void rtklib_nav_callback(const rtklib_msgs::msg::RtklibNav::ConstSharedPtr msg)
+class VelocityScaleFactorNode : public rclcpp::Node
 {
-  _rtklib_nav = *msg;
-}
-
-void velocity_callback(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg)
-{
-  _velocity = *msg;
-
-  if (_is_first_move == false && msg->twist.linear.x > _velocity_scale_factor_parameter.moving_judgment_threshold)
+public:
+  VelocityScaleFactorNode() : Node("eagleye_velocity_scale_factor")
   {
-    _is_first_move = true;
-  }
-}
+    std::string subscribe_twist_topic_name = "vehicle/twist";
+    std::string subscribe_rtklib_nav_topic_name = "gnss/rtklib_nav";
+    std::string subscribe_rmc_topic_name = "gnss/rmc";
 
-void rmc_callback(const nmea_msgs::msg::Gprmc::ConstSharedPtr msg)
-{
-  _nmea_rmc = *msg;
-}
+    double velocity_scale_factor_save_duration = 100.0;
 
-void imu_callback(const sensor_msgs::msg::Imu::ConstSharedPtr msg)
-{
-  double initial_velocity_scale_factor = _saved_velocity_scale_factor;
+    std::string yaml_file;
+    this->declare_parameter("yaml_file", yaml_file);
+    this->get_parameter("yaml_file", yaml_file);
+    std::cout << "yaml_file: " << yaml_file << std::endl;
 
-  _imu = *msg;
-  _velocity_scale_factor.header = msg->header;
-  _velocity_scale_factor.header.frame_id = "base_link";
+    try {
+      YAML::Node conf = YAML::LoadFile(yaml_file);
 
-  _correction_velocity.header = msg->header;
-  _correction_velocity.header.frame_id = "base_link";
+      use_gnss_mode_ = conf["/**"]["ros__parameters"]["use_gnss_mode"].as<std::string>();
 
-  if (_is_first_move == false)
-  {
-    _velocity_scale_factor.scale_factor = initial_velocity_scale_factor;
-    _correction_velocity.twist = _velocity.twist;
-    _pub1->publish(_correction_velocity);
-    _pub2->publish(_velocity_scale_factor);
-    return;
-  }
+      velocity_scale_factor_parameter_.imu_rate =
+        conf["/**"]["ros__parameters"]["common"]["imu_rate"].as<double>();
+      velocity_scale_factor_parameter_.gnss_rate =
+        conf["/**"]["ros__parameters"]["common"]["gnss_rate"].as<double>();
+      velocity_scale_factor_parameter_.moving_judgment_threshold =
+        conf["/**"]["ros__parameters"]["common"]["stop_judgment_threshold"].as<double>();
 
-  if (_use_gnss_mode == "rtklib" || _use_gnss_mode == "RTKLIB") // use RTKLIB mode
-  {
-    velocity_scale_factor_estimate(_rtklib_nav,_velocity,_velocity_scale_factor_parameter,
-      &_velocity_scale_factor_status,&_correction_velocity,&_velocity_scale_factor);
-  }
-  else if (_use_gnss_mode == "nmea" || _use_gnss_mode == "NMEA") // use NMEA mode
-  {
-    velocity_scale_factor_estimate(_nmea_rmc,_velocity,_velocity_scale_factor_parameter,
-      &_velocity_scale_factor_status,&_correction_velocity,&_velocity_scale_factor);
-  }
+      velocity_scale_factor_parameter_.estimated_minimum_interval =
+        conf["/**"]["ros__parameters"]["velocity_scale_factor"]["estimated_minimum_interval"]
+          .as<double>();
+      velocity_scale_factor_parameter_.estimated_maximum_interval =
+        conf["/**"]["ros__parameters"]["velocity_scale_factor"]["estimated_maximum_interval"]
+          .as<double>();
+      velocity_scale_factor_parameter_.gnss_receiving_threshold =
+        conf["/**"]["ros__parameters"]["velocity_scale_factor"]["gnss_receiving_threshold"]
+          .as<double>();
 
-  _velocity_scale_factor.status.is_abnormal = false;
-  if (!std::isfinite(_velocity_scale_factor.scale_factor)) {
-    _correction_velocity.twist.linear.x = _velocity.twist.linear.x * _previous_velocity_scale_factor;
-    _velocity_scale_factor.scale_factor = _previous_velocity_scale_factor;
-    _velocity_scale_factor.status.is_abnormal = true;
-    _velocity_scale_factor.status.error_code = eagleye_msgs::msg::Status::NAN_OR_INFINITE;
-  }
-  else if (_th_velocity_scale_factor_percent / 100 < std::abs(1.0 - _velocity_scale_factor.scale_factor))
-  {
-    _correction_velocity.twist.linear.x = _velocity.twist.linear.x * _previous_velocity_scale_factor;
-    _velocity_scale_factor.scale_factor = _previous_velocity_scale_factor;
-    _velocity_scale_factor.status.is_abnormal = true;
-    _velocity_scale_factor.status.error_code = eagleye_msgs::msg::Status::TOO_LARGE_OR_SMALL;
-  }
-  else
-  {
-    _previous_velocity_scale_factor = _velocity_scale_factor.scale_factor;
-  }
+      this->declare_parameter(
+        "velocity_scale_factor_save_str", velocity_scale_factor_save_str_);
+      this->declare_parameter(
+        "velocity_scale_factor.save_velocity_scale_factor",
+        velocity_scale_factor_parameter_.save_velocity_scale_factor);
+      this->declare_parameter(
+        "velocity_scale_factor.velocity_scale_factor_save_duration",
+        velocity_scale_factor_save_duration);
+      this->declare_parameter(
+        "velocity_scale_factor.th_velocity_scale_factor_percent",
+        th_velocity_scale_factor_percent_);
 
-  _pub1->publish(_correction_velocity);
-  _pub2->publish(_velocity_scale_factor);
-}
+      this->get_parameter(
+        "velocity_scale_factor_save_str", velocity_scale_factor_save_str_);
+      this->get_parameter(
+        "velocity_scale_factor.save_velocity_scale_factor",
+        velocity_scale_factor_parameter_.save_velocity_scale_factor);
+      this->get_parameter(
+        "velocity_scale_factor.velocity_scale_factor_save_duration",
+        velocity_scale_factor_save_duration);
+      this->get_parameter(
+        "velocity_scale_factor.th_velocity_scale_factor_percent",
+        th_velocity_scale_factor_percent_);
 
-void load_velocity_scale_factor(std::string txt_path)
-{
-  std::ifstream ifs(txt_path);
-  if (!ifs)
-  {
-    std::cout << "Initial VelocityScaleFactor file not found!" << std::endl;
-  }
-  else
-  {
-    std::cout << "Loaded the saved velocity scale factor!" << std::endl;
-    int count = 0;
-    std::string row;
-    while (getline(ifs, row))
-    {
-      if(count == 1)
-      {
-        _saved_vsf_estimater_number = std::stod(row);
-        std::cout<< "saved_vsf_estimater_number " << _saved_vsf_estimater_number << std::endl;
-      }
-      if(count == 3)
-      {
-        _saved_velocity_scale_factor = std::stod(row);
-        _velocity_scale_factor_status.estimate_start_status = true;
-        _velocity_scale_factor_status.velocity_scale_factor_last = _saved_velocity_scale_factor;
-        _velocity_scale_factor.status.enabled_status = true;
-        _velocity_scale_factor.scale_factor = _saved_velocity_scale_factor;
-        std::cout<< "saved_velocity_scale_factor " << _saved_velocity_scale_factor << std::endl;
-      }
-      count++;
+      std::cout << "use_gnss_mode " << use_gnss_mode_ << std::endl;
+      std::cout << "subscribe_twist_topic_name " << subscribe_twist_topic_name << std::endl;
+      std::cout << "subscribe_rtklib_nav_topic_name " << subscribe_rtklib_nav_topic_name
+                << std::endl;
+      std::cout << "gnss_rate " << velocity_scale_factor_parameter_.gnss_rate << std::endl;
+      std::cout << "moving_judgment_threshold "
+                << velocity_scale_factor_parameter_.moving_judgment_threshold << std::endl;
+      std::cout << "estimated_minimum_interval "
+                << velocity_scale_factor_parameter_.estimated_minimum_interval << std::endl;
+      std::cout << "estimated_maximum_interval "
+                << velocity_scale_factor_parameter_.estimated_maximum_interval << std::endl;
+      std::cout << "gnss_receiving_threshold "
+                << velocity_scale_factor_parameter_.gnss_receiving_threshold << std::endl;
+      std::cout << "velocity_scale_factor_save_str " << velocity_scale_factor_save_str_
+                << std::endl;
+      std::cout << "save_velocity_scale_factor "
+                << velocity_scale_factor_parameter_.save_velocity_scale_factor << std::endl;
+      std::cout << "velocity_scale_factor_save_duration " << velocity_scale_factor_save_duration
+                << std::endl;
+      std::cout << "th_velocity_scale_factor_percent " << th_velocity_scale_factor_percent_
+                << std::endl;
+    } catch (YAML::Exception& e) {
+      std::cerr << "\033[1;31mvelocity_scale_factor Node YAML Error: " << e.msg << "\033[0m"
+                << std::endl;
+      exit(3);
+    }
+
+    sub_imu_ = this->create_subscription<sensor_msgs::msg::Imu>(
+      "imu/data_tf_converted", 1000,
+      std::bind(&VelocityScaleFactorNode::imuCallback, this, std::placeholders::_1));
+    sub_velocity_ = this->create_subscription<geometry_msgs::msg::TwistStamped>(
+      subscribe_twist_topic_name, 1000,
+      std::bind(&VelocityScaleFactorNode::velocityCallback, this, std::placeholders::_1));
+    sub_rtklib_nav_ = this->create_subscription<rtklib_msgs::msg::RtklibNav>(
+      subscribe_rtklib_nav_topic_name, 1000,
+      std::bind(&VelocityScaleFactorNode::rtklibNavCallback, this, std::placeholders::_1));
+    sub_rmc_ = this->create_subscription<nmea_msgs::msg::Gprmc>(
+      subscribe_rmc_topic_name, 1000,
+      std::bind(&VelocityScaleFactorNode::rmcCallback, this, std::placeholders::_1));
+    pub_correction_velocity_ =
+      this->create_publisher<geometry_msgs::msg::TwistStamped>("velocity", rclcpp::QoS(10));
+    pub_velocity_scale_factor_ = this->create_publisher<eagleye_msgs::msg::VelocityScaleFactor>(
+      "velocity_scale_factor", rclcpp::QoS(10));
+
+    if (velocity_scale_factor_parameter_.save_velocity_scale_factor) {
+      const auto period_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
+        std::chrono::duration<double>(velocity_scale_factor_save_duration));
+      timer_ = this->create_wall_timer(
+        period_ns, std::bind(&VelocityScaleFactorNode::onTimer, this));
+      loadVelocityScaleFactor(velocity_scale_factor_save_str_);
     }
   }
-  ifs.close();
-}
 
-void on_timer()
-{
-  if(!_velocity_scale_factor.status.enabled_status && _saved_vsf_estimater_number >= _velocity_scale_factor_status.estimated_number)
+private:
+  rtklib_msgs::msg::RtklibNav rtklib_nav_;
+  nmea_msgs::msg::Gprmc nmea_rmc_;
+  geometry_msgs::msg::TwistStamped velocity_;
+  sensor_msgs::msg::Imu imu_;
+  geometry_msgs::msg::TwistStamped correction_velocity_;
+  eagleye_msgs::msg::VelocityScaleFactor velocity_scale_factor_;
+
+  VelocityScaleFactorParameter velocity_scale_factor_parameter_;
+  VelocityScaleFactorStatus velocity_scale_factor_status_;
+
+  std::string use_gnss_mode_;
+  bool is_first_move_ = false;
+  std::string velocity_scale_factor_save_str_;
+  double saved_vsf_estimater_number_ = 0;
+  double saved_velocity_scale_factor_ = 1.0;
+  double previous_velocity_scale_factor_ = 1.0;
+  double th_velocity_scale_factor_percent_ = 20;
+
+  rclcpp::TimerBase::SharedPtr timer_;
+  rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr pub_correction_velocity_;
+  rclcpp::Publisher<eagleye_msgs::msg::VelocityScaleFactor>::SharedPtr
+    pub_velocity_scale_factor_;
+  rclcpp::Subscription<sensor_msgs::msg::Imu>::SharedPtr sub_imu_;
+  rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr sub_velocity_;
+  rclcpp::Subscription<rtklib_msgs::msg::RtklibNav>::SharedPtr sub_rtklib_nav_;
+  rclcpp::Subscription<nmea_msgs::msg::Gprmc>::SharedPtr sub_rmc_;
+
+  void rtklibNavCallback(const rtklib_msgs::msg::RtklibNav::ConstSharedPtr msg)
   {
-    std::ofstream csv_file(_velocity_scale_factor_save_str);
-    return;
+    rtklib_nav_ = *msg;
   }
 
-  std::ofstream csv_file(_velocity_scale_factor_save_str);
-  csv_file << "estimated_number";
-  csv_file << "\n";
-  csv_file << _velocity_scale_factor_status.estimated_number;
-  csv_file << "\n";
-  csv_file << "velocity_scale_factor";
-  csv_file << "\n";
-  csv_file << _velocity_scale_factor_status.velocity_scale_factor_last;
-  csv_file << "\n";
-  csv_file.close();
+  void velocityCallback(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg)
+  {
+    velocity_ = *msg;
 
-  _saved_vsf_estimater_number = _velocity_scale_factor_status.estimated_number;
+    if (
+      is_first_move_ == false &&
+      msg->twist.linear.x > velocity_scale_factor_parameter_.moving_judgment_threshold) {
+      is_first_move_ = true;
+    }
+  }
 
-  return;
-}
+  void rmcCallback(const nmea_msgs::msg::Gprmc::ConstSharedPtr msg) { nmea_rmc_ = *msg; }
+
+  void imuCallback(const sensor_msgs::msg::Imu::ConstSharedPtr msg)
+  {
+    double initial_velocity_scale_factor = saved_velocity_scale_factor_;
+
+    imu_ = *msg;
+    velocity_scale_factor_.header = msg->header;
+    velocity_scale_factor_.header.frame_id = "base_link";
+
+    correction_velocity_.header = msg->header;
+    correction_velocity_.header.frame_id = "base_link";
+
+    if (is_first_move_ == false) {
+      velocity_scale_factor_.scale_factor = initial_velocity_scale_factor;
+      correction_velocity_.twist = velocity_.twist;
+      pub_correction_velocity_->publish(correction_velocity_);
+      pub_velocity_scale_factor_->publish(velocity_scale_factor_);
+      return;
+    }
+
+    if (use_gnss_mode_ == "rtklib" || use_gnss_mode_ == "RTKLIB") {
+      velocity_scale_factor_estimate(
+        rtklib_nav_, velocity_, velocity_scale_factor_parameter_,
+        &velocity_scale_factor_status_, &correction_velocity_, &velocity_scale_factor_);
+    } else if (use_gnss_mode_ == "nmea" || use_gnss_mode_ == "NMEA") {
+      velocity_scale_factor_estimate(
+        nmea_rmc_, velocity_, velocity_scale_factor_parameter_, &velocity_scale_factor_status_,
+        &correction_velocity_, &velocity_scale_factor_);
+    }
+
+    velocity_scale_factor_.status.is_abnormal = false;
+    if (!std::isfinite(velocity_scale_factor_.scale_factor)) {
+      correction_velocity_.twist.linear.x =
+        velocity_.twist.linear.x * previous_velocity_scale_factor_;
+      velocity_scale_factor_.scale_factor = previous_velocity_scale_factor_;
+      velocity_scale_factor_.status.is_abnormal = true;
+      velocity_scale_factor_.status.error_code = eagleye_msgs::msg::Status::NAN_OR_INFINITE;
+    } else if (
+      th_velocity_scale_factor_percent_ / 100 <
+      std::abs(1.0 - velocity_scale_factor_.scale_factor)) {
+      correction_velocity_.twist.linear.x =
+        velocity_.twist.linear.x * previous_velocity_scale_factor_;
+      velocity_scale_factor_.scale_factor = previous_velocity_scale_factor_;
+      velocity_scale_factor_.status.is_abnormal = true;
+      velocity_scale_factor_.status.error_code = eagleye_msgs::msg::Status::TOO_LARGE_OR_SMALL;
+    } else {
+      previous_velocity_scale_factor_ = velocity_scale_factor_.scale_factor;
+    }
+
+    pub_correction_velocity_->publish(correction_velocity_);
+    pub_velocity_scale_factor_->publish(velocity_scale_factor_);
+  }
+
+  void loadVelocityScaleFactor(std::string txt_path)
+  {
+    std::ifstream ifs(txt_path);
+    if (!ifs) {
+      std::cout << "Initial VelocityScaleFactor file not found!" << std::endl;
+    } else {
+      std::cout << "Loaded the saved velocity scale factor!" << std::endl;
+      int count = 0;
+      std::string row;
+      while (getline(ifs, row)) {
+        if (count == 1) {
+          saved_vsf_estimater_number_ = std::stod(row);
+          std::cout << "saved_vsf_estimater_number " << saved_vsf_estimater_number_ << std::endl;
+        }
+        if (count == 3) {
+          saved_velocity_scale_factor_ = std::stod(row);
+          velocity_scale_factor_status_.estimate_start_status = true;
+          velocity_scale_factor_status_.velocity_scale_factor_last =
+            saved_velocity_scale_factor_;
+          velocity_scale_factor_.status.enabled_status = true;
+          velocity_scale_factor_.scale_factor = saved_velocity_scale_factor_;
+          std::cout << "saved_velocity_scale_factor " << saved_velocity_scale_factor_
+                    << std::endl;
+        }
+        count++;
+      }
+    }
+    ifs.close();
+  }
+
+  void onTimer()
+  {
+    if (
+      !velocity_scale_factor_.status.enabled_status &&
+      saved_vsf_estimater_number_ >= velocity_scale_factor_status_.estimated_number) {
+      std::ofstream csv_file(velocity_scale_factor_save_str_);
+      return;
+    }
+
+    std::ofstream csv_file(velocity_scale_factor_save_str_);
+    csv_file << "estimated_number";
+    csv_file << "\n";
+    csv_file << velocity_scale_factor_status_.estimated_number;
+    csv_file << "\n";
+    csv_file << "velocity_scale_factor";
+    csv_file << "\n";
+    csv_file << velocity_scale_factor_status_.velocity_scale_factor_last;
+    csv_file << "\n";
+    csv_file.close();
+
+    saved_vsf_estimater_number_ = velocity_scale_factor_status_.estimated_number;
+  }
+};
 
 int main(int argc, char** argv)
 {
   rclcpp::init(argc, argv);
-  auto node = rclcpp::Node::make_shared("eagleye_velocity_scale_factor");
-
-  double velocity_scale_factor_save_duration = 100.0;
-
-  std::string subscribe_twist_topic_name = "vehicle/twist";
-
-  std::string subscribe_rtklib_nav_topic_name = "gnss/rtklib_nav";
-  std::string subscribe_rmc_topic_name = "gnss/rmc";
-
-  std::string yaml_file;
-  node->declare_parameter("yaml_file",yaml_file);
-  node->get_parameter("yaml_file",yaml_file);
-  std::cout << "yaml_file: " << yaml_file << std::endl;
-
-  try
-  {
-    YAML::Node conf = YAML::LoadFile(yaml_file);
-
-    _use_gnss_mode = conf["/**"]["ros__parameters"]["use_gnss_mode"].as<std::string>();
-
-    _velocity_scale_factor_parameter.imu_rate = conf["/**"]["ros__parameters"]["common"]["imu_rate"].as<double>();
-    _velocity_scale_factor_parameter.gnss_rate = conf["/**"]["ros__parameters"]["common"]["gnss_rate"].as<double>();
-    _velocity_scale_factor_parameter.moving_judgment_threshold = conf["/**"]["ros__parameters"]["common"]["stop_judgment_threshold"].as<double>();
-
-    _velocity_scale_factor_parameter.estimated_minimum_interval = conf["/**"]["ros__parameters"]["velocity_scale_factor"]["estimated_minimum_interval"].as<double>();
-    _velocity_scale_factor_parameter.estimated_maximum_interval = conf["/**"]["ros__parameters"]["velocity_scale_factor"]["estimated_maximum_interval"].as<double>();
-    _velocity_scale_factor_parameter.gnss_receiving_threshold = conf["/**"]["ros__parameters"]["velocity_scale_factor"]["gnss_receiving_threshold"].as<double>();
-
-    node->declare_parameter("velocity_scale_factor_save_str",_velocity_scale_factor_save_str);
-    node->declare_parameter("velocity_scale_factor.save_velocity_scale_factor",_velocity_scale_factor_parameter.save_velocity_scale_factor);
-    node->declare_parameter("velocity_scale_factor.velocity_scale_factor_save_duration",velocity_scale_factor_save_duration);
-    node->declare_parameter("velocity_scale_factor.th_velocity_scale_factor_percent",_th_velocity_scale_factor_percent);
-
-    node->get_parameter("velocity_scale_factor_save_str",_velocity_scale_factor_save_str);
-    node->get_parameter("velocity_scale_factor.save_velocity_scale_factor",_velocity_scale_factor_parameter.save_velocity_scale_factor);
-    node->get_parameter("velocity_scale_factor.velocity_scale_factor_save_duration",velocity_scale_factor_save_duration);
-    node->get_parameter("velocity_scale_factor.th_velocity_scale_factor_percent",_th_velocity_scale_factor_percent);
-
-    std::cout << "use_gnss_mode " << _use_gnss_mode << std::endl;
-
-    std::cout << "subscribe_twist_topic_name " << subscribe_twist_topic_name << std::endl;
-    std::cout << "subscribe_rtklib_nav_topic_name " << subscribe_rtklib_nav_topic_name << std::endl;
-
-    std::cout << "gnss_rate " << _velocity_scale_factor_parameter.gnss_rate << std::endl;
-    std::cout << "moving_judgment_threshold " << _velocity_scale_factor_parameter.moving_judgment_threshold << std::endl;
-
-    std::cout << "estimated_minimum_interval " << _velocity_scale_factor_parameter.estimated_minimum_interval << std::endl;
-    std::cout << "estimated_maximum_interval " << _velocity_scale_factor_parameter.estimated_maximum_interval << std::endl;
-    std::cout << "gnss_receiving_threshold " << _velocity_scale_factor_parameter.gnss_receiving_threshold << std::endl;
-
-    std::cout<< "velocity_scale_factor_save_str " << _velocity_scale_factor_save_str << std::endl;
-    std::cout<< "save_velocity_scale_factor " << _velocity_scale_factor_parameter.save_velocity_scale_factor << std::endl;
-    std::cout<< "velocity_scale_factor_save_duration " << velocity_scale_factor_save_duration << std::endl;
-    std::cout<< "th_velocity_scale_factor_percent "<<_th_velocity_scale_factor_percent<<std::endl;
-  }
-  catch (YAML::Exception& e)
-  {
-    std::cerr << "\033[1;31mvelocity_scale_factor Node YAML Error: " << e.msg << "\033[0m" << std::endl;
-    exit(3);
-  }
-  auto sub1 = node->create_subscription<sensor_msgs::msg::Imu>("imu/data_tf_converted", 1000, imu_callback);
-  auto sub2 = node->create_subscription<geometry_msgs::msg::TwistStamped>(subscribe_twist_topic_name, 1000, velocity_callback);
-  auto sub3 = node->create_subscription<rtklib_msgs::msg::RtklibNav>(subscribe_rtklib_nav_topic_name, 1000, rtklib_nav_callback);
-  auto sub4 = node->create_subscription<nmea_msgs::msg::Gprmc>(subscribe_rmc_topic_name, 1000, rmc_callback);
-  _pub1 = node->create_publisher<geometry_msgs::msg::TwistStamped>("velocity", rclcpp::QoS(10));
-  _pub2 = node->create_publisher<eagleye_msgs::msg::VelocityScaleFactor>("velocity_scale_factor", rclcpp::QoS(10));
-
-  double delta_time = static_cast<double>(velocity_scale_factor_save_duration);
-  auto timer_callback = std::bind(on_timer);
-  const auto period_ns =
-    std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::duration<double>(delta_time));
-  auto timer = std::make_shared<rclcpp::GenericTimer<decltype(timer_callback)>>(
-    node->get_clock(), period_ns, std::move(timer_callback),
-    node->get_node_base_interface()->get_context());
-  if(_velocity_scale_factor_parameter.save_velocity_scale_factor)
-  {
-    node->get_node_timers_interface()->add_timer(timer, nullptr);
-    load_velocity_scale_factor(_velocity_scale_factor_save_str);
-  }
-
-  rclcpp::spin(node);
-
+  rclcpp::spin(std::make_shared<VelocityScaleFactorNode>());
   return 0;
 }

--- a/eagleye_rt/src/yaw_rate_offset_node.cpp
+++ b/eagleye_rt/src/yaw_rate_offset_node.cpp
@@ -166,7 +166,7 @@ private:
   sensor_msgs::msg::Imu imu_;
   eagleye_msgs::msg::YawrateOffset yaw_rate_offset_;
   YawrateOffsetParameter yaw_rate_offset_parameter_;
-  YawrateOffsetStatus yaw_rate_offset_status_;
+  YawrateOffsetStatus yaw_rate_offset_status_ = {};
   bool is_first_heading_ = false;
   bool use_can_less_mode_ = false;
   double previous_yaw_rate_offset_ = 0.0;

--- a/eagleye_rt/src/yaw_rate_offset_node.cpp
+++ b/eagleye_rt/src/yaw_rate_offset_node.cpp
@@ -28,176 +28,207 @@
  * Author MapIV Sekino
  */
 
-#include "rclcpp/rclcpp.hpp"
 #include "eagleye_coordinate/eagleye_coordinate.hpp"
 #include "eagleye_navigation/eagleye_navigation.hpp"
+#include "rclcpp/rclcpp.hpp"
 
-static geometry_msgs::msg::TwistStamped _velocity;
-static eagleye_msgs::msg::StatusStamped _velocity_status;
-static eagleye_msgs::msg::YawrateOffset _yaw_rate_offset_stop;
-static eagleye_msgs::msg::Heading _heading_interpolate;
-static sensor_msgs::msg::Imu _imu;
-rclcpp::Publisher<eagleye_msgs::msg::YawrateOffset>::SharedPtr _pub;
-static eagleye_msgs::msg::YawrateOffset _yaw_rate_offset;
-
-struct YawrateOffsetParameter _yaw_rate_offset_parameter;
-struct YawrateOffsetStatus _yaw_rate_offset_status;
-
-bool _is_first_heading = false;
-static bool _use_can_less_mode = false;
-
-double _previous_yaw_rate_offset = 0.0;
-
-void velocity_callback(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg)
+class YawRateOffsetNode : public rclcpp::Node
 {
-  _velocity = *msg;
-}
-
-void velocity_status_callback(const eagleye_msgs::msg::StatusStamped::ConstSharedPtr msg)
-{
-  _velocity_status = *msg;
-}
-
-void yaw_rate_offset_stop_callback(const eagleye_msgs::msg::YawrateOffset::ConstSharedPtr msg)
-{
-  _yaw_rate_offset_stop = *msg;
-}
-
-void heading_interpolate_callback(const eagleye_msgs::msg::Heading::ConstSharedPtr msg)
-{
-  _heading_interpolate = *msg;
-  if (_is_first_heading == false && _heading_interpolate.status.enabled_status == true)
+public:
+  YawRateOffsetNode(int argc, char** argv) : Node("eagleye_yaw_rate_offset")
   {
-    _is_first_heading = true;
+    std::string publish_topic_name = "/publish_topic_name/invalid";
+    std::string subscribe_topic_name = "/subscribe_topic_name/invalid";
+
+    std::string yaml_file;
+    this->declare_parameter("yaml_file", yaml_file);
+    this->get_parameter("yaml_file", yaml_file);
+    std::cout << "yaml_file: " << yaml_file << std::endl;
+
+    if (argc > 2) {
+      if (strcmp(argv[1], "1st") == 0) {
+        publish_topic_name = "yaw_rate_offset_1st";
+        subscribe_topic_name = "heading_interpolate_1st";
+
+        try {
+          YAML::Node conf = YAML::LoadFile(yaml_file);
+
+          yaw_rate_offset_parameter_.imu_rate =
+            conf["/**"]["ros__parameters"]["common"]["imu_rate"].as<double>();
+          yaw_rate_offset_parameter_.gnss_rate =
+            conf["/**"]["ros__parameters"]["common"]["gnss_rate"].as<double>();
+          yaw_rate_offset_parameter_.moving_judgment_threshold =
+            conf["/**"]["ros__parameters"]["common"]["moving_judgment_threshold"].as<double>();
+          yaw_rate_offset_parameter_.estimated_minimum_interval =
+            conf["/**"]["ros__parameters"]["yaw_rate_offset"]["estimated_minimum_interval"]
+              .as<double>();
+          yaw_rate_offset_parameter_.estimated_maximum_interval =
+            conf["/**"]["ros__parameters"]["yaw_rate_offset"]["1st"]["estimated_maximum_interval"]
+              .as<double>();
+          yaw_rate_offset_parameter_.gnss_receiving_threshold =
+            conf["/**"]["ros__parameters"]["yaw_rate_offset"]["gnss_receiving_threshold"]
+              .as<double>();
+          yaw_rate_offset_parameter_.outlier_threshold =
+            conf["/**"]["ros__parameters"]["yaw_rate_offset_stop"]["outlier_threshold"].as<double>();
+
+          std::cout << "imu_rate " << yaw_rate_offset_parameter_.imu_rate << std::endl;
+          std::cout << "gnss_rate " << yaw_rate_offset_parameter_.gnss_rate << std::endl;
+          std::cout << "moving_judgment_threshold "
+                    << yaw_rate_offset_parameter_.moving_judgment_threshold << std::endl;
+          std::cout << "estimated_minimum_interval "
+                    << yaw_rate_offset_parameter_.estimated_minimum_interval << std::endl;
+          std::cout << "estimated_maximum_interval "
+                    << yaw_rate_offset_parameter_.estimated_maximum_interval << std::endl;
+          std::cout << "gnss_receiving_threshold "
+                    << yaw_rate_offset_parameter_.gnss_receiving_threshold << std::endl;
+          std::cout << "outlier_threshold " << yaw_rate_offset_parameter_.outlier_threshold
+                    << std::endl;
+        } catch (YAML::Exception& e) {
+          std::cerr << "\033[1;yaw_rate_offset_1st Node YAML Error: " << e.msg << "\033[0m"
+                    << std::endl;
+          exit(3);
+        }
+      } else if (strcmp(argv[1], "2nd") == 0) {
+        publish_topic_name = "yaw_rate_offset_2nd";
+        subscribe_topic_name = "heading_interpolate_2nd";
+
+        try {
+          YAML::Node conf = YAML::LoadFile(yaml_file);
+
+          yaw_rate_offset_parameter_.imu_rate =
+            conf["/**"]["ros__parameters"]["common"]["imu_rate"].as<double>();
+          yaw_rate_offset_parameter_.gnss_rate =
+            conf["/**"]["ros__parameters"]["common"]["gnss_rate"].as<double>();
+          yaw_rate_offset_parameter_.moving_judgment_threshold =
+            conf["/**"]["ros__parameters"]["common"]["moving_judgment_threshold"].as<double>();
+          yaw_rate_offset_parameter_.estimated_minimum_interval =
+            conf["/**"]["ros__parameters"]["yaw_rate_offset"]["estimated_minimum_interval"]
+              .as<double>();
+          yaw_rate_offset_parameter_.estimated_maximum_interval =
+            conf["/**"]["ros__parameters"]["yaw_rate_offset"]["2nd"]["estimated_maximum_interval"]
+              .as<double>();
+          yaw_rate_offset_parameter_.gnss_receiving_threshold =
+            conf["/**"]["ros__parameters"]["yaw_rate_offset"]["gnss_receiving_threshold"]
+              .as<double>();
+          yaw_rate_offset_parameter_.outlier_threshold =
+            conf["/**"]["ros__parameters"]["yaw_rate_offset_stop"]["outlier_threshold"].as<double>();
+
+          std::cout << "imu_rate " << yaw_rate_offset_parameter_.imu_rate << std::endl;
+          std::cout << "gnss_rate " << yaw_rate_offset_parameter_.gnss_rate << std::endl;
+          std::cout << "moving_judgment_threshold "
+                    << yaw_rate_offset_parameter_.moving_judgment_threshold << std::endl;
+          std::cout << "estimated_minimum_interval "
+                    << yaw_rate_offset_parameter_.estimated_minimum_interval << std::endl;
+          std::cout << "estimated_maximum_interval "
+                    << yaw_rate_offset_parameter_.estimated_maximum_interval << std::endl;
+          std::cout << "gnss_receiving_threshold "
+                    << yaw_rate_offset_parameter_.gnss_receiving_threshold << std::endl;
+          std::cout << "outlier_threshold " << yaw_rate_offset_parameter_.outlier_threshold
+                    << std::endl;
+        } catch (YAML::Exception& e) {
+          std::cerr << "\033[1;yaw_rate_offset_2nd Node YAML Error: " << e.msg << "\033[0m"
+                    << std::endl;
+          exit(3);
+        }
+      } else {
+        RCLCPP_ERROR(this->get_logger(), "No arguments");
+        rclcpp::shutdown();
+      }
+    } else {
+      RCLCPP_ERROR(this->get_logger(), "No arguments");
+      rclcpp::shutdown();
+    }
+
+    sub_velocity_ = this->create_subscription<geometry_msgs::msg::TwistStamped>(
+      "velocity", rclcpp::QoS(10),
+      std::bind(&YawRateOffsetNode::velocityCallback, this, std::placeholders::_1));
+    sub_velocity_status_ = this->create_subscription<eagleye_msgs::msg::StatusStamped>(
+      "velocity_status", rclcpp::QoS(10),
+      std::bind(&YawRateOffsetNode::velocityStatusCallback, this, std::placeholders::_1));
+    sub_yaw_rate_offset_stop_ = this->create_subscription<eagleye_msgs::msg::YawrateOffset>(
+      "yaw_rate_offset_stop", rclcpp::QoS(10),
+      std::bind(&YawRateOffsetNode::yawRateOffsetStopCallback, this, std::placeholders::_1));
+    sub_heading_interpolate_ = this->create_subscription<eagleye_msgs::msg::Heading>(
+      subscribe_topic_name, 1000,
+      std::bind(&YawRateOffsetNode::headingInterpolateCallback, this, std::placeholders::_1));
+    sub_imu_ = this->create_subscription<sensor_msgs::msg::Imu>(
+      "imu/data_tf_converted", 1000,
+      std::bind(&YawRateOffsetNode::imuCallback, this, std::placeholders::_1));
+    pub_ =
+      this->create_publisher<eagleye_msgs::msg::YawrateOffset>(publish_topic_name, rclcpp::QoS(10));
   }
-}
 
-void imu_callback(const sensor_msgs::msg::Imu::ConstSharedPtr msg)
-{
-  if (_is_first_heading == false) return;
-  if(_use_can_less_mode && !_velocity_status.status.enabled_status) return;
+private:
+  geometry_msgs::msg::TwistStamped velocity_;
+  eagleye_msgs::msg::StatusStamped velocity_status_;
+  eagleye_msgs::msg::YawrateOffset yaw_rate_offset_stop_;
+  eagleye_msgs::msg::Heading heading_interpolate_;
+  sensor_msgs::msg::Imu imu_;
+  eagleye_msgs::msg::YawrateOffset yaw_rate_offset_;
+  YawrateOffsetParameter yaw_rate_offset_parameter_;
+  YawrateOffsetStatus yaw_rate_offset_status_;
+  bool is_first_heading_ = false;
+  bool use_can_less_mode_ = false;
+  double previous_yaw_rate_offset_ = 0.0;
 
-  _imu = *msg;
-  _yaw_rate_offset.header = msg->header;
-  yaw_rate_offset_estimate(_velocity,_yaw_rate_offset_stop,_heading_interpolate,_imu,_yaw_rate_offset_parameter, &_yaw_rate_offset_status, &_yaw_rate_offset);
+  rclcpp::Publisher<eagleye_msgs::msg::YawrateOffset>::SharedPtr pub_;
+  rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr sub_velocity_;
+  rclcpp::Subscription<eagleye_msgs::msg::StatusStamped>::SharedPtr sub_velocity_status_;
+  rclcpp::Subscription<eagleye_msgs::msg::YawrateOffset>::SharedPtr sub_yaw_rate_offset_stop_;
+  rclcpp::Subscription<eagleye_msgs::msg::Heading>::SharedPtr sub_heading_interpolate_;
+  rclcpp::Subscription<sensor_msgs::msg::Imu>::SharedPtr sub_imu_;
 
-  _yaw_rate_offset.status.is_abnormal = false;
-  if (!std::isfinite(_yaw_rate_offset_stop.yaw_rate_offset)) {
-    _yaw_rate_offset_stop.yaw_rate_offset =_previous_yaw_rate_offset;
-    _yaw_rate_offset.status.is_abnormal = true;
-    _yaw_rate_offset.status.error_code = eagleye_msgs::msg::Status::NAN_OR_INFINITE;
-  }
-  else
+  void velocityCallback(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg)
   {
-    _previous_yaw_rate_offset = _yaw_rate_offset_stop.yaw_rate_offset;
+    velocity_ = *msg;
   }
 
-  _pub->publish(_yaw_rate_offset);
-  _yaw_rate_offset.status.estimate_status = false;
-}
+  void velocityStatusCallback(const eagleye_msgs::msg::StatusStamped::ConstSharedPtr msg)
+  {
+    velocity_status_ = *msg;
+  }
+
+  void yawRateOffsetStopCallback(const eagleye_msgs::msg::YawrateOffset::ConstSharedPtr msg)
+  {
+    yaw_rate_offset_stop_ = *msg;
+  }
+
+  void headingInterpolateCallback(const eagleye_msgs::msg::Heading::ConstSharedPtr msg)
+  {
+    heading_interpolate_ = *msg;
+    if (is_first_heading_ == false && heading_interpolate_.status.enabled_status == true) {
+      is_first_heading_ = true;
+    }
+  }
+
+  void imuCallback(const sensor_msgs::msg::Imu::ConstSharedPtr msg)
+  {
+    if (is_first_heading_ == false) return;
+    if (use_can_less_mode_ && !velocity_status_.status.enabled_status) return;
+
+    imu_ = *msg;
+    yaw_rate_offset_.header = msg->header;
+    yaw_rate_offset_estimate(
+      velocity_, yaw_rate_offset_stop_, heading_interpolate_, imu_, yaw_rate_offset_parameter_,
+      &yaw_rate_offset_status_, &yaw_rate_offset_);
+
+    yaw_rate_offset_.status.is_abnormal = false;
+    if (!std::isfinite(yaw_rate_offset_stop_.yaw_rate_offset)) {
+      yaw_rate_offset_stop_.yaw_rate_offset = previous_yaw_rate_offset_;
+      yaw_rate_offset_.status.is_abnormal = true;
+      yaw_rate_offset_.status.error_code = eagleye_msgs::msg::Status::NAN_OR_INFINITE;
+    } else {
+      previous_yaw_rate_offset_ = yaw_rate_offset_stop_.yaw_rate_offset;
+    }
+
+    pub_->publish(yaw_rate_offset_);
+    yaw_rate_offset_.status.estimate_status = false;
+  }
+};
 
 int main(int argc, char** argv)
 {
   rclcpp::init(argc, argv);
-  auto node = rclcpp::Node::make_shared("eagleye_yaw_rate_offset");
-
-  std::string publish_topic_name = "/publish_topic_name/invalid";
-  std::string subscribe_topic_name = "/subscribe_topic_name/invalid";
-
-  std::string yaml_file;
-  node->declare_parameter("yaml_file",yaml_file);
-  node->get_parameter("yaml_file",yaml_file);
-  std::cout << "yaml_file: " << yaml_file << std::endl;
-
-  if (argc > 2)
-  {
-    if (strcmp(argv[1], "1st") == 0)
-    {
-      publish_topic_name = "yaw_rate_offset_1st";
-      subscribe_topic_name = "heading_interpolate_1st";
-
-      try
-      {
-        YAML::Node conf = YAML::LoadFile(yaml_file);
-
-        _yaw_rate_offset_parameter.imu_rate = conf["/**"]["ros__parameters"]["common"]["imu_rate"].as<double>();
-        _yaw_rate_offset_parameter.gnss_rate = conf["/**"]["ros__parameters"]["common"]["gnss_rate"].as<double>();
-        _yaw_rate_offset_parameter.moving_judgment_threshold = conf["/**"]["ros__parameters"]["common"]["moving_judgment_threshold"].as<double>();
-
-        _yaw_rate_offset_parameter.estimated_minimum_interval = conf["/**"]["ros__parameters"]["yaw_rate_offset"]["estimated_minimum_interval"].as<double>();
-        _yaw_rate_offset_parameter.estimated_maximum_interval = conf["/**"]["ros__parameters"]["yaw_rate_offset"]["1st"]["estimated_maximum_interval"].as<double>();
-        _yaw_rate_offset_parameter.gnss_receiving_threshold = conf["/**"]["ros__parameters"]["yaw_rate_offset"]["gnss_receiving_threshold"].as<double>();
-        _yaw_rate_offset_parameter.outlier_threshold = conf["/**"]["ros__parameters"]["yaw_rate_offset_stop"]["outlier_threshold"].as<double>();
-
-        std::cout << "imu_rate " << _yaw_rate_offset_parameter.imu_rate << std::endl;
-        std::cout << "gnss_rate " << _yaw_rate_offset_parameter.gnss_rate << std::endl;
-        std::cout << "moving_judgment_threshold " << _yaw_rate_offset_parameter.moving_judgment_threshold << std::endl;
-
-        std::cout << "estimated_minimum_interval " << _yaw_rate_offset_parameter.estimated_minimum_interval << std::endl;
-        std::cout << "estimated_maximum_interval " << _yaw_rate_offset_parameter.estimated_maximum_interval << std::endl;
-        std::cout << "gnss_receiving_threshold " << _yaw_rate_offset_parameter.gnss_receiving_threshold << std::endl;
-        std::cout << "outlier_threshold " << _yaw_rate_offset_parameter.outlier_threshold << std::endl;
-      }
-      catch (YAML::Exception& e)
-      {
-        std::cerr << "\033[1;yaw_rate_offset_1st Node YAML Error: " << e.msg << "\033[0m" << std::endl;
-        exit(3);
-      }
-    }
-    else if (strcmp(argv[1], "2nd") == 0)
-    {
-      publish_topic_name = "yaw_rate_offset_2nd";
-      subscribe_topic_name = "heading_interpolate_2nd";
-      
-      try
-      {
-        YAML::Node conf = YAML::LoadFile(yaml_file);
-
-        _yaw_rate_offset_parameter.imu_rate = conf["/**"]["ros__parameters"]["common"]["imu_rate"].as<double>();
-        _yaw_rate_offset_parameter.gnss_rate = conf["/**"]["ros__parameters"]["common"]["gnss_rate"].as<double>();
-        _yaw_rate_offset_parameter.moving_judgment_threshold = conf["/**"]["ros__parameters"]["common"]["moving_judgment_threshold"].as<double>();
-
-        _yaw_rate_offset_parameter.estimated_minimum_interval = conf["/**"]["ros__parameters"]["yaw_rate_offset"]["estimated_minimum_interval"].as<double>();
-        _yaw_rate_offset_parameter.estimated_maximum_interval = conf["/**"]["ros__parameters"]["yaw_rate_offset"]["2nd"]["estimated_maximum_interval"].as<double>();
-        _yaw_rate_offset_parameter.gnss_receiving_threshold = conf["/**"]["ros__parameters"]["yaw_rate_offset"]["gnss_receiving_threshold"].as<double>();
-        _yaw_rate_offset_parameter.outlier_threshold = conf["/**"]["ros__parameters"]["yaw_rate_offset_stop"]["outlier_threshold"].as<double>();
-
-        std::cout << "imu_rate " << _yaw_rate_offset_parameter.imu_rate << std::endl;
-        std::cout << "gnss_rate " << _yaw_rate_offset_parameter.gnss_rate << std::endl;
-        std::cout << "moving_judgment_threshold " << _yaw_rate_offset_parameter.moving_judgment_threshold << std::endl;
-
-        std::cout << "estimated_minimum_interval " << _yaw_rate_offset_parameter.estimated_minimum_interval << std::endl;
-        std::cout << "estimated_maximum_interval " << _yaw_rate_offset_parameter.estimated_maximum_interval << std::endl;
-        std::cout << "gnss_receiving_threshold " << _yaw_rate_offset_parameter.gnss_receiving_threshold << std::endl;
-        std::cout << "outlier_threshold " << _yaw_rate_offset_parameter.outlier_threshold << std::endl;
-      }
-      catch (YAML::Exception& e)
-      {
-        std::cerr << "\033[1;yaw_rate_offset_2nd Node YAML Error: " << e.msg << "\033[0m" << std::endl;
-        exit(3);
-      }
-    }
-    else
-    {
-      // RCLCPP_ERROR(node->get_logger(),"Invalid argument");
-      RCLCPP_ERROR(node->get_logger(), "No arguments");
-      rclcpp::shutdown();
-    }
-  }
-  else
-  {
-    RCLCPP_ERROR(node->get_logger(), "No arguments");
-    rclcpp::shutdown();
-  }
-
-  auto sub1 = node->create_subscription<geometry_msgs::msg::TwistStamped>("velocity", rclcpp::QoS(10), velocity_callback);  //ros::TransportHints().tcpNoDelay()
-  auto sub2 = node->create_subscription<eagleye_msgs::msg::YawrateOffset>("yaw_rate_offset_stop", rclcpp::QoS(10), yaw_rate_offset_stop_callback);  //ros::TransportHints().tcpNoDelay()
-  auto sub3 = node->create_subscription<eagleye_msgs::msg::Heading>(subscribe_topic_name, 1000, heading_interpolate_callback);  //ros::TransportHints().tcpNoDelay()
-  auto sub4 = node->create_subscription<sensor_msgs::msg::Imu>("imu/data_tf_converted", 1000, imu_callback);  //ros::TransportHints().tcpNoDelay()
-  _pub = node->create_publisher<eagleye_msgs::msg::YawrateOffset>(publish_topic_name, rclcpp::QoS(10));
-
-  rclcpp::spin(node);
-
-
+  rclcpp::spin(std::make_shared<YawRateOffsetNode>(argc, argv));
   return 0;
 }

--- a/eagleye_rt/src/yaw_rate_offset_stop_node.cpp
+++ b/eagleye_rt/src/yaw_rate_offset_stop_node.cpp
@@ -85,7 +85,7 @@ private:
   eagleye_msgs::msg::YawrateOffset yaw_rate_offset_stop_;
   sensor_msgs::msg::Imu imu_;
   YawrateOffsetStopParameter yaw_rate_offset_stop_parameter_;
-  YawrateOffsetStopStatus yaw_rate_offset_stop_status_;
+  YawrateOffsetStopStatus yaw_rate_offset_stop_status_ = {};
   double previous_yaw_rate_offset_stop_ = 0.0;
 
   rclcpp::Publisher<eagleye_msgs::msg::YawrateOffset>::SharedPtr pub_;

--- a/eagleye_rt/src/yaw_rate_offset_stop_node.cpp
+++ b/eagleye_rt/src/yaw_rate_offset_stop_node.cpp
@@ -28,86 +28,100 @@
  * Author MapIV Sekino
  */
 
-#include "rclcpp/rclcpp.hpp"
 #include "eagleye_coordinate/eagleye_coordinate.hpp"
 #include "eagleye_navigation/eagleye_navigation.hpp"
+#include "rclcpp/rclcpp.hpp"
 
-static geometry_msgs::msg::TwistStamped::ConstSharedPtr _velocity_ptr ;
-rclcpp::Publisher<eagleye_msgs::msg::YawrateOffset>::SharedPtr _pub;
-static eagleye_msgs::msg::YawrateOffset _yaw_rate_offset_stop;
-static sensor_msgs::msg::Imu _imu;
-
-struct YawrateOffsetStopParameter _yaw_rate_offset_stop_parameter;
-struct YawrateOffsetStopStatus _yaw_rate_offset_stop_status;
-
-double _previous_yaw_rate_offset_stop = 0.0;
-
-void velocity_callback(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg)
+class YawRateOffsetStopNode : public rclcpp::Node
 {
-  _velocity_ptr = msg;
-}
-
-void imu_callback(const sensor_msgs::msg::Imu::ConstSharedPtr msg)
-{
-  if (_velocity_ptr == nullptr) return;
-  _imu = *msg;
-  _yaw_rate_offset_stop.header = msg->header;
-  yaw_rate_offset_stop_estimate(*_velocity_ptr, _imu, _yaw_rate_offset_stop_parameter, &_yaw_rate_offset_stop_status, &_yaw_rate_offset_stop);
-
-  _yaw_rate_offset_stop.status.is_abnormal = false;
-  if (!std::isfinite(_yaw_rate_offset_stop.yaw_rate_offset)) {
-    _yaw_rate_offset_stop.yaw_rate_offset =_previous_yaw_rate_offset_stop;
-    _yaw_rate_offset_stop.status.is_abnormal = true;
-    _yaw_rate_offset_stop.status.error_code = eagleye_msgs::msg::Status::NAN_OR_INFINITE;
-  }
-  else
+public:
+  YawRateOffsetStopNode() : Node("eagleye_yaw_rate_offset_stop")
   {
-    _previous_yaw_rate_offset_stop = _yaw_rate_offset_stop.yaw_rate_offset;
+    std::string subscribe_twist_topic_name = "vehicle/twist";
+
+    std::string yaml_file;
+    this->declare_parameter("yaml_file", yaml_file);
+    this->get_parameter("yaml_file", yaml_file);
+    std::cout << "yaml_file: " << yaml_file << std::endl;
+
+    try {
+      YAML::Node conf = YAML::LoadFile(yaml_file);
+
+      yaw_rate_offset_stop_parameter_.imu_rate =
+        conf["/**"]["ros__parameters"]["common"]["imu_rate"].as<double>();
+      yaw_rate_offset_stop_parameter_.stop_judgment_threshold =
+        conf["/**"]["ros__parameters"]["common"]["stop_judgment_threshold"].as<double>();
+      yaw_rate_offset_stop_parameter_.estimated_interval =
+        conf["/**"]["ros__parameters"]["yaw_rate_offset_stop"]["estimated_interval"].as<double>();
+      yaw_rate_offset_stop_parameter_.outlier_threshold =
+        conf["/**"]["ros__parameters"]["yaw_rate_offset_stop"]["outlier_threshold"].as<double>();
+
+      std::cout << "subscribe_twist_topic_name " << subscribe_twist_topic_name << std::endl;
+      std::cout << "imu_rate " << yaw_rate_offset_stop_parameter_.imu_rate << std::endl;
+      std::cout << "stop_judgment_threshold "
+                << yaw_rate_offset_stop_parameter_.stop_judgment_threshold << std::endl;
+      std::cout << "estimated_minimum_interval "
+                << yaw_rate_offset_stop_parameter_.estimated_interval << std::endl;
+      std::cout << "outlier_threshold " << yaw_rate_offset_stop_parameter_.outlier_threshold
+                << std::endl;
+    } catch (YAML::Exception& e) {
+      std::cerr << "\033[1;31myaw_rate_offset_stop Node YAML Error: " << e.msg << "\033[0m"
+                << std::endl;
+      exit(3);
+    }
+
+    sub_velocity_ = this->create_subscription<geometry_msgs::msg::TwistStamped>(
+      subscribe_twist_topic_name, 1000,
+      std::bind(&YawRateOffsetStopNode::velocityCallback, this, std::placeholders::_1));
+    sub_imu_ = this->create_subscription<sensor_msgs::msg::Imu>(
+      "imu/data_tf_converted", 1000,
+      std::bind(&YawRateOffsetStopNode::imuCallback, this, std::placeholders::_1));
+    pub_ = this->create_publisher<eagleye_msgs::msg::YawrateOffset>(
+      "yaw_rate_offset_stop", rclcpp::QoS(10));
   }
 
-  _pub->publish(_yaw_rate_offset_stop);
-}
+private:
+  geometry_msgs::msg::TwistStamped::ConstSharedPtr velocity_ptr_;
+  eagleye_msgs::msg::YawrateOffset yaw_rate_offset_stop_;
+  sensor_msgs::msg::Imu imu_;
+  YawrateOffsetStopParameter yaw_rate_offset_stop_parameter_;
+  YawrateOffsetStopStatus yaw_rate_offset_stop_status_;
+  double previous_yaw_rate_offset_stop_ = 0.0;
+
+  rclcpp::Publisher<eagleye_msgs::msg::YawrateOffset>::SharedPtr pub_;
+  rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr sub_velocity_;
+  rclcpp::Subscription<sensor_msgs::msg::Imu>::SharedPtr sub_imu_;
+
+  void velocityCallback(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg)
+  {
+    velocity_ptr_ = msg;
+  }
+
+  void imuCallback(const sensor_msgs::msg::Imu::ConstSharedPtr msg)
+  {
+    if (velocity_ptr_ == nullptr) return;
+    imu_ = *msg;
+    yaw_rate_offset_stop_.header = msg->header;
+    yaw_rate_offset_stop_estimate(
+      *velocity_ptr_, imu_, yaw_rate_offset_stop_parameter_, &yaw_rate_offset_stop_status_,
+      &yaw_rate_offset_stop_);
+
+    yaw_rate_offset_stop_.status.is_abnormal = false;
+    if (!std::isfinite(yaw_rate_offset_stop_.yaw_rate_offset)) {
+      yaw_rate_offset_stop_.yaw_rate_offset = previous_yaw_rate_offset_stop_;
+      yaw_rate_offset_stop_.status.is_abnormal = true;
+      yaw_rate_offset_stop_.status.error_code = eagleye_msgs::msg::Status::NAN_OR_INFINITE;
+    } else {
+      previous_yaw_rate_offset_stop_ = yaw_rate_offset_stop_.yaw_rate_offset;
+    }
+
+    pub_->publish(yaw_rate_offset_stop_);
+  }
+};
 
 int main(int argc, char** argv)
 {
   rclcpp::init(argc, argv);
-  auto node = rclcpp::Node::make_shared("eagleye_yaw_rate_offset_stop");
-  std::string subscribe_twist_topic_name = "vehicle/twist";
-
-  std::string yaml_file;
-  node->declare_parameter("yaml_file",yaml_file);
-  node->get_parameter("yaml_file",yaml_file);
-  std::cout << "yaml_file: " << yaml_file << std::endl;
-
-    try
-  {
-    YAML::Node conf = YAML::LoadFile(yaml_file);
-
-    _yaw_rate_offset_stop_parameter.imu_rate = conf["/**"]["ros__parameters"]["common"]["imu_rate"].as<double>();
-    _yaw_rate_offset_stop_parameter.stop_judgment_threshold = conf["/**"]["ros__parameters"]["common"]["stop_judgment_threshold"].as<double>();
-
-    _yaw_rate_offset_stop_parameter.estimated_interval = conf["/**"]["ros__parameters"]["yaw_rate_offset_stop"]["estimated_interval"].as<double>();
-    _yaw_rate_offset_stop_parameter.outlier_threshold = conf["/**"]["ros__parameters"]["yaw_rate_offset_stop"]["outlier_threshold"].as<double>();
-
-    std::cout << "subscribe_twist_topic_name " << subscribe_twist_topic_name << std::endl;
-
-    std::cout << "imu_rate " << _yaw_rate_offset_stop_parameter.imu_rate << std::endl;
-    std::cout << "stop_judgment_threshold " << _yaw_rate_offset_stop_parameter.stop_judgment_threshold << std::endl;
-
-    std::cout << "estimated_minimum_interval " << _yaw_rate_offset_stop_parameter.estimated_interval << std::endl;
-    std::cout << "outlier_threshold " << _yaw_rate_offset_stop_parameter.outlier_threshold << std::endl;
-  }
-  catch (YAML::Exception& e)
-  {
-    std::cerr << "\033[1;31myaw_rate_offset_stop Node YAML Error: " << e.msg << "\033[0m" << std::endl;
-    exit(3);
-  }
-
-  auto sub1 = node->create_subscription<geometry_msgs::msg::TwistStamped>(subscribe_twist_topic_name, 1000, velocity_callback);  //ros::TransportHints().tcpNoDelay()
-  auto sub2 = node->create_subscription<sensor_msgs::msg::Imu>("imu/data_tf_converted", 1000, imu_callback);  //ros::TransportHints().tcpNoDelay()
-  _pub = node->create_publisher<eagleye_msgs::msg::YawrateOffset>("yaw_rate_offset_stop", rclcpp::QoS(10));
-
-  rclcpp::spin(node);
-
+  rclcpp::spin(std::make_shared<YawRateOffsetStopNode>());
   return 0;
 }

--- a/eagleye_util/result_logger/eagleye_result_logger/result_logger_node.py
+++ b/eagleye_util/result_logger/eagleye_result_logger/result_logger_node.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2024, Map IV, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name of the Map IV, Inc. nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDER BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""
+eagleye_result_logger: Save eagleye estimation results to CSV for regression comparison.
+
+Output files (written to --output-dir, default: current directory):
+  fix.csv   - NavSatFix: timestamp_s, latitude, longitude, altitude, status
+  pose.csv  - PoseStamped: timestamp_s, x, y, z, qx, qy, qz, qw
+"""
+
+import csv
+import os
+import sys
+from datetime import datetime
+
+import rclpy
+from rclpy.node import Node
+from geometry_msgs.msg import PoseStamped
+from sensor_msgs.msg import NavSatFix
+
+
+class ResultLoggerNode(Node):
+
+    def __init__(self):
+        super().__init__('eagleye_result_logger')
+
+        self.declare_parameter('output_dir', '.')
+        self.declare_parameter('fix_topic', '/eagleye/fix')
+        self.declare_parameter('pose_topic', '/eagleye/eagleye/pose')
+
+        output_dir = self.get_parameter('output_dir').get_parameter_value().string_value
+        fix_topic = self.get_parameter('fix_topic').get_parameter_value().string_value
+        pose_topic = self.get_parameter('pose_topic').get_parameter_value().string_value
+
+        os.makedirs(output_dir, exist_ok=True)
+
+        timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
+        fix_path = os.path.join(output_dir, f'fix_{timestamp}.csv')
+        pose_path = os.path.join(output_dir, f'pose_{timestamp}.csv')
+
+        self._fix_file = open(fix_path, 'w', newline='')
+        self._pose_file = open(pose_path, 'w', newline='')
+
+        self._fix_writer = csv.writer(self._fix_file)
+        self._pose_writer = csv.writer(self._pose_file)
+
+        self._fix_writer.writerow(['timestamp_s', 'latitude', 'longitude', 'altitude', 'status'])
+        self._pose_writer.writerow(['timestamp_s', 'x', 'y', 'z', 'qx', 'qy', 'qz', 'qw'])
+
+        self._fix_count = 0
+        self._pose_count = 0
+
+        self._fix_sub = self.create_subscription(
+            NavSatFix, fix_topic, self._fix_callback, 10)
+        self._pose_sub = self.create_subscription(
+            PoseStamped, pose_topic, self._pose_callback, 10)
+
+        self.get_logger().info(f'Logging fix  -> {fix_path}')
+        self.get_logger().info(f'Logging pose -> {pose_path}')
+
+    def _fix_callback(self, msg: NavSatFix):
+        t = msg.header.stamp.sec + msg.header.stamp.nanosec * 1e-9
+        self._fix_writer.writerow([
+            f'{t:.9f}',
+            msg.latitude,
+            msg.longitude,
+            msg.altitude,
+            msg.status.status,
+        ])
+        self._fix_count += 1
+        if self._fix_count % 100 == 0:
+            self._fix_file.flush()
+
+    def _pose_callback(self, msg: PoseStamped):
+        t = msg.header.stamp.sec + msg.header.stamp.nanosec * 1e-9
+        p = msg.pose.position
+        q = msg.pose.orientation
+        self._pose_writer.writerow([
+            f'{t:.9f}',
+            p.x, p.y, p.z,
+            q.x, q.y, q.z, q.w,
+        ])
+        self._pose_count += 1
+        if self._pose_count % 100 == 0:
+            self._pose_file.flush()
+
+    def destroy_node(self):
+        self._fix_file.flush()
+        self._fix_file.close()
+        self._pose_file.flush()
+        self._pose_file.close()
+        self.get_logger().info(
+            f'Saved {self._fix_count} fix rows, {self._pose_count} pose rows.')
+        super().destroy_node()
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = ResultLoggerNode()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/eagleye_util/result_logger/launch/result_logger.launch.xml
+++ b/eagleye_util/result_logger/launch/result_logger.launch.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<launch>
+  <arg name="output_dir" default="." description="Directory to write CSV files"/>
+  <arg name="fix_topic"  default="/eagleye/fix"/>
+  <arg name="pose_topic" default="/eagleye/eagleye/pose"/>
+
+  <node pkg="eagleye_result_logger" exec="result_logger" output="screen">
+    <param name="output_dir" value="$(var output_dir)"/>
+    <param name="fix_topic"  value="$(var fix_topic)"/>
+    <param name="pose_topic" value="$(var pose_topic)"/>
+  </node>
+</launch>

--- a/eagleye_util/result_logger/package.xml
+++ b/eagleye_util/result_logger/package.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>eagleye_result_logger</name>
+  <version>1.0.0</version>
+  <description>Save eagleye estimation results to CSV for regression comparison</description>
+  <maintainer email="support@map4.jp">Map IV, Inc.</maintainer>
+  <license>BSD</license>
+
+  <buildtool_depend>ament_python</buildtool_depend>
+
+  <depend>rclpy</depend>
+  <depend>geometry_msgs</depend>
+  <depend>sensor_msgs</depend>
+
+  <export>
+    <build_type>ament_python</build_type>
+  </export>
+</package>

--- a/eagleye_util/result_logger/setup.py
+++ b/eagleye_util/result_logger/setup.py
@@ -1,0 +1,25 @@
+from setuptools import setup
+
+package_name = 'eagleye_result_logger'
+
+setup(
+    name=package_name,
+    version='1.0.0',
+    packages=[package_name],
+    data_files=[
+        ('share/ament_index/resource_index/packages', ['resource/' + package_name]),
+        ('share/' + package_name, ['package.xml']),
+        ('share/' + package_name + '/launch', ['launch/result_logger.launch.xml']),
+    ],
+    install_requires=['setuptools'],
+    zip_safe=True,
+    maintainer='Map IV, Inc.',
+    maintainer_email='support@map4.jp',
+    description='Save eagleye estimation results to CSV for regression comparison',
+    license='BSD',
+    entry_points={
+        'console_scripts': [
+            'result_logger = eagleye_result_logger.result_logger_node:main',
+        ],
+    },
+)


### PR DESCRIPTION
## Summary

- `/eagleye/fix` (NavSatFix) と `/eagleye/eagleye/pose` (PoseStamped) をタイムスタンプ付き CSV に保存する新パッケージ `eagleye_result_logger` を追加
- リファクタリング前後の推定結果比較（リグレッションテスト）に使用

## 出力ファイル

| ファイル | トピック | カラム |
|---|---|---|
| `fix_YYYYMMDD_HHMMSS.csv` | `/eagleye/fix` | timestamp_s, latitude, longitude, altitude, status |
| `pose_YYYYMMDD_HHMMSS.csv` | `/eagleye/eagleye/pose` | timestamp_s, x, y, z, qx, qy, qz, qw |

## 使い方

```bash
# eagleye と同時に起動
ros2 launch eagleye_result_logger result_logger.launch.xml output_dir:=/tmp/results

# トピック名変更も可能
ros2 launch eagleye_result_logger result_logger.launch.xml \
  output_dir:=/tmp/results \
  fix_topic:=/eagleye/fix \
  pose_topic:=/eagleye/eagleye/pose
```